### PR TITLE
refactor: copilot-guard から Java env-dump パターンを削除

### DIFF
--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -279,7 +279,6 @@ _RUNTIME_ENV_DUMP_RE = re.compile(
     r"|%ENV\b"                 # Perl    %ENV
     r"|\bENV\.to_h\b"         # Ruby    ENV.to_h
     r"|\bENV\.each\b"         # Ruby    ENV.each
-    r"|\bSystem\.getenv\(\s*\)"  # Java  System.getenv()
     r"|\bDeno\.env\.toObject\b"  # Deno  Deno.env.toObject()
     r"|\bGet-ChildItem\s+Env:"   # PowerShell Get-ChildItem Env:
     r"|\\\$env:",              # PowerShell $env: variable access


### PR DESCRIPTION
## 概要

`copilot-guard` の `_RUNTIME_ENV_DUMP_RE` から Java のパターンを削除する。

## 背景

ランタイム環境変数ダンプ検出の正規表現は、シェルからインラインで即座に実行できるスクリプト言語を対象としている（Python, Node.js, Perl, Ruby, Deno, PowerShell）。

Java はコンパイル言語であり、`bash` / `powershell` コマンド内にインラインで現れる現実的なシナリオがほぼない。`jshell` 経由の可能性はゼロではないが、LLM がわざわざ `jshell` で環境変数をダンプする攻撃パスは非現実的。

## 変更内容

- `_RUNTIME_ENV_DUMP_RE` から `System.getenv()` パターン（1行）を削除

## テスト

- 既存テスト全 70 件パス確認済み
