### PR TITLE
feat: allow Copilot to access IaC parameter/variable files

### DIFF
--- a/home/private_dot_copilot/hooks/blocked-files.txt
+++ b/home/private_dot_copilot/hooks/blocked-files.txt
@@ -27,10 +27,10 @@
 
 # Terraform / Bicep
 **/terraform.tfstate
-**/terraform.tfvars
-**/*.auto.tfvars
-**/*.bicepparam
-**/*.parameters.json
+# **/terraform.tfvars
+# **/*.auto.tfvars
+# **/*.bicepparam
+# **/*.parameters.json
 
 # Terraform Cloud
 **/.terraform.d/credentials.tfrc.json


### PR DESCRIPTION
## 概要

Copilot Guard の `blocked-files.txt` から Terraform 変数ファイルと Bicep パラメータファイルのブロックパターンをコメントアウトし、Copilot がこれらのファイルを読み書きできるようにする。

## 変更内容

以下の4パターンを `#` でコメントアウト:

- `**/terraform.tfvars`
- `**/*.auto.tfvars`
- `**/*.bicepparam`
- `**/*.parameters.json`

`**/terraform.tfstate`（状態ファイル）は引き続きブロック対象のまま。

## 背景

IaC のパラメータ/変数ファイルは機密情報を含む場合があるためブロック対象にしていたが、Copilot による IaC 支援の利便性を優先し、アクセスを許可する。
