### PR TITLE
perf(shell): completion スクリプトのキャッシュによる起動高速化

### DIFF
--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -136,10 +136,47 @@ Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
     Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME, Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE, Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
 }
 
-kubectl completion powershell | Out-String | Invoke-Expression
-Register-ArgumentCompleter -CommandName k -ScriptBlock $__kubectlCompleterBlock
+# Completion cache: generate once, dot-source from file on subsequent loads.
+# Cache is invalidated when the tool binary is updated (mtime comparison).
+function Invoke-CachedSource {
+    param(
+        [string]$Name,
+        [string]$Command,
+        [scriptblock]$Generator
+    )
+    $cmdInfo = Get-Command $Command -ErrorAction SilentlyContinue
+    if (-not $cmdInfo) { return }
+    $cmdPath = $cmdInfo.Source
+
+    $cacheDir = Join-Path $env:LOCALAPPDATA 'shell-completions'
+    $cacheFile = Join-Path $cacheDir "$Name.ps1"
+    if (-not (Test-Path $cacheDir)) { [void](New-Item -ItemType Directory -Path $cacheDir -Force) }
+
+    $cmdMtime = (Get-Item $cmdPath).LastWriteTime
+    if ((Test-Path $cacheFile) -and (Get-Item $cacheFile).LastWriteTime -gt $cmdMtime) {
+        . $cacheFile
+        return
+    }
+
+    $output = & $Generator 2>$null | Out-String
+    if ($output) {
+        Set-Content -Path $cacheFile -Value $output -Encoding utf8
+        . $cacheFile
+    }
+}
+
+function Clear-CompletionCache {
+    $cacheDir = Join-Path $env:LOCALAPPDATA 'shell-completions'
+    if (Test-Path $cacheDir) { Remove-Item -Recurse -Force $cacheDir }
+    Write-Host "Completion cache cleared. Restart shell to regenerate."
+}
+
+Invoke-CachedSource -Name kubectl -Command kubectl -Generator { kubectl completion powershell }
+if ($__kubectlCompleterBlock) {
+    Register-ArgumentCompleter -CommandName k -ScriptBlock $__kubectlCompleterBlock
+}
 
 # zoxide (smarter cd)
-Invoke-Expression (& { (zoxide init powershell --cmd cd | Out-String) })
+Invoke-CachedSource -Name zoxide -Command zoxide -Generator { zoxide init powershell --cmd cd }
 Set-Alias -Name z -Value cd
 {{ end -}}

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -149,17 +149,43 @@ case $(uname) in
   ;;
 esac
 
-# Tool completions
-command -v zoxide >/dev/null && source <(zoxide init zsh --cmd cd)
+# Completion cache: generate once, source from file on subsequent loads.
+# Cache is invalidated when the tool binary is updated (mtime comparison).
+# Usage: _cached_source <cache_name> <command> <generation_command>
+_cached_source() {
+  local name=$1 cmd=$2 gen_cmd=$3
+  local cmd_path
+  cmd_path=$(command -v "$cmd" 2>/dev/null) || return 1
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zsh-completions"
+  local cache_file="$cache_dir/$name.zsh"
+  mkdir -p "$cache_dir"
+
+  if [[ -f "$cache_file" && "$cache_file" -nt "$cmd_path" ]]; then
+    source "$cache_file"
+    return
+  fi
+
+  eval "$gen_cmd" > "$cache_file" 2>/dev/null || { rm -f "$cache_file"; return 1; }
+  source "$cache_file"
+}
+
+_completion_cache_clear() {
+  rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/zsh-completions"
+  echo "Completion cache cleared. Restart shell to regenerate."
+}
+
+# Tool completions (cached)
+_cached_source zoxide zoxide "zoxide init zsh --cmd cd"
 alias z='cd'
 alias zi='cdi'
-command -v kubectl >/dev/null && source <(kubectl completion zsh) && complete -o default -F __start_kubectl k
-command -v helm >/dev/null && source <(helm completion zsh)
+_cached_source kubectl kubectl "kubectl completion zsh" && complete -o default -F __start_kubectl k
+_cached_source helm helm "helm completion zsh"
 command -v terraform >/dev/null && complete -o nospace -C "$(command -v terraform)" terraform
-command -v rad >/dev/null && . <(rad completion zsh)
-command -v gh >/dev/null && source <(gh completion -s zsh)
-command -v azd >/dev/null && source <(azd completion zsh)
-command -v trivy >/dev/null && source <(trivy completion zsh)
+_cached_source rad rad "rad completion zsh"
+_cached_source gh gh "gh completion -s zsh"
+_cached_source azd azd "azd completion zsh"
+_cached_source trivy trivy "trivy completion zsh"
 
 if [ -z "$SSH_AUTH_SOCK" ] ; then
   if agent_output=$(ssh-agent -s 2>/dev/null); then


### PR DESCRIPTION
## 背景

VS Code がシェル環境を解決できずタイムアウトするエラーが発生。調査の結果、Helm v4 が `~/.docker/config.json` 内の古い ACR 認証情報を解決しようとして ~13秒ブロックし、`.zshrc` の `source <(helm completion zsh)` がシェル起動全体を巻き添えにしていたことが判明。

直接原因（Docker 認証情報）は手動で解消済みだが、同種の問題の再発を防ぐため、completion スクリプトの生成結果をキャッシュする仕組みを導入する。

## 変更内容

### zsh (`dot_zshrc.tmpl`)
- `_cached_source` 関数を追加: バイナリの mtime とキャッシュファイルを比較し、新しければ再生成
- 7 ツール (kubectl, helm, gh, azd, trivy, rad, zoxide) の `source <(...)` をキャッシュ読み込みに置換
- `_completion_cache_clear` 関数でキャッシュの手動削除が可能

### PowerShell (`PowerShell_profile.ps1.tmpl`)
- `Invoke-CachedSource` 関数を追加: 同じ mtime 比較ロジック
- kubectl, zoxide の `Invoke-Expression` をキャッシュ読み込みに置換
- `Clear-CompletionCache` 関数でキャッシュの手動削除が可能

### キャッシュ対象外（変更なし）
| ツール | 理由 |
|--------|------|
| mise | `activate` はシェルフック（PATH 管理）であり毎回実行が必要 |
| terraform | `complete -C` パターンでプロセス起動なし |
| az (Azure CLI) | 静的ファイルの source / 遅延評価の `Register-ArgumentCompleter` |

## 計測結果 (zsh, macOS)

| シナリオ | 起動時間 |
|----------|----------|
| 修正前（Helm v4 問題あり） | 17.0 秒 |
| 初回起動（キャッシュ生成） | 1.2 秒 |
| 2回目以降（キャッシュ利用） | **0.27 秒** |

## 検証

- [x] zsh: `time zsh -i -c exit` で起動時間改善を確認
- [x] zsh: kubectl, helm, gh, azd, trivy, zoxide の補完関数が正常にロードされることを確認
- [x] zsh: `k` エイリアスの補完が動作することを確認
- [x] zsh: キャッシュ無効化（バイナリ touch → 次回起動で再生成）を確認
- [x] zsh: `_completion_cache_clear` による手動クリア → 再生成を確認
- [ ] PowerShell: 構文確認済み（Windows 実機での動作確認は別途）
