### PR TITLE
feat: enhance Copilot CLI security based on audit report

### DIFF
--- a/.github/workflows/test-copilot-guard.yml
+++ b/.github/workflows/test-copilot-guard.yml
@@ -1,0 +1,66 @@
+name: Test Copilot Guard
+on:
+  pull_request:
+    paths:
+      - 'home/private_dot_copilot/hooks/**'
+      - 'tests/test_copilot_guard.py'
+  push:
+    branches: [main]
+    paths:
+      - 'home/private_dot_copilot/hooks/**'
+      - 'tests/test_copilot_guard.py'
+  schedule:
+    # Weekly Monday 00:00 UTC — detect fail-open regressions
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+
+      - name: Run copilot-guard unit tests
+        run: uv run -m unittest tests.test_copilot_guard -v
+
+      - name: Smoke test — .env access is blocked
+        run: |
+          RESULT=$(echo '{"toolName":"bash","toolArgs":{"command":"cat .env"}}' \
+            | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
+          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
+
+      - name: Smoke test — .azure access is blocked
+        run: |
+          RESULT=$(echo '{"toolName":"bash","toolArgs":{"command":"cat ~/.azure/azureProfile.json"}}' \
+            | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
+          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
+
+      - name: Smoke test — terraform.tfstate access is blocked
+        run: |
+          RESULT=$(echo '{"toolName":"bash","toolArgs":{"command":"cat terraform.tfstate"}}' \
+            | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
+          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
+
+      - name: Smoke test — copilot hooks modification is blocked
+        run: |
+          RESULT=$(echo '{"toolName":"edit","toolArgs":{"path":"/home/user/.copilot/hooks/hooks.json"}}' \
+            | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
+          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
+
+      - name: Smoke test — SSH key access is blocked
+        run: |
+          RESULT=$(echo '{"toolName":"bash","toolArgs":{"command":"cat ~/.ssh/id_ed25519"}}' \
+            | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
+          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
+
+      - name: Smoke test — printenv is blocked
+        run: |
+          RESULT=$(echo '{"toolName":"bash","toolArgs":{"command":"printenv"}}' \
+            | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
+          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -14,9 +14,10 @@ GitHub Copilot CLI の設定・運用ガイドである。chezmoi が `~/.copilo
 |---------|------|----------|
 | `copilot-instructions.md` | ユーザーレベルのカスタム指示 | chezmoi |
 | `mcp-config.json` | MCP サーバー設定 | chezmoi（`/mcp add` 後は `re-add`） |
-| `hooks/hooks.json` | preToolUse フック定義 | chezmoi |
+| `hooks/hooks.json` | preToolUse / postToolUse フック定義 | chezmoi |
 | `hooks/scripts/copilot-guard.py` | セキュリティガード（ファイル・URL・環境変数） | chezmoi |
 | `hooks/scripts/uv-enforcer.py` | Python / pip 直接実行をブロック | chezmoi |
+| `hooks/scripts/audit-log.py` | ツール実行の監査ログ記録 | chezmoi |
 | `hooks/blocked-files.txt` | ブロック対象ファイルパターン | chezmoi |
 | `hooks/allowed-urls.txt` | URL 許可リスト | chezmoi |
 | `skills/` | エージェントスキル | chezmoi（上流更新時は `re-add`） |
@@ -100,6 +101,56 @@ echo '{"toolName":"bash","toolArgs":{"command":"echo $GITHUB_TOKEN"}}' | uv run 
 # copilot-guard: 安全な変数参照は許可
 echo '{"toolName":"bash","toolArgs":{"command":"echo $HOME"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
 
+# copilot-guard: Hook ファイル改変のブロック
+echo '{"toolName":"edit","toolArgs":{"path":"/home/user/.copilot/hooks/hooks.json"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
+
+# copilot-guard: SSH 鍵アクセスのブロック
+echo '{"toolName":"bash","toolArgs":{"command":"cat ~/.ssh/id_ed25519"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
+
 # uv-enforcer: python/pip 直接実行のブロック
 echo '{"toolName":"bash","toolArgs":{"command":"python script.py"}}' | uv run ~/.copilot/hooks/scripts/uv-enforcer.py
 ```
+
+### 自動テスト
+
+```bash
+# ユニットテスト（65 テストケース）
+uv run -m unittest tests.test_copilot_guard -v
+```
+
+CI でも自動実行される（`.github/workflows/test-copilot-guard.yml`）。Hook 関連ファイルの変更時と週次スケジュールで実行し、fail-open リグレッションを検知する。
+
+### Autopilot モードでの安全な利用
+
+`--allow-all` 下ではツール承認・パス権限・URL 権限がすべて無効化されるが、`--deny-tool` と Hooks は引き続き有効である。`.zshrc` に定義された `copilot-safe` エイリアスは、多層防御を固定化した Autopilot 起動設定である。
+
+```bash
+copilot-safe -p "YOUR PROMPT"
+```
+
+このエイリアスには以下が含まれる:
+
+- `--deny-tool` による外部送信コマンド（curl, wget, nslookup, dig）のブロック（fail-open リスクなし）
+- `--secret-env-vars` による機微な環境変数値の隠蔽
+- `--max-autopilot-continues 20` による実行ステップ数の上限
+
+ファイルの読み取り・書き込み保護は `--deny-tool` ではなく preToolUse Hook（copilot-guard.py + blocked-files.txt）が担う。`--deny-tool` がサポートする kind は `shell(cmd)`, `write`（パス指定不可）, `url(domain)`, `<MCP>(tool)` のみであり、`read(...)` kind は存在しない。
+
+環境に応じて `--disable-mcp-server` や `--excluded-tools` を追加して攻撃面をさらに縮小できる。
+
+### 監査ログ
+
+`postToolUse` フックにより、ツール実行ごとに `~/.copilot/audit.jsonl` へログが記録される。
+
+```bash
+# 直近のツール実行を確認
+tail -5 ~/.copilot/audit.jsonl | python3 -m json.tool
+
+# 環境変数 COPILOT_AUDIT_DIR でログ出力先を変更可能
+COPILOT_AUDIT_DIR=/path/to/logs copilot
+```
+
+### 参考資料
+
+- [GitHub Copilot CLI — Permissions](https://docs.github.com/en/copilot/copilot-cli/using-copilot-cli/permissions) — 公式のパーミッション設計ドキュメント
+- [GitHub Copilot CLI — Hooks](https://docs.github.com/en/copilot/copilot-cli/using-copilot-cli/using-copilot-cli-hooks) — 公式の Hooks 設定リファレンス

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -115,6 +115,23 @@ Set-Alias -Name e -Value Open-EditInNewConsole
 Set-Alias -Name k -Value kubectl
 Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 
+# Copilot CLI: Autopilot + multi-layer defense (based on security report recommendations)
+# --deny-tool overrides --allow-all and has no fail-open risk.
+# File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
+# Supported --deny-tool kinds: shell(cmd), write, url(domain), <MCP>(tool)
+function Invoke-CopilotSafe {
+    copilot --autopilot `
+      --allow-all `
+      --deny-tool 'shell(curl)' `
+      --deny-tool 'shell(wget)' `
+      --deny-tool 'shell(nslookup)' `
+      --deny-tool 'shell(dig)' `
+      --secret-env-vars 'AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING' `
+      --max-autopilot-continues 20 `
+      @args
+}
+Set-Alias -Name copilot-safe -Value Invoke-CopilotSafe
+
 # === Completers and tool setup ===
 
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-windows?tabs=azure-cli#enable-tab-completion-in-powershell

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -128,6 +128,19 @@ command -v mise >/dev/null && source <(mise activate zsh)
 alias k=kubectl
 alias ll='ls -ahl'
 
+# Copilot CLI: Autopilot + multi-layer defense alias (based on security report recommendations)
+# --deny-tool overrides --allow-all and has no fail-open risk.
+# File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
+# Supported --deny-tool kinds: shell(cmd), write, url(domain), <MCP>(tool)
+alias copilot-safe='copilot --autopilot \
+  --allow-all \
+  --deny-tool "shell(curl)" \
+  --deny-tool "shell(wget)" \
+  --deny-tool "shell(nslookup)" \
+  --deny-tool "shell(dig)" \
+  --secret-env-vars "AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING" \
+  --max-autopilot-continues 20'
+
 # FPATH for completions (must be before compinit)
 [ -f "$HOME/.zfunc/_rustup" ] && FPATH=$HOME/.zfunc:$FPATH
 

--- a/home/private_dot_copilot/hooks/blocked-files.txt
+++ b/home/private_dot_copilot/hooks/blocked-files.txt
@@ -41,6 +41,22 @@
 # Publish Profile
 **/*.PublishSettings
 
+# Copilot CLI 設定・Hook (改変防止)
+# read/write 両方をブロック。--allow-all 下での 2 ステップ攻撃対策:
+# 攻撃者が Hook ファイルを改変→機密ファイルにアクセスする経路を遮断する。
+# ** を使い hooks/scripts/ 配下のスクリプトも保護する。
+**/.copilot/hooks/**
+**/.copilot/mcp-config.json
+**/.copilot/config.json
+**/.github/hooks/**
+
+# SSH
+**/.ssh/*
+**/id_rsa
+**/id_ed25519
+**/id_ecdsa
+**/id_dsa
+
 # 汎用
 **/.env
 **/.env.*

--- a/home/private_dot_copilot/hooks/hooks.json
+++ b/home/private_dot_copilot/hooks/hooks.json
@@ -14,6 +14,14 @@
         "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\uv-enforcer.py\"",
         "timeoutSec": 10
       }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "uv run \"$HOME/.copilot/hooks/scripts/audit-log.py\"",
+        "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-log.py\"",
+        "timeoutSec": 5
+      }
     ]
   }
 }

--- a/home/private_dot_copilot/hooks/scripts/executable_audit-log.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_audit-log.py
@@ -1,0 +1,106 @@
+# /// script
+# requires-python = ">=3.9"
+# ///
+"""Copilot Audit Log — postToolUse hook for recording tool invocations.
+
+Reads a JSON tool-call from stdin and appends a one-line JSON log entry to
+~/.copilot/audit.jsonl. The postToolUse output is ignored by Copilot CLI,
+so this script is purely for logging/auditing purposes.
+
+Security: Sensitive patterns (tokens, secrets, auth headers) are redacted
+before writing to prevent the audit log from becoming a secondary secret store.
+
+Run via: uv run audit-log.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Maximum audit log file size before rotation (default: 50 MB)
+MAX_LOG_BYTES = int(os.environ.get("COPILOT_AUDIT_MAX_BYTES", 50 * 1024 * 1024))
+
+# Patterns to redact from logged values
+_REDACT_PATTERNS = re.compile(
+    r"(?i)"
+    r"(?:"
+    # Auth headers: "Authorization: Bearer xxx" or "Authorization: Basic xxx"
+    r"authorization[=:\s]+\S+(?:\s+\S+){0,2}"
+    # Key-value: "token=xxx", "secret: xxx", "password=xxx"
+    r"|(?:bearer|token|basic|key|secret|password)[=:\s]+\S+"
+    r"|ghp_\S+"           # GitHub PAT
+    r"|github_pat_\S+"    # GitHub fine-grained PAT
+    r"|ghu_\S+|ghs_\S+"   # GitHub App tokens
+    r"|xox[bprs]-\S+"     # Slack tokens
+    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI API keys
+    r"|DefaultEndpointsProtocol=\S+"  # Azure connection strings
+    r"|AccountKey=[A-Za-z0-9+/=]+"    # Azure storage keys
+    r"|SharedAccessSignature=\S+"     # Azure SAS
+    r")"
+)
+
+
+def redact(value: str) -> str:
+    """Replace sensitive patterns with [REDACTED]."""
+    return _REDACT_PATTERNS.sub("[REDACTED]", value)
+
+
+def rotate_if_needed(log_file: Path) -> None:
+    """Rotate the log file if it exceeds the size threshold."""
+    try:
+        if log_file.exists() and log_file.stat().st_size > MAX_LOG_BYTES:
+            rotated = log_file.with_suffix(".jsonl.1")
+            # Simple single-file rotation: overwrite previous rotated file
+            if rotated.exists():
+                rotated.unlink()
+            log_file.rename(rotated)
+    except Exception:
+        pass  # Best-effort; never block agent operation
+
+
+def main() -> None:
+    log_dir = Path(os.environ.get("COPILOT_AUDIT_DIR", Path.home() / ".copilot"))
+    log_file = log_dir / "audit.jsonl"
+
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return
+        data = json.loads(raw)
+    except Exception:
+        return  # postToolUse output is ignored; silently skip on bad input
+
+    tool_name: str = data.get("toolName", "unknown")
+    tool_args = data.get("toolArgs", {})
+
+    # Extract a brief summary of the tool call (avoid logging full file contents)
+    summary: dict[str, str] = {"tool": tool_name}
+    if isinstance(tool_args, dict):
+        for key in ("command", "path", "file", "url", "pattern", "query"):
+            val = tool_args.get(key)
+            if val and isinstance(val, str):
+                # Truncate long values to avoid bloating the log
+                truncated = val[:500] if len(val) > 500 else val
+                summary[key] = redact(truncated)
+
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "cwd": os.getcwd(),
+        **summary,
+    }
+
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        rotate_if_needed(log_file)
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass  # Best-effort logging; never block agent operation
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_copilot_guard.py
+++ b/tests/test_copilot_guard.py
@@ -274,5 +274,165 @@ class CopilotGuardEnvBlockingTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class CopilotGuardNewBlockedPatternsTests(unittest.TestCase):
+    """Tests for newly added blocked-files.txt patterns (Copilot hooks, SSH, .github/hooks)."""
+
+    # --- Copilot CLI 設定・Hook (改変防止) ---
+
+    def test_blocks_copilot_hooks_direct_child(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.copilot/hooks/hooks.json",
+            ["**/.copilot/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.copilot/hooks/**")
+
+    def test_blocks_copilot_hooks_config_file(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.copilot/hooks/blocked-files.txt",
+            ["**/.copilot/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.copilot/hooks/**")
+
+    def test_blocks_copilot_hooks_nested_script(self) -> None:
+        """Critical: scripts/ subdirectory must be protected to prevent 2-step attacks."""
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.copilot/hooks/scripts/copilot-guard.py",
+            ["**/.copilot/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.copilot/hooks/**")
+
+    def test_blocks_copilot_hooks_nested_audit_log(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.copilot/hooks/scripts/audit-log.py",
+            ["**/.copilot/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.copilot/hooks/**")
+
+    def test_blocks_copilot_mcp_config(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.copilot/mcp-config.json",
+            ["**/.copilot/mcp-config.json"],
+        )
+        self.assertEqual(hit, "**/.copilot/mcp-config.json")
+
+    def test_blocks_copilot_config(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.copilot/config.json",
+            ["**/.copilot/config.json"],
+        )
+        self.assertEqual(hit, "**/.copilot/config.json")
+
+    def test_blocks_github_hooks_file(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/workspace/project/.github/hooks/check-sensitive-access.sh",
+            ["**/.github/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.github/hooks/**")
+
+    def test_blocks_github_hooks_json(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            ".github/hooks/pre-tool-use.json",
+            ["**/.github/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.github/hooks/**")
+
+    def test_blocks_github_hooks_nested_script(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            ".github/hooks/scripts/check.sh",
+            ["**/.github/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.github/hooks/**")
+
+    # --- SSH ---
+
+    def test_blocks_ssh_directory(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.ssh/known_hosts",
+            ["**/.ssh/*"],
+        )
+        self.assertEqual(hit, "**/.ssh/*")
+
+    def test_blocks_ssh_config(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.ssh/config",
+            ["**/.ssh/*"],
+        )
+        self.assertEqual(hit, "**/.ssh/*")
+
+    def test_blocks_id_rsa(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.ssh/id_rsa",
+            ["**/id_rsa"],
+        )
+        self.assertEqual(hit, "**/id_rsa")
+
+    def test_blocks_id_ed25519(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.ssh/id_ed25519",
+            ["**/id_ed25519"],
+        )
+        self.assertEqual(hit, "**/id_ed25519")
+
+    def test_blocks_id_ecdsa(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.ssh/id_ecdsa",
+            ["**/id_ecdsa"],
+        )
+        self.assertEqual(hit, "**/id_ecdsa")
+
+    def test_does_not_match_id_rsa_pub(self) -> None:
+        hit = copilot_guard.check_blocked_path(
+            "/home/user/.ssh/id_rsa.pub",
+            ["**/id_rsa"],
+        )
+        self.assertIsNone(hit)
+
+    # --- Command matching for hook file modification ---
+
+    def test_command_blocks_cat_copilot_hooks(self) -> None:
+        hit = copilot_guard.check_blocked_command(
+            "cat ~/.copilot/hooks/blocked-files.txt",
+            ["**/.copilot/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.copilot/hooks/**")
+
+    def test_command_blocks_cat_copilot_guard_script(self) -> None:
+        """Critical: must block reading the guard script itself."""
+        hit = copilot_guard.check_blocked_command(
+            "cat ~/.copilot/hooks/scripts/copilot-guard.py",
+            ["**/.copilot/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.copilot/hooks/**")
+
+    def test_command_blocks_sed_modify_guard_script(self) -> None:
+        """Critical: must block modification of the guard script."""
+        hit = copilot_guard.check_blocked_command(
+            "sed -i 's/deny/allow/g' ~/.copilot/hooks/scripts/copilot-guard.py",
+            ["**/.copilot/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.copilot/hooks/**")
+
+    def test_command_blocks_rm_github_hooks(self) -> None:
+        hit = copilot_guard.check_blocked_command(
+            "rm .github/hooks/check-sensitive-access.sh",
+            ["**/.github/hooks/**"],
+        )
+        self.assertEqual(hit, "**/.github/hooks/**")
+
+    def test_command_blocks_cat_ssh_key(self) -> None:
+        hit = copilot_guard.check_blocked_command(
+            "cat ~/.ssh/id_ed25519",
+            ["**/id_ed25519"],
+        )
+        self.assertEqual(hit, "**/id_ed25519")
+
+    def test_command_blocks_cat_copilot_mcp_config(self) -> None:
+        hit = copilot_guard.check_blocked_command(
+            "cat ~/.copilot/mcp-config.json",
+            ["**/.copilot/mcp-config.json"],
+        )
+        self.assertEqual(hit, "**/.copilot/mcp-config.json")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

Copilot CLI の Autopilot モードにおけるセキュリティ防御を強化する。セキュリティレポートの実機検証結果に基づき、blocked-files パターンの拡充、監査ログ Hook の追加、安全な Autopilot エイリアスの整備を行う。

## 変更内容

### blocked-files.txt — パターン追加
- `.copilot/hooks/**`: Hook スクリプト自体の読み書き保護（2ステップ攻撃対策）
- `.copilot/mcp-config.json`, `.copilot/config.json`: Copilot 設定保護
- `.github/hooks/**`: リポジトリレベルの Hook ファイル保護
- `.ssh/*`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`: SSH 鍵保護

### hooks.json — postToolUse 追加
- `audit-log.py` を postToolUse Hook として登録（タイムアウト 5 秒）

### audit-log.py — 新規
- ツール実行ごとに `~/.copilot/audit.jsonl` へ JSON ログを記録
- **シークレットリダクション**: Auth ヘッダー、GitHub PAT、Azure 接続文字列、SAS、AccountKey 等を `[REDACTED]` に置換
- **ログローテーション**: 50MB 超で `.jsonl.1` にローテーション（`COPILOT_AUDIT_MAX_BYTES` で設定可能）
- Best-effort: エラー時もエージェント動作をブロックしない

### copilot-safe エイリアス — 新規（zsh + PowerShell）
- `--deny-tool "shell(curl/wget/nslookup/dig)"`: 外部送信コマンドのブロック
- `--secret-env-vars`: Azure 機微環境変数の隠蔽
- `--max-autopilot-continues 20`: ステップ数上限
- ファイル読み書き保護は `--deny-tool` ではなく preToolUse Hook が担う（`read(...)` kind は `copilot help permissions` に存在しないため）

### CI ワークフロー — 新規
- `.github/workflows/test-copilot-guard.yml`
- PR/push トリガー（Hook 関連ファイル変更時）+ 週次スケジュール
- ユニットテスト + スモークテスト 6 件（.env, .azure, tfstate, Hook 改変, SSH 鍵, printenv）

### テスト — 拡充（45 → 70 テストケース）
- Hook ファイルのネストパス保護（`hooks/scripts/copilot-guard.py` 等）
- `sed` による Guard スクリプト改変コマンドの検出
- SSH 鍵アクセスブロック、公開鍵の非マッチ確認

### ドキュメント — copilot-cli.md 更新
- Autopilot 安全利用セクション追加
- 監査ログの使い方
- 自動テストの実行方法

## レビュー経過

Claude Opus 4.6 + GPT 5.4 の 2 モデルでレビューを実施し、以下の指摘を修正済み:

| 指摘 | 対応 |
|------|------|
| glob `*` が `hooks/scripts/` 配下を保護しない | `**/.copilot/hooks/**` に修正 |
| テストが実攻撃パスを未検証 | ネストパス + sed 改変のテスト追加 |
| `--deny-tool 'read(...)'` が未サポート kind | 削除。ファイル保護は Hook に委ねる設計に変更 |
| 監査ログが機微情報を平文記録 | リダクション追加 |
| 監査ログにローテーションなし | 50MB 閾値のローテーション追加 |
