### PR TITLE
feat: add Stats (exelban/stats) to macOS brew cask packages

### DIFF
--- a/home/run_once_after_30-install-tools.sh.tmpl
+++ b/home/run_once_after_30-install-tools.sh.tmpl
@@ -47,6 +47,9 @@ fi
 if ! brew install --cask --force drawio; then
   echo "Warning: failed to install draw.io via Homebrew. Retry manually with 'brew install --cask --force drawio'." >&2
 fi
+if ! brew install --cask --force stats; then
+  echo "Warning: failed to install Stats via Homebrew. Retry manually with 'brew install --cask --force stats'." >&2
+fi
 {{ end -}}
 
 {{ if and (eq .chezmoi.os "linux") (not .isWSL) -}}


### PR DESCRIPTION
## Summary

Add [Stats](https://github.com/exelban/stats) to the macOS brew cask packages in `run_once_after_30-install-tools.sh.tmpl`.

Stats is a macOS system monitor for the menu bar, providing CPU, GPU, memory, disk, network, battery, and sensor information.

## Changes

- Added `brew install --cask --force stats` to the macOS-specific section
- Follows existing error-handling pattern (warning on failure with manual retry instructions)
