### PR TITLE
docs: rename Windows setup step from "GUI アプリ" to "Windows セットアップ (DSC)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ GITHUB_TOKEN=$(gh auth token) mise install --yes
 
 1. chezmoi インストール: `winget install twpayne.chezmoi`
 2. 設定適用: `chezmoi init --apply torumakabe`
-3. GUI アプリ: `winget configure -f "$(chezmoi source-path)\..\reference\windows\configuration.dsc.yaml"`
+3. Windows セットアップ (DSC): `winget configure -f "$(chezmoi source-path)\..\reference\windows\configuration.dsc.yaml"`
 4. PowerShell Profile のローダー設定（初回のみ）:
 
 ```powershell


### PR DESCRIPTION
## 概要

Windows セットアップ手順のステップ 3 の説明を「GUI アプリ」から「Windows セットアップ (DSC)」に修正。

## 背景

DSC configuration (`configuration.dsc.yaml`) の内容は GUI アプリだけでなく、以下を含む:

- OS 設定 (Developer Mode)
- CLI ツール (Git, GitHub CLI, mise, Azure CLI, PowerShell)
- GUI アプリ (PowerToys, DevToys, draw.io)

「GUI アプリ」というラベルは実態と合わないため、より正確な表記に変更。
