### PR TITLE
feat(copilot-guard): 環境変数読み取りブロックを追加

### DIFF
--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -9,7 +9,7 @@ chezmoi は `~/.copilot/` 配下の一部を管理する。プラグインはプ
 | `copilot-instructions.md` | ユーザーレベルのカスタム指示 | chezmoi |
 | `mcp-config.json` | MCP サーバー設定 | chezmoi（`/mcp add` 後は `re-add`） |
 | `hooks/hooks.json` | preToolUse フック定義 | chezmoi |
-| `hooks/scripts/copilot-guard.py` | セキュリティガード | chezmoi |
+| `hooks/scripts/copilot-guard.py` | セキュリティガード（ファイル・URL・環境変数） | chezmoi |
 | `hooks/scripts/uv-enforcer.py` | Python / pip 直接実行をブロック | chezmoi |
 | `hooks/blocked-files.txt` | ブロック対象ファイルパターン | chezmoi |
 | `hooks/allowed-urls.txt` | URL 許可リスト | chezmoi |
@@ -62,6 +62,13 @@ chezmoi diff
 ```bash
 # copilot-guard: ファイル・URL アクセス制御
 echo '{"toolName":"edit","toolArgs":{"path":".env"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
+
+# copilot-guard: 環境変数アクセスのブロック（bash ツールのみ対象）
+echo '{"toolName":"bash","toolArgs":{"command":"printenv"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
+echo '{"toolName":"bash","toolArgs":{"command":"echo $GITHUB_TOKEN"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
+
+# copilot-guard: 安全な変数参照は許可
+echo '{"toolName":"bash","toolArgs":{"command":"echo $HOME"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
 
 # uv-enforcer: python/pip 直接実行のブロック
 echo '{"toolName":"bash","toolArgs":{"command":"python script.py"}}' | uv run ~/.copilot/hooks/scripts/uv-enforcer.py

--- a/home/private_dot_copilot/hooks/blocked-files.txt
+++ b/home/private_dot_copilot/hooks/blocked-files.txt
@@ -47,3 +47,6 @@
 **/*.pem
 **/*.key
 **/*.token
+
+# proc 環境変数 (Linux)
+**/proc/*/environ

--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -23,6 +23,160 @@ COMMAND_STRIP_CHARS = "\"'`()[]{};,"
 # Quoted spans also allow backslash escapes such as \" and \'.
 COMMAND_TOKEN_RE = re.compile(r"""(?:[^\s"']+|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')+""")
 
+# ---------------------------------------------------------------------------
+# Environment variable access blocking
+# ---------------------------------------------------------------------------
+
+# Commands that dump all environment variables.
+ENV_DUMP_COMMANDS: frozenset[str] = frozenset({
+    "printenv",
+})
+
+# Commands that dump all variables when invoked *without meaningful arguments*.
+# ``env`` is allowed with ``-i`` / ``-u`` / ``--`` (environment manipulation),
+# so only a bare ``env`` (optionally with trailing pipe) is blocked.
+_BARE_ENV_RE = re.compile(
+    r"(?:^|\s*(?:&&|\|\||;)\s*)"  # start or after shell operator
+    r"env"
+    r"(?:\s*(?:\||;|&&|\|\||$))",  # followed by pipe, operator, or end
+)
+
+# ``set`` without arguments dumps all variables; ``set -e`` etc. is fine.
+_BARE_SET_RE = re.compile(
+    r"(?:^|\s*(?:&&|\|\||;)\s*)"
+    r"set"
+    r"(?:\s*(?:\||;|&&|\|\||$))",
+)
+
+# Full-variable enumeration builtins.
+_ENUM_BUILTINS_RE = re.compile(
+    r"\b(?:declare|typeset)\s+-p\b"
+    r"|\bexport\s+-p\b"
+    r"|\bcompgen\s+-[ve]\b",
+)
+
+# Language-runtime patterns that dump the *entire* environment mapping.
+_RUNTIME_ENV_DUMP_RE = re.compile(
+    r"\bos\.environ\b"         # Python  os.environ  (whole mapping)
+    r"|\bos\.getenv\(\s*\)"    # Python  os.getenv() with no arg
+    r"|\bprocess\.env\b"       # Node.js process.env (whole object)
+    r"|%ENV\b"                 # Perl    %ENV
+    r"|\bENV\.to_h\b"         # Ruby    ENV.to_h
+    r"|\bENV\.each\b"         # Ruby    ENV.each
+    r"|\bSystem\.getenv\(\s*\)"  # Java  System.getenv()
+    r"|\bDeno\.env\.toObject\b"  # Deno  Deno.env.toObject()
+    r"|\bGet-ChildItem\s+Env:"   # PowerShell Get-ChildItem Env:
+    r"|\\\$env:",              # PowerShell $env: variable access
+    re.IGNORECASE,
+)
+
+# Sensitive variable name fragments.  If a shell expansion ``$VAR`` or
+# ``${VAR}`` contains one of these (case-insensitive), it is blocked.
+_SENSITIVE_FRAGMENTS: frozenset[str] = frozenset({
+    "secret", "token", "key", "password", "credential",
+    "api_key", "apikey", "access_key", "accesskey",
+    "private_key", "privatekey",
+    "connection_string", "connectionstring",
+    "client_secret", "clientsecret",
+    "db_password", "dbpassword",
+    "auth",
+})
+
+# Safe variable names that are never blocked even if they match fragments
+# above (e.g. ``SSH_AUTH_SOCK`` contains ``auth``).
+_SAFE_VARIABLES: frozenset[str] = frozenset({
+    "path", "home", "shell", "user", "logname",
+    "lang", "language", "lc_all", "lc_ctype", "lc_messages",
+    "term", "colorterm",
+    "pwd", "oldpwd", "tmpdir",
+    "editor", "visual", "pager",
+    "hostname", "hosttype", "ostype", "machtype",
+    "display", "wayland_display",
+    "xdg_config_home", "xdg_data_home", "xdg_cache_home",
+    "xdg_runtime_dir", "xdg_state_home",
+    "xdg_current_desktop", "xdg_session_type",
+    "node_env", "npm_config_prefix",
+    "gopath", "goroot",
+    "cargo_home", "rustup_home",
+    "ssh_auth_sock", "ssh_agent_pid",
+    "shlvl", "lines", "columns",
+    "histsize", "histfile", "histcontrol",
+    "ps1", "ps2", "ps4",
+    "ifs",
+    "uid", "euid", "groups",
+    "browser", "http_proxy", "https_proxy", "no_proxy",
+    "ftp_proxy", "all_proxy",
+    "mise_shell",
+    "_",  # last command
+})
+
+# Regex that captures ``$VAR`` or ``${VAR}`` references.
+_SHELL_VAR_REF_RE = re.compile(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?")
+
+
+def _is_sensitive_var(name: str) -> bool:
+    """Return True if *name* looks like a secret variable."""
+    lower = name.lower()
+    if lower in _SAFE_VARIABLES:
+        return False
+    return any(frag in lower for frag in _SENSITIVE_FRAGMENTS)
+
+
+def check_env_access(command: str) -> str | None:
+    """Detect environment-variable access patterns in a shell command.
+
+    Returns a deny reason string when the command appears to read
+    environment variables in a way that could leak secrets, or ``None``
+    if the command looks safe.
+    """
+    stripped = command.strip()
+    if not stripped:
+        return None
+
+    # --- 1. Dump-all commands in leading position (per shell segment) ---
+    # Split by shell operators so ``ls && printenv`` catches ``printenv``.
+    segments = re.split(r"\s*(?:&&|\|\||;)\s*", stripped)
+    for seg in segments:
+        seg = seg.strip()
+        if not seg:
+            continue
+        # Also look past pipes — ``foo | printenv`` should be caught.
+        pipe_parts = seg.split("|")
+        for part in pipe_parts:
+            part = part.strip()
+            if not part:
+                continue
+            seg_tokens = part.split()
+            seg_lead = seg_tokens[0] if seg_tokens else ""
+            if seg_lead in ENV_DUMP_COMMANDS:
+                return f"Blocked env dump command: {seg_lead}"
+            if seg_lead == "env":
+                if len(seg_tokens) == 1:
+                    return "Blocked env dump command: env (use 'env -i' to run with clean environment)"
+                second = seg_tokens[1]
+                if not (second.startswith("-") or "=" in second or second == "--"):
+                    return "Blocked env dump command: env (use 'env -i' to run with clean environment)"
+
+    if _BARE_SET_RE.search(stripped):
+        return "Blocked env dump command: set (without arguments lists all variables)"
+
+    # --- 2. Enumeration builtins ---
+    if _ENUM_BUILTINS_RE.search(stripped):
+        return "Blocked env enumeration builtin"
+
+    # --- 3. Runtime env dump patterns ---
+    m = _RUNTIME_ENV_DUMP_RE.search(stripped)
+    if m:
+        return f"Blocked runtime env dump pattern: {m.group(0)}"
+
+    # --- 4. Sensitive variable expansion ---
+    for var_match in _SHELL_VAR_REF_RE.finditer(stripped):
+        var_name = var_match.group(1)
+        if _is_sensitive_var(var_name):
+            return f"Blocked sensitive variable reference: ${var_name}"
+
+    return None
+
 
 def deny(reason: str) -> None:
     print(json.dumps({"permissionDecision": "deny", "permissionDecisionReason": reason}))
@@ -245,6 +399,12 @@ def main() -> None:
         hit = check_blocked_command(command, blocked_patterns)
         if hit:
             deny(f"Blocked pattern: {hit}")
+
+    # --- Environment variable access check (bash / powershell only) ---
+    if tool_name in ("bash", "powershell") and command:
+        env_hit = check_env_access(command)
+        if env_hit:
+            deny(env_hit)
 
     # --- URL allowlist ---
     if allowed_domains:

--- a/tests/test_copilot_guard.py
+++ b/tests/test_copilot_guard.py
@@ -81,5 +81,198 @@ class CopilotGuardCommandMatchingTests(unittest.TestCase):
         self.assertEqual(hit, "**/accessTokens.json")
 
 
+class CopilotGuardEnvBlockingTests(unittest.TestCase):
+    """Tests for environment variable access blocking."""
+
+    # --- Dump commands ---
+
+    def test_blocks_printenv(self) -> None:
+        result = copilot_guard.check_env_access("printenv")
+        self.assertIsNotNone(result)
+        self.assertIn("printenv", result)
+
+    def test_blocks_printenv_with_pipe(self) -> None:
+        result = copilot_guard.check_env_access("printenv | grep SECRET")
+        self.assertIsNotNone(result)
+
+    def test_blocks_bare_env(self) -> None:
+        result = copilot_guard.check_env_access("env")
+        self.assertIsNotNone(result)
+
+    def test_allows_env_i(self) -> None:
+        result = copilot_guard.check_env_access("env -i PATH=/usr/bin bash")
+        self.assertIsNone(result)
+
+    def test_allows_env_u(self) -> None:
+        result = copilot_guard.check_env_access("env -u SECRET command")
+        self.assertIsNone(result)
+
+    def test_allows_env_with_assignment(self) -> None:
+        result = copilot_guard.check_env_access("env FOO=bar command")
+        self.assertIsNone(result)
+
+    def test_allows_env_double_dash(self) -> None:
+        result = copilot_guard.check_env_access("env -- command")
+        self.assertIsNone(result)
+
+    def test_blocks_bare_set(self) -> None:
+        result = copilot_guard.check_env_access("set")
+        self.assertIsNotNone(result)
+
+    def test_allows_set_with_options(self) -> None:
+        result = copilot_guard.check_env_access("set -e")
+        self.assertIsNone(result)
+
+    def test_allows_set_euo_pipefail(self) -> None:
+        result = copilot_guard.check_env_access("set -euo pipefail")
+        self.assertIsNone(result)
+
+    def test_blocks_declare_p(self) -> None:
+        result = copilot_guard.check_env_access("declare -p")
+        self.assertIsNotNone(result)
+
+    def test_blocks_export_p(self) -> None:
+        result = copilot_guard.check_env_access("export -p")
+        self.assertIsNotNone(result)
+
+    def test_blocks_compgen_v(self) -> None:
+        result = copilot_guard.check_env_access("compgen -v")
+        self.assertIsNotNone(result)
+
+    def test_blocks_compgen_e(self) -> None:
+        result = copilot_guard.check_env_access("compgen -e")
+        self.assertIsNotNone(result)
+
+    # --- Sensitive variable expansion ---
+
+    def test_blocks_github_token(self) -> None:
+        result = copilot_guard.check_env_access("echo $GITHUB_TOKEN")
+        self.assertIsNotNone(result)
+
+    def test_blocks_secret_key_braces(self) -> None:
+        result = copilot_guard.check_env_access("echo ${SECRET_KEY}")
+        self.assertIsNotNone(result)
+
+    def test_blocks_azure_client_secret(self) -> None:
+        result = copilot_guard.check_env_access('echo "$AZURE_CLIENT_SECRET"')
+        self.assertIsNotNone(result)
+
+    def test_blocks_api_key(self) -> None:
+        result = copilot_guard.check_env_access("curl -H 'Authorization: $API_KEY'")
+        self.assertIsNotNone(result)
+
+    def test_blocks_db_password(self) -> None:
+        result = copilot_guard.check_env_access("mysql -p$DB_PASSWORD")
+        self.assertIsNotNone(result)
+
+    def test_blocks_connection_string(self) -> None:
+        result = copilot_guard.check_env_access("echo $DATABASE_CONNECTION_STRING")
+        self.assertIsNotNone(result)
+
+    def test_blocks_auth_token(self) -> None:
+        result = copilot_guard.check_env_access("echo $AUTH_TOKEN")
+        self.assertIsNotNone(result)
+
+    # --- Safe variables ---
+
+    def test_allows_path(self) -> None:
+        result = copilot_guard.check_env_access("echo $PATH")
+        self.assertIsNone(result)
+
+    def test_allows_home(self) -> None:
+        result = copilot_guard.check_env_access("echo $HOME")
+        self.assertIsNone(result)
+
+    def test_allows_shell(self) -> None:
+        result = copilot_guard.check_env_access("echo $SHELL")
+        self.assertIsNone(result)
+
+    def test_allows_user(self) -> None:
+        result = copilot_guard.check_env_access("echo $USER")
+        self.assertIsNone(result)
+
+    def test_allows_node_env(self) -> None:
+        result = copilot_guard.check_env_access("echo $NODE_ENV")
+        self.assertIsNone(result)
+
+    def test_allows_editor(self) -> None:
+        result = copilot_guard.check_env_access("echo $EDITOR")
+        self.assertIsNone(result)
+
+    def test_allows_ssh_auth_sock(self) -> None:
+        result = copilot_guard.check_env_access("echo $SSH_AUTH_SOCK")
+        self.assertIsNone(result)
+
+    def test_allows_xdg_config_home(self) -> None:
+        result = copilot_guard.check_env_access("echo $XDG_CONFIG_HOME")
+        self.assertIsNone(result)
+
+    def test_allows_tmpdir(self) -> None:
+        result = copilot_guard.check_env_access("echo $TMPDIR")
+        self.assertIsNone(result)
+
+    def test_allows_pwd(self) -> None:
+        result = copilot_guard.check_env_access("echo $PWD")
+        self.assertIsNone(result)
+
+    # --- Language runtime env dumps ---
+
+    def test_blocks_python_os_environ(self) -> None:
+        result = copilot_guard.check_env_access(
+            'uv run python -c "import os; print(os.environ)"'
+        )
+        self.assertIsNotNone(result)
+
+    def test_blocks_node_process_env(self) -> None:
+        result = copilot_guard.check_env_access(
+            'node -e "console.log(process.env)"'
+        )
+        self.assertIsNotNone(result)
+
+    def test_blocks_perl_env(self) -> None:
+        result = copilot_guard.check_env_access(
+            'perl -e \'foreach (keys %ENV) { print }\''
+        )
+        self.assertIsNotNone(result)
+
+    def test_blocks_ruby_env_to_h(self) -> None:
+        result = copilot_guard.check_env_access(
+            'ruby -e "puts ENV.to_h"'
+        )
+        self.assertIsNotNone(result)
+
+    def test_blocks_powershell_get_childitem_env(self) -> None:
+        result = copilot_guard.check_env_access(
+            "Get-ChildItem Env:"
+        )
+        self.assertIsNotNone(result)
+
+    # --- Compound commands ---
+
+    def test_blocks_env_in_pipe_chain(self) -> None:
+        result = copilot_guard.check_env_access("ls && printenv | grep SECRET")
+        self.assertIsNotNone(result)
+
+    def test_blocks_sensitive_var_in_chained_command(self) -> None:
+        result = copilot_guard.check_env_access(
+            "cd /tmp && echo $GITHUB_TOKEN"
+        )
+        self.assertIsNotNone(result)
+
+    # --- Empty / safe commands ---
+
+    def test_allows_empty_command(self) -> None:
+        result = copilot_guard.check_env_access("")
+        self.assertIsNone(result)
+
+    def test_allows_normal_command(self) -> None:
+        result = copilot_guard.check_env_access("ls -la /tmp")
+        self.assertIsNone(result)
+
+    def test_allows_git_commands(self) -> None:
+        result = copilot_guard.check_env_access("git --no-pager status")
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 環境変数読み取りブロックを copilot-guard に追加

### 概要

bash / powershell ツール実行時に環境変数アクセスを検出・拒否するロジックを `copilot-guard.py` に追加します。

### 変更内容

- **列挙コマンドのブロック**: `printenv`, `env` (引数なし), `declare -p`, `export -p`, `compgen -v/-e`, `set` (引数なし)
- **秘匿変数名パターンの検出**: `$SECRET`, `$TOKEN`, `$API_KEY`, `$PASSWORD` 等の `$` 展開をブロック
- **言語ランタイム全体ダンプのブロック**: `os.environ`, `process.env`, `%ENV`, `ENV.to_h` 等
- **許可リスト**: `PATH`, `HOME`, `SHELL`, `SSH_AUTH_SOCK` 等 50+ の汎用変数は除外
- **正当な使用の許可**: `env -i`, `set -e`, `env FOO=bar` 等
- `blocked-files.txt` に `**/proc/*/environ` を追加
- テスト 41 件追加（全 49 件パス）
