### PR TITLE
docs(copilot-instructions): ツール制約の構造化と言語ガイド拡充

### DIFF
--- a/home/private_dot_copilot/copilot-instructions.md
+++ b/home/private_dot_copilot/copilot-instructions.md
@@ -2,15 +2,29 @@
 
 ## ツール操作の制約（デフォルト動作より優先）
 
-- **[Windows]** ファイルをエディタで開く → `Start-Process edit <path>`（Microsoft Edit が別ウィンドウで起動する）
-- Python 実行・パッケージ管理 → 常に `uv` 経由。`python` / `pip` の直接実行は禁止（preToolUse フックで強制）
-- **[Unix]** コマンド存在チェック → `command -v`（`which` は使わない）
-- **[Windows]** Copilot CLI のシェルセッションでは `$PROFILE` が読み込まれないため、エイリアスや関数は使えない
+### 共通
+
+- Python → `python` / `pip` の直接実行は禁止。以下を使うこと:
+  - スクリプト実行: `uv run script.py`（依存は PEP 723 インラインメタデータで宣言）
+  - パッケージ追加: `uv add <pkg>`（プロジェクト）/ `uv pip install <pkg>`（グローバル）
+  - REPL: `uv run python`
+
+### Windows
+
+- ファイルをエディタで開く → `Start-Process edit <path>`（Microsoft Edit が別ウィンドウで起動する）
+- Copilot CLI のシェルセッションでは `$PROFILE` が読み込まれないため、エイリアスや関数は使えない
+
+### macOS / Linux
+
+- コマンド存在チェック → `command -v`（`which` は使わない）
 
 ## 言語
 
 - 日本語で応答する（文脈上明らかに英語が必要な場合を除く）
 - コードコメント: README が英語のリポジトリでは英語、それ以外は日本語
+- コミットメッセージ: Conventional Commits プレフィックスは英語。説明文は README の言語に従う
+- PR タイトル/本文: README の言語に従う
+- ブランチ名: 常に英語（URL/CLI の互換性）
 
 ## 基本方針
 


### PR DESCRIPTION
## 背景

ユーザーレベルの `copilot-instructions.md` に以下の課題があった:

1. **ツール操作の制約が OS 別と共通で混在** — エージェントがどのルールを適用すべきか判断しづらい
2. **Python/uv の指示が抽象的** — 「常に uv 経由」だけでは守られず、`python` / `pip` の直接実行が発生していた
3. **言語ルールがコードコメントのみ** — コミットメッセージ・PR・ブランチ名についてのガイドがなく、リポジトリごとに言語が混在

## 変更内容

### ツール操作の制約を構造化
- フラットな箇条書きを「共通」「Windows」「macOS / Linux」のサブセクションに分離

### Python/uv の指示を明確化
**Before:**
```
Python 実行・パッケージ管理 → 常に `uv` 経由。`python` / `pip` の直接実行は禁止（preToolUse フックで強制）
```

**After:**
```
Python → `python` / `pip` の直接実行は禁止。以下を使うこと:
  - スクリプト実行: `uv run script.py`（依存は PEP 723 インラインメタデータで宣言）
  - パッケージ追加: `uv add <pkg>`（プロジェクト）/ `uv pip install <pkg>`（グローバル）
  - REPL: `uv run python`
```

### 言語セクションの拡充
以下のルールを追加:
- コミットメッセージ: Conventional Commits プレフィックスは英語、説明文は README の言語に従う
- PR タイトル/本文: README の言語に従う
- ブランチ名: 常に英語（URL/CLI の互換性）
