### PR TITLE
docs: PR #24 セキュリティ強化の README・architecture への反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Cross-platform dotfiles managed by [chezmoi](https://www.chezmoi.io/) + [mise](h
 - **1つのソースで複数環境を管理**: `chezmoi` のテンプレートで、プラットフォームごとの差分を吸収しながら設定を一元管理している
 - **ツールチェーンを再現しやすい**: `mise` と lockfile で、開発ツールのバージョンと取得元をそろえやすい構成である
 - **GitHub Copilot CLI 向け設定を共通化**: カスタム指示、フック、スキルを dotfiles として管理している
-- **安全なデフォルト**: `gitleaks` を組み込んだ `git pre-commit` フックと Copilot CLI の `preToolUse` フックにより、コミット前とエージェント実行時のガードをそろえている。エージェント向けフックは秘匿ファイルへのアクセス、環境変数の読み取り、許可外 URL への送信を自動拒否する（[詳細](docs/copilot-cli.md#セキュリティフック)）
+- **安全なデフォルト**: `gitleaks` を組み込んだ `git pre-commit` フックと Copilot CLI の `preToolUse` フックにより、コミット前とエージェント実行時のガードをそろえている。エージェント向けフックは秘匿ファイルへのアクセス、環境変数の読み取り、許可外 URL への送信を自動拒否する。さらに `postToolUse` フックによる監査ログと、Autopilot モード向けの `copilot-safe` エイリアスで多層防御を構成している（[詳細](docs/copilot-cli.md#セキュリティフック)）
 - **制約の多いコンテナ環境でも破綻しにくい**: 非対話での作成やホスト側ツールにアクセスできないケースを考慮し、必要な分岐やフォールバックを組み込んでいる
 
 ## 対応環境
@@ -152,5 +152,5 @@ mise-upgrade
 
 - [`docs/operations.md`](docs/operations.md): 運用詳細、`mise` の追加・削除、lockfile 再構築、`git pre-commit` フックの追加・更新、`run_once_*` の扱い
 - [`docs/architecture.md`](docs/architecture.md): ディレクトリ構造、主要な設計判断、`git pre-commit` フックの構造、プラットフォーム検出、Git `includeIf` 設計
-- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象ファイル、プラグイン、スキル、フックのテスト方法
+- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象ファイル、プラグイン、スキル、セキュリティフック、Autopilot 安全利用、監査ログ
 - [`docs/troubleshooting.md`](docs/troubleshooting.md): よくあるエラーと復旧手順

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,12 +27,13 @@ home/                          ← chezmoi source (.chezmoiroot で指定)
 │   ├── copilot-instructions.md
 │   ├── mcp-config.json        ← MCP サーバー設定 (/mcp add 後は re-add)
 │   ├── hooks/
-│   │   ├── hooks.json         ← preToolUse フック定義
+│   │   ├── hooks.json         ← preToolUse / postToolUse フック定義
 │   │   ├── blocked-files.txt  ← ブロックパターン
 │   │   ├── allowed-urls.txt   ← URL 許可リスト
 │   │   └── scripts/
 │   │       ├── copilot-guard.py
-│   │       └── uv-enforcer.py
+│   │       ├── uv-enforcer.py
+│   │       └── audit-log.py
 │   └── skills/
 ├── run_once_before_*          ← パッケージ・mise インストール
 └── run_once_after_*           ← シェル・ツールセットアップ
@@ -53,6 +54,8 @@ reference/windows/             ← デプロイしない参照ファイル
 - **Git includeIf** を使って、プラットフォーム別 gitconfig の差分だけを自動読込する
 - **コミット署名** は 1Password SSH エージェント経由を基本とし、コンテナ系環境では自動無効化する
 - **Copilot Guard / uv Enforcer** により、危険なファイルアクセスや Python / pip の直接実行を抑止する
+- **postToolUse 監査ログ** により、ツール実行履歴を `~/.copilot/audit.jsonl` に記録し、事後検証を可能にする
+- **`copilot-safe` エイリアス** により、Autopilot モードでの多層防御（`--deny-tool` による外部送信ブロック、`--secret-env-vars` による機微変数隠蔽、ステップ数上限）を固定化する
 - **gitleaks + git pre-commit** により、コミット前に secret scan を走らせつつ、各リポジトリ固有のフックも併用できる
 - **Codespaces / Dev Container** では、非対話での作成や認証制約に合わせたワークアラウンドとフォールバックを持つ
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -114,7 +114,7 @@ echo '{"toolName":"bash","toolArgs":{"command":"python script.py"}}' | uv run ~/
 ### 自動テスト
 
 ```bash
-# ユニットテスト（65 テストケース）
+# ユニットテスト（70 テストケース）
 uv run -m unittest tests.test_copilot_guard -v
 ```
 


### PR DESCRIPTION
## 概要

PR #24 (feat: enhance Copilot CLI security based on audit report) で追加されたセキュリティ強化が、README と architecture.md に十分反映されていなかったため修正する。

## 変更内容

### README.md
- 「安全なデフォルト」に `postToolUse` 監査ログと `copilot-safe` エイリアスによる多層防御を追記
- `docs/copilot-cli.md` の要約に Autopilot 安全利用・監査ログのセクションを反映

### docs/architecture.md
- ディレクトリツリーに `audit-log.py` を追加
- `hooks.json` の説明を `preToolUse / postToolUse` に更新
- 主要な決定事項に監査ログと `copilot-safe` エイリアスを追加

### docs/copilot-cli.md
- テストケース数を 65 → 70 に修正（実際のテスト数と一致させる）
