### PR TITLE
feat: preToolUse フックに ask 判定を追加

### DIFF
--- a/.github/workflows/test-copilot-guard.yml
+++ b/.github/workflows/test-copilot-guard.yml
@@ -47,11 +47,11 @@ jobs:
             | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
           echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
 
-      - name: Smoke test — copilot hooks modification is blocked
+      - name: Smoke test — copilot hooks modification requires confirmation (ask)
         run: |
           RESULT=$(echo '{"toolName":"edit","toolArgs":{"path":"/home/user/.copilot/hooks/hooks.json"}}' \
             | uv run home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py)
-          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
+          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='ask', f'Expected ask, got {d}'"
 
       - name: Smoke test — SSH key access is blocked
         run: |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Cross-platform dotfiles managed by [chezmoi](https://www.chezmoi.io/) + [mise](h
 - **1つのソースで複数環境を管理**: `chezmoi` のテンプレートで、プラットフォームごとの差分を吸収しながら設定を一元管理している
 - **ツールチェーンを再現しやすい**: `mise` と lockfile で、開発ツールのバージョンと取得元をそろえやすい構成である
 - **GitHub Copilot CLI 向け設定を共通化**: カスタム指示、フック、スキルを dotfiles として管理している
-- **安全なデフォルト**: `gitleaks` を組み込んだ `git pre-commit` フックと Copilot CLI の `preToolUse` フックにより、コミット前とエージェント実行時のガードをそろえている。エージェント向けフックは秘匿ファイルへのアクセス、環境変数の読み取り、許可外 URL への送信を自動拒否する。さらに `postToolUse` フックによる監査ログと、Autopilot モード向けの `copilot-safe` エイリアスで多層防御を構成している（[詳細](docs/copilot-cli.md#セキュリティフック)）
+- **安全なデフォルト**: `gitleaks` を組み込んだ `git pre-commit` フックと Copilot CLI の `preToolUse` フックにより、コミット前とエージェント実行時のガードをそろえている。エージェント向けフックは秘匿ファイルへのアクセスを自動拒否（`blocked-files.txt`）または確認付きアクセス（`ask-files.txt`）に振り分け、環境変数の読み取りや許可外 URL への送信も自動拒否する。さらに `postToolUse` フックによる監査ログと、Autopilot モード向けの `copilot-safe` エイリアスで多層防御を構成している（[詳細](docs/copilot-cli.md#セキュリティフック)）
 - **制約の多いコンテナ環境でも破綻しにくい**: 非対話での作成やホスト側ツールにアクセスできないケースを考慮し、必要な分岐やフォールバックを組み込んでいる
 
 ## 対応環境

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,8 @@ home/                          ← chezmoi source (.chezmoiroot で指定)
 │   ├── mcp-config.json        ← MCP サーバー設定 (/mcp add 後は re-add)
 │   ├── hooks/
 │   │   ├── hooks.json         ← preToolUse / postToolUse フック定義
-│   │   ├── blocked-files.txt  ← ブロックパターン
+│   │   ├── blocked-files.txt  ← ブロックパターン (deny)
+│   │   ├── ask-files.txt      ← 確認付きアクセスパターン (ask)
 │   │   ├── allowed-urls.txt   ← URL 許可リスト
 │   │   └── scripts/
 │   │       ├── copilot-guard.py
@@ -61,23 +62,27 @@ reference/windows/             ← デプロイしない参照ファイル
 
 ## Copilot Guard の設計
 
-`copilot-guard.py` は `preToolUse` フックとして、エージェントのツール呼び出しを**実行前にテキスト検査**し、以下の 3 種類の操作を拒否する。
+`copilot-guard.py` は `preToolUse` フックとして、エージェントのツール呼び出しを**実行前にテキスト検査**し、以下の判定を行う。
 
-1. **秘匿ファイルへのアクセス** — `.env`、`*.pem`、認証トークンファイル等（`blocked-files.txt` で定義）
-2. **環境変数からの秘匿情報読み取り** — `printenv`、`$GITHUB_TOKEN` 展開、`os.environ` 等
-3. **許可外 URL への送信** — `allowed-urls.txt` に含まれないドメインへのリクエスト
+1. **秘匿ファイルへのアクセス拒否** — `.env`、`*.pem`、認証トークンファイル等（`blocked-files.txt` で定義）
+2. **確認付きアクセス (ask)** — Copilot Hook 設定、Terraform パラメータ等（`ask-files.txt` で定義）。ユーザーの明示的な承認が必要
+3. **環境変数からの秘匿情報読み取り拒否** — `printenv`、`$GITHUB_TOKEN` 展開、`os.environ` 等
+4. **許可外 URL への送信拒否** — `allowed-urls.txt` に含まれないドメインへのリクエスト
+
+判定の優先度は deny > ask > allow であり、複数のチェック層が異なる判定を返した場合は最も制限的な判定が採用される。
 
 ### 設計上の位置づけ
 
 このフックは**エージェント向けのガードレール**であり、上記の操作をコマンド文字列のパターンマッチで検出する。LLM エージェントは通常、最も自然なコード（`printenv`、`echo $SECRET`、`os.environ` 等）を生成するため、そのパターンをブロックするだけで大部分のリスクをカバーできる。Base64 エンコードや変数間接参照などの難読化には対応しないが、プロンプトインジェクション等の悪意ある介入がない限り、エージェントがそのようなコードを生成する可能性は低い。`blocked-files.txt` によるファイルブロックも同様に、テキストベースの検査で実用上十分なカバー範囲を得る設計である。
 
-### 3 つのチェック層
+### チェック層
 
 ```text
 preToolUse 入力 (JSON)
   │
-  ├─ 1. ファイルアクセスチェック ← blocked-files.txt
+  ├─ 1. ファイルアクセスチェック ← blocked-files.txt / ask-files.txt
   │     対象: 全ツールの path/file/uri/glob/command 引数
+  │     判定: blocked → deny, ask → ask (ユーザー確認)
   │
   ├─ 2. 環境変数アクセスチェック ← コード内定義
   │     対象: bash/powershell の command 引数のみ

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -18,7 +18,8 @@ GitHub Copilot CLI の設定・運用ガイドである。chezmoi が `~/.copilo
 | `hooks/scripts/copilot-guard.py` | セキュリティガード（ファイル・URL・環境変数） | chezmoi |
 | `hooks/scripts/uv-enforcer.py` | Python / pip 直接実行をブロック | chezmoi |
 | `hooks/scripts/audit-log.py` | ツール実行の監査ログ記録 | chezmoi |
-| `hooks/blocked-files.txt` | ブロック対象ファイルパターン | chezmoi |
+| `hooks/blocked-files.txt` | ブロック対象ファイルパターン (deny) | chezmoi |
+| `hooks/ask-files.txt` | 確認付きアクセスパターン (ask) | chezmoi |
 | `hooks/allowed-urls.txt` | URL 許可リスト | chezmoi |
 | `skills/` | エージェントスキル | chezmoi（上流更新時は `re-add`） |
 | `installed-plugins/` | プラグイン | `/plugin install` で管理 |
@@ -61,7 +62,7 @@ chezmoi diff
 
 ## セキュリティフック
 
-コーディングエージェントは `bash` ツールを通じてファイル読み取りやコマンド実行を行える。便利な一方で、秘匿情報の意図しない読み取りや外部送信のリスクがある。このリポジトリでは `preToolUse` フックで **ツール実行前に検査し、危険な操作を自動拒否する** ガードを提供している。
+コーディングエージェントは `bash` ツールを通じてファイル読み取りやコマンド実行を行える。便利な一方で、秘匿情報の意図しない読み取りや外部送信のリスクがある。このリポジトリでは `preToolUse` フックで **ツール実行前に検査し、危険な操作を自動拒否（deny）または確認付きアクセス（ask）に振り分ける** ガードを提供している。
 
 脅威モデル、多層防御の構造、各チェック層の判定ロジックについては [`docs/architecture.md` の Copilot Guard セクション](architecture.md#copilot-guard-の設計) を参照する。
 
@@ -69,7 +70,7 @@ chezmoi diff
 
 #### blocked-files.txt
 
-ブロック対象のファイルパスをグロブパターンで記述する。1 行 1 パターン、`#` で始まる行はコメント。
+ブロック対象（deny）のファイルパスをグロブパターンで記述する。1 行 1 パターン、`#` で始まる行はコメント。マッチしたファイルへのアクセスは即座に拒否される。
 
 **パターン記法**:
 
@@ -86,6 +87,14 @@ chezmoi diff
 
 許可するドメインを 1 行 1 つ記述する。サブドメインも自動的に許可される（例: `github.com` は `api.github.com` も許可）。全行コメントアウトすると URL チェック自体が無効になる。
 
+#### ask-files.txt
+
+確認付きアクセス（ask）のファイルパスをグロブパターンで記述する。`blocked-files.txt` と同じ書式・パターン記法。マッチしたファイルへのアクセスはユーザーに確認プロンプトが表示され、明示的な承認が必要になる。
+
+同一パスが `blocked-files.txt` と `ask-files.txt` の両方にマッチした場合は deny が優先される。
+
+判定の優先度: **deny > ask > allow**
+
 ### フックのテスト
 
 フックは stdin に JSON を受け取り、stdout に許可 / 拒否の JSON を返す。
@@ -101,7 +110,7 @@ echo '{"toolName":"bash","toolArgs":{"command":"echo $GITHUB_TOKEN"}}' | uv run 
 # copilot-guard: 安全な変数参照は許可
 echo '{"toolName":"bash","toolArgs":{"command":"echo $HOME"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
 
-# copilot-guard: Hook ファイル改変のブロック
+# copilot-guard: Hook ファイルへの確認付きアクセス (ask)
 echo '{"toolName":"edit","toolArgs":{"path":"/home/user/.copilot/hooks/hooks.json"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
 
 # copilot-guard: SSH 鍵アクセスのブロック
@@ -114,7 +123,7 @@ echo '{"toolName":"bash","toolArgs":{"command":"python script.py"}}' | uv run ~/
 ### 自動テスト
 
 ```bash
-# ユニットテスト（70 テストケース）
+# ユニットテスト（86 テストケース）
 uv run -m unittest tests.test_copilot_guard -v
 ```
 
@@ -155,7 +164,7 @@ copilot-safe -p "YOUR PROMPT"
 
 これらは copilot-guard.py の URL 許可リストチェック、環境変数アクセスチェック、および OS レベルのネットワーク制御で補完する。`--deny-tool` は多層防御の第一層（fail-open リスクなし）として機能し、copilot-guard.py（第二層）と組み合わせて使う設計である。
 
-ファイルの読み取り・書き込み保護は `--deny-tool` ではなく preToolUse Hook（copilot-guard.py + blocked-files.txt）が担う。`--deny-tool` がサポートする kind は `shell(cmd)`, `write`（パス指定不可）, `url(domain)`, `<MCP>(tool)` のみであり、`read(...)` kind は存在しない（`copilot help permissions` で確認済み）。
+ファイルの読み取り・書き込み保護は `--deny-tool` ではなく preToolUse Hook（copilot-guard.py + blocked-files.txt / ask-files.txt）が担う。`--deny-tool` がサポートする kind は `shell(cmd)`, `write`（パス指定不可）, `url(domain)`, `<MCP>(tool)` のみであり、`read(...)` kind は存在しない（`copilot help permissions` で確認済み）。
 
 環境に応じて `--disable-mcp-server` や `--excluded-tools` を追加して攻撃面をさらに縮小できる。
 

--- a/home/private_dot_copilot/hooks/ask-files.txt
+++ b/home/private_dot_copilot/hooks/ask-files.txt
@@ -1,0 +1,23 @@
+# Path glob rules:
+# - Write patterns with `/` separators even for Windows paths.
+# - Matching normalizes `\` to `/`, collapses repeated separators, and strips `file://`.
+# - `*` matches within one path segment, `?` matches one character, `**` matches across segments.
+# - Patterns are evaluated as path globs, not as plain substrings.
+#
+# Patterns listed here trigger a user confirmation prompt ("ask") instead of
+# an outright block ("deny"). The agent cannot proceed without explicit approval.
+
+# Copilot CLI 設定・Hook (確認付きアクセス)
+# エージェントの自律操作は抑止しつつ、ユーザーが明示的に承認すればアクセス可能にする。
+# 2 ステップ攻撃（Hook 改変→機密ファイルアクセス）のリスクは残るが、
+# ユーザー確認が入るため意図しない改変は防げる。
+**/.copilot/hooks/**
+**/.copilot/mcp-config.json
+**/.copilot/config.json
+**/.github/hooks/**
+
+# Terraform / Bicep パラメータ
+**/terraform.tfvars
+**/*.auto.tfvars
+**/*.bicepparam
+**/*.parameters.json

--- a/home/private_dot_copilot/hooks/blocked-files.txt
+++ b/home/private_dot_copilot/hooks/blocked-files.txt
@@ -27,10 +27,6 @@
 
 # Terraform / Bicep
 **/terraform.tfstate
-# **/terraform.tfvars
-# **/*.auto.tfvars
-# **/*.bicepparam
-# **/*.parameters.json
 
 # Terraform Cloud
 **/.terraform.d/credentials.tfrc.json
@@ -45,10 +41,7 @@
 # read/write 両方をブロック。--allow-all 下での 2 ステップ攻撃対策:
 # 攻撃者が Hook ファイルを改変→機密ファイルにアクセスする経路を遮断する。
 # ** を使い hooks/scripts/ 配下のスクリプトも保護する。
-**/.copilot/hooks/**
-**/.copilot/mcp-config.json
-**/.copilot/config.json
-**/.github/hooks/**
+# → 確認付きアクセス (ask) に移設: ask-files.txt を参照。
 
 # SSH
 **/.ssh/*

--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -3,16 +3,18 @@
 # ///
 """Copilot Guard — cross-platform preToolUse hook (bash / powershell).
 
-Reads a JSON tool-call from stdin, checks against blocked-files.txt and
-allowed-urls.txt, and emits a JSON permission decision on stdout.
+Reads a JSON tool-call from stdin, checks against blocked-files.txt,
+ask-files.txt, and allowed-urls.txt, and emits a JSON permission decision
+on stdout.
 
 Architecture:
     Each security check is implemented as a *checker function* with the
-    signature ``(CheckContext) -> str | None``.  Returning a string means
-    "deny with this reason"; returning ``None`` means "pass".  All checkers
-    are registered in the ``CHECKERS`` list and executed in order by
-    ``main()``.  To add a new check, write a checker function and append
-    it to ``CHECKERS``.
+    signature ``(CheckContext) -> CheckResult | None``.  Returning a
+    ``CheckResult`` means "deny or ask with this reason"; returning ``None``
+    means "pass".  All checkers are registered in the ``CHECKERS`` list and
+    executed in order by ``main()``.  Results are aggregated with the priority
+    deny > ask > allow.  To add a new check, write a checker function and
+    append it to ``CHECKERS``.
 
 Run via: uv run copilot-guard.py
 """
@@ -33,6 +35,11 @@ from urllib.parse import unquote, urlsplit
 
 def deny(reason: str) -> None:
     print(json.dumps({"permissionDecision": "deny", "permissionDecisionReason": reason}))
+    sys.exit(0)
+
+
+def ask(reason: str) -> None:
+    print(json.dumps({"permissionDecision": "ask", "permissionDecisionReason": reason}))
     sys.exit(0)
 
 
@@ -86,8 +93,14 @@ def load_config_lines(path: Path) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# CheckContext
+# CheckResult and CheckContext
 # ---------------------------------------------------------------------------
+
+class CheckResult(NamedTuple):
+    """Result of a checker function: a decision and the reason for it."""
+    decision: str   # "deny" or "ask"
+    reason: str
+
 
 class CheckContext(NamedTuple):
     """Immutable bundle of data available to every checker function."""
@@ -95,11 +108,12 @@ class CheckContext(NamedTuple):
     tool_args: dict[str, Any]
     command: str
     blocked_patterns: list[str]
+    ask_patterns: list[str]
     allowed_domains: list[str]
 
 
-# Checker function contract: (CheckContext) -> deny reason or None.
-Checker = Callable[[CheckContext], Optional[str]]
+# Checker function contract: (CheckContext) -> CheckResult or None.
+Checker = Callable[[CheckContext], Optional[CheckResult]]
 
 
 # ---------------------------------------------------------------------------
@@ -222,19 +236,37 @@ def check_blocked_command(target: str, patterns: list[str]) -> str | None:
     return None
 
 
-def check_blocked_files(ctx: CheckContext) -> str | None:
-    """Check path-like tool args and command tokens against blocked-files patterns."""
+def check_blocked_files(ctx: CheckContext) -> CheckResult | None:
+    """Check path-like tool args and command tokens against blocked/ask patterns.
+
+    Returns CheckResult("deny", ...) for blocked patterns,
+    CheckResult("ask", ...) for ask patterns, or None if no match.
+    Blocked patterns are checked first (deny takes priority over ask).
+    """
     for prop in ("path", "file", "uri", "glob"):
         prop_value = ctx.tool_args.get(prop, "")
         if prop_value:
             matched_pattern = check_blocked_path(prop_value, ctx.blocked_patterns)
             if matched_pattern:
-                return f"Blocked pattern: {matched_pattern}"
+                return CheckResult("deny", f"Blocked pattern: {matched_pattern}")
 
     if ctx.command:
         matched_pattern = check_blocked_command(ctx.command, ctx.blocked_patterns)
         if matched_pattern:
-            return f"Blocked pattern: {matched_pattern}"
+            return CheckResult("deny", f"Blocked pattern: {matched_pattern}")
+
+    # Ask patterns (lower priority than deny)
+    for prop in ("path", "file", "uri", "glob"):
+        prop_value = ctx.tool_args.get(prop, "")
+        if prop_value:
+            matched_pattern = check_blocked_path(prop_value, ctx.ask_patterns)
+            if matched_pattern:
+                return CheckResult("ask", f"Confirm access — matched pattern: {matched_pattern}")
+
+    if ctx.command:
+        matched_pattern = check_blocked_command(ctx.command, ctx.ask_patterns)
+        if matched_pattern:
+            return CheckResult("ask", f"Confirm access — matched pattern: {matched_pattern}")
 
     return None
 
@@ -393,11 +425,14 @@ def check_env_access(command: str) -> str | None:
     return None
 
 
-def check_env(ctx: CheckContext) -> str | None:
+def check_env(ctx: CheckContext) -> CheckResult | None:
     """Check for environment variable access in shell commands."""
     if ctx.tool_name not in ("bash", "powershell") or not ctx.command:
         return None
-    return check_env_access(ctx.command)
+    reason = check_env_access(ctx.command)
+    if reason:
+        return CheckResult("deny", reason)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -423,7 +458,7 @@ def is_url_allowed(url: str, allowed_domains: list[str]) -> bool:
     return False
 
 
-def check_url_allowlist(ctx: CheckContext) -> str | None:
+def check_url_allowlist(ctx: CheckContext) -> CheckResult | None:
     """Check URLs in commands and web_fetch args against the domain allowlist."""
     if not ctx.allowed_domains:
         return None
@@ -431,12 +466,12 @@ def check_url_allowlist(ctx: CheckContext) -> str | None:
     if ctx.command:
         for url in extract_urls(ctx.command):
             if not is_url_allowed(url, ctx.allowed_domains):
-                return f"URL not in allowlist: {url}"
+                return CheckResult("deny", f"URL not in allowlist: {url}")
 
     if ctx.tool_name == "web_fetch":
         url = ctx.tool_args.get("url", "")
         if url and not is_url_allowed(url, ctx.allowed_domains):
-            return f"URL not in allowlist: {url}"
+            return CheckResult("deny", f"URL not in allowlist: {url}")
 
     return None
 
@@ -470,6 +505,7 @@ def build_context() -> CheckContext:
     script_dir = Path(__file__).resolve().parent
     hooks_dir = script_dir.parent
     blocked_file = hooks_dir / "blocked-files.txt"
+    ask_file = hooks_dir / "ask-files.txt"
     allowed_urls_file = hooks_dir / "allowed-urls.txt"
 
     if not blocked_file.is_file():
@@ -480,6 +516,7 @@ def build_context() -> CheckContext:
         tool_args=tool_args,
         command=command,
         blocked_patterns=load_config_lines(blocked_file),
+        ask_patterns=load_config_lines(ask_file),
         allowed_domains=load_config_lines(allowed_urls_file),
     )
 
@@ -490,10 +527,20 @@ def build_context() -> CheckContext:
 
 def main() -> None:
     ctx = build_context()
+    results: list[CheckResult] = []
     for checker in CHECKERS:
-        reason = checker(ctx)
-        if reason:
-            deny(reason)
+        result = checker(ctx)
+        if result:
+            results.append(result)
+    if not results:
+        allow()
+    # Priority: deny > ask > allow
+    denies = [r for r in results if r.decision == "deny"]
+    if denies:
+        deny(denies[0].reason)
+    asks = [r for r in results if r.decision == "ask"]
+    if asks:
+        ask(asks[0].reason)
     allow()
 
 

--- a/tests/test_copilot_guard.py
+++ b/tests/test_copilot_guard.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import pathlib
 import unittest
 
@@ -19,6 +20,25 @@ def load_module():
 
 
 copilot_guard = load_module()
+
+
+# Helper to build a CheckContext for testing.
+def make_ctx(
+    tool_name: str = "",
+    tool_args: dict | None = None,
+    command: str = "",
+    blocked_patterns: list[str] | None = None,
+    ask_patterns: list[str] | None = None,
+    allowed_domains: list[str] | None = None,
+) -> "copilot_guard.CheckContext":
+    return copilot_guard.CheckContext(
+        tool_name=tool_name,
+        tool_args=tool_args or {},
+        command=command,
+        blocked_patterns=blocked_patterns or [],
+        ask_patterns=ask_patterns or [],
+        allowed_domains=allowed_domains or [],
+    )
 
 
 class CopilotGuardPathMatchingTests(unittest.TestCase):
@@ -432,6 +452,172 @@ class CopilotGuardNewBlockedPatternsTests(unittest.TestCase):
             ["**/.copilot/mcp-config.json"],
         )
         self.assertEqual(hit, "**/.copilot/mcp-config.json")
+
+
+class CopilotGuardCheckResultTests(unittest.TestCase):
+    """Tests for the CheckResult type and ask() output helper."""
+
+    def test_check_result_is_named_tuple(self) -> None:
+        result = copilot_guard.CheckResult("deny", "test reason")
+        self.assertEqual(result.decision, "deny")
+        self.assertEqual(result.reason, "test reason")
+
+    def test_check_result_ask(self) -> None:
+        result = copilot_guard.CheckResult("ask", "confirm this")
+        self.assertEqual(result.decision, "ask")
+        self.assertEqual(result.reason, "confirm this")
+
+
+class CopilotGuardAskPatternsTests(unittest.TestCase):
+    """Tests for ask-files.txt pattern matching via check_blocked_files."""
+
+    def test_ask_pattern_returns_ask_decision(self) -> None:
+        ctx = make_ctx(
+            tool_name="edit",
+            tool_args={"path": "/home/user/.copilot/hooks/hooks.json"},
+            ask_patterns=["**/.copilot/hooks/**"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "ask")
+        self.assertIn("**/.copilot/hooks/**", result.reason)
+
+    def test_blocked_pattern_returns_deny_decision(self) -> None:
+        ctx = make_ctx(
+            tool_name="view",
+            tool_args={"path": "/home/user/.ssh/id_rsa"},
+            blocked_patterns=["**/id_rsa"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "deny")
+
+    def test_deny_takes_priority_over_ask_same_file(self) -> None:
+        """When a path matches both blocked and ask patterns, deny wins."""
+        ctx = make_ctx(
+            tool_name="edit",
+            tool_args={"path": "/home/user/.copilot/hooks/hooks.json"},
+            blocked_patterns=["**/.copilot/hooks/**"],
+            ask_patterns=["**/.copilot/hooks/**"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "deny")
+
+    def test_no_match_returns_none(self) -> None:
+        ctx = make_ctx(
+            tool_name="view",
+            tool_args={"path": "/home/user/project/src/main.py"},
+            blocked_patterns=["**/id_rsa"],
+            ask_patterns=["**/.copilot/hooks/**"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNone(result)
+
+    def test_ask_pattern_command_matching(self) -> None:
+        ctx = make_ctx(
+            tool_name="bash",
+            tool_args={"command": "cat ~/.copilot/hooks/hooks.json"},
+            command="cat ~/.copilot/hooks/hooks.json",
+            ask_patterns=["**/.copilot/hooks/**"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "ask")
+
+    def test_ask_pattern_terraform_tfvars(self) -> None:
+        ctx = make_ctx(
+            tool_name="edit",
+            tool_args={"path": "/project/infra/terraform.tfvars"},
+            ask_patterns=["**/terraform.tfvars"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "ask")
+
+    def test_ask_pattern_bicepparam(self) -> None:
+        ctx = make_ctx(
+            tool_name="view",
+            tool_args={"path": "/project/infra/main.bicepparam"},
+            ask_patterns=["**/*.bicepparam"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "ask")
+
+    def test_ask_copilot_mcp_config(self) -> None:
+        ctx = make_ctx(
+            tool_name="edit",
+            tool_args={"path": "/home/user/.copilot/mcp-config.json"},
+            ask_patterns=["**/.copilot/mcp-config.json"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "ask")
+
+    def test_ask_copilot_config_json(self) -> None:
+        ctx = make_ctx(
+            tool_name="view",
+            tool_args={"path": "/home/user/.copilot/config.json"},
+            ask_patterns=["**/.copilot/config.json"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "ask")
+
+    def test_ask_github_hooks(self) -> None:
+        ctx = make_ctx(
+            tool_name="edit",
+            tool_args={"path": "/workspace/.github/hooks/policy.json"},
+            ask_patterns=["**/.github/hooks/**"],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "ask")
+
+    def test_empty_ask_patterns_skips(self) -> None:
+        ctx = make_ctx(
+            tool_name="edit",
+            tool_args={"path": "/project/terraform.tfvars"},
+            ask_patterns=[],
+        )
+        result = copilot_guard.check_blocked_files(ctx)
+        self.assertIsNone(result)
+
+
+class CopilotGuardCheckerReturnTypeTests(unittest.TestCase):
+    """Tests that existing checkers now return CheckResult instead of raw str."""
+
+    def test_check_env_returns_check_result(self) -> None:
+        ctx = make_ctx(
+            tool_name="bash",
+            tool_args={"command": "printenv"},
+            command="printenv",
+        )
+        result = copilot_guard.check_env(ctx)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, copilot_guard.CheckResult)
+        self.assertEqual(result.decision, "deny")
+
+    def test_check_env_returns_none_for_safe(self) -> None:
+        ctx = make_ctx(
+            tool_name="bash",
+            tool_args={"command": "ls -la"},
+            command="ls -la",
+        )
+        result = copilot_guard.check_env(ctx)
+        self.assertIsNone(result)
+
+    def test_check_url_returns_check_result(self) -> None:
+        ctx = make_ctx(
+            tool_name="web_fetch",
+            tool_args={"url": "https://evil.example.com"},
+            allowed_domains=["github.com"],
+        )
+        result = copilot_guard.check_url_allowlist(ctx)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, copilot_guard.CheckResult)
+        self.assertEqual(result.decision, "deny")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Copilot CLI v1.0.4 で `preToolUse` フックの `permissionDecision` に `"ask"` が追加された。これを活用し、`copilot-guard.py` に deny/ask の振り分け機能を実装する。

## Changes

### New: `ask-files.txt`
- `blocked-files.txt` と同じ glob 形式で「確認付きアクセス」パターンを管理
- 初期パターン:
  - Copilot Hook 関連（`**/.copilot/hooks/**`, `**/.copilot/mcp-config.json`, `**/.copilot/config.json`, `**/.github/hooks/**`）
  - Terraform/Bicep パラメータ（`**/terraform.tfvars`, `**/*.auto.tfvars`, `**/*.bicepparam`, `**/*.parameters.json`）

### Modified: `copilot-guard.py`
- `CheckResult` NamedTuple 導入（`decision` + `reason`）
- `ask()` 出力ヘルパー追加
- Checker の戻り値型を `str | None` → `CheckResult | None` に変更
- `CheckContext` に `ask_patterns` フィールド追加
- `main()` で deny > ask > allow の優先度判定を実装

### Modified: `blocked-files.txt`
- Copilot Hook 関連 4 パターンを `ask-files.txt` に移設
- コメントアウトされていた Terraform/Bicep パターンのコメント行を削除

### Tests
- 16 テスト追加（ask 判定、deny 優先度、戻り値型など）
- 全 86 テスト通過

### Documentation
- README.md: 安全なデフォルトの説明に ask-files.txt を追記
- docs/architecture.md: ディレクトリ構造、Copilot Guard セクション、チェック図を更新
- docs/copilot-cli.md: 管理対象ファイル表、ask-files.txt セクション新設、テスト例・テスト数更新

## Background

- [Hooks configuration reference](https://docs.github.com/en/copilot/reference/hooks-configuration): `permissionDecision` は `"allow"`, `"deny"`, `"ask"` の 3 値
- Copilot CLI v1.0.4 changelog: "Hooks can now request user confirmation before tool execution with 'ask' permission decision"
- 判定優先度（deny > ask > allow）は [VS Code agent hooks](https://code.visualstudio.com/docs/copilot/customization/hooks) の仕様に準拠
