### PR TITLE
fix: exclude azure-dev from mise on Windows due to binary name normalization bug

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ mise 設定を変更する際は、以下のツールの対応状況を確認し
 
 - **cargo-make**: linux/arm64 未提供（[sagiegurari/cargo-make#541](https://github.com/sagiegurari/cargo-make/issues/541)）
 - **edit**: macOS 未提供（[releases](https://github.com/microsoft/edit/releases) を確認）
-- **azure-dev**: macOS では mise `github:` バックエンドがバイナリ名を正規化しない（`azd-darwin-arm64` → `azd`）ため brew で管理。非 macOS は `github:` バックエンド使用（aqua レジストリが linux/arm64 未対応: [aqua registry](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/Azure/azure-dev/registry.yaml) を確認）
+- **azure-dev**: macOS/Windows では mise `github:` バックエンドがバイナリ名を正規化しない（`azd-darwin-arm64` → `azd`、`azd-windows-amd64.exe` → `azd.exe`）ため、macOS は brew、Windows は winget で管理。Linux は `github:` バックエンド使用（aqua レジストリが linux/arm64 未対応: [aqua registry](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/Azure/azure-dev/registry.yaml) を確認）
 
 ## ワークアラウンド（定期チェック対象）
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -26,8 +26,9 @@ shellcheck = "latest"
 gitleaks = "latest"
 jq = "latest"
 rust = "latest"
-{{ if ne .chezmoi.os "darwin" -}}
-# macOS では github: バックエンドが正しく動作しないため brew で管理
+{{ if eq .chezmoi.os "linux" -}}
+# macOS/Windows では github: バックエンドがバイナリ名を正規化しないため
+# macOS は brew、Windows は winget で管理
 # aqua レジストリが linux/arm64 未対応のため github バックエンドを使用
 "github:Azure/azure-dev" = "latest"
 {{ end -}}

--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -51,6 +51,13 @@ properties:
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
+        description: "Install Azure Developer CLI"
+        allowPrerelease: false
+      settings:
+        id: Microsoft.Azd
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
         description: "Install mise"
         allowPrerelease: false
       settings:


### PR DESCRIPTION
## 概要

mise の `github:` バックエンドが Windows でもバイナリ名を正規化しない問題（`azd-windows-amd64.exe` → `azd.exe`）に対応する。macOS では既知だったが、Windows でも同様に発生することを確認した。

## 変更内容

- **`home/dot_config/mise/config.toml.tmpl`**: `azure-dev` の条件を `ne darwin` → `eq linux` に変更し、Windows でも mise 管理から除外
- **`reference/windows/configuration.dsc.yaml`**: Windows ブートストラップ用に `Microsoft.Azd` を DSC に追加
- **`.github/copilot-instructions.md`**: プラットフォーム制約の記述に Windows を追記

## 背景

`winget upgrade --all` と `mise upgrade` で azd が二重更新されていた。mise に一本化しようとしたところ、winget 版をアンインストールすると `azd` コマンドが使えなくなることが判明。mise がインストールしたバイナリは `azd-windows-amd64.exe` のままで、`azd.exe` として認識されない。
