### PR TITLE
fix: mise-upgrade で lockfile を削除してから再生成し先祖返りを防止する

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,7 +61,7 @@ chezmoi add ~/.some-config
 
 1. `gh auth token` で一時トークンを取得
 2. `mise upgrade` で全ツールを最新化
-3. `mise lock --global --platform` で全プラットフォームの lockfile を更新
+3. lockfile を削除し、`mise lock --global --platform` で全プラットフォーム分を再生成
 4. `chezmoi re-add` で lockfile をソースに反映
 5. git commit + push
 
@@ -78,17 +78,18 @@ mise-upgrade
 
 ### 手動で実行する場合
 
-`mise lock` はデフォルトでプロジェクトレベルの設定のみ対象にするため、グローバル設定には **`--global`** が必須。また引数なしだと既定の 8 プラットフォーム（musl 含む）を対象にするため、**`--platform` も常に指定する**。
+`mise lock` はデフォルトでプロジェクトレベルの設定のみ対象にするため、グローバル設定には **`--global`** が必須。また引数なしだと既定の 8 プラットフォーム（musl 含む）を対象にするため、**`--platform` も常に指定する**。`mise upgrade` 後は lockfile を削除してから再生成する。`mise lock` は既存エントリのリフレッシュしか行わず、`mise upgrade` がバックエンドによっては新バージョンのエントリを追加しないことがあるため。
 
 ```bash
 GITHUB_TOKEN=$(gh auth token) mise upgrade
+rm -f ~/.config/mise/mise.lock
 GITHUB_TOKEN=$(gh auth token) mise lock --global --platform linux-x64,linux-arm64,macos-arm64,windows-x64,windows-arm64
 chezmoi re-add ~/.config/mise/mise.lock
 cd $(chezmoi source-path)/.. && git add -A && git commit -m "chore: upgrade mise tools" && git push
 ```
 
 ```powershell
-$env:GITHUB_TOKEN = (gh auth token); mise upgrade; mise lock --global --platform "linux-x64,linux-arm64,macos-arm64,windows-x64,windows-arm64"; $env:GITHUB_TOKEN = $null
+$env:GITHUB_TOKEN = (gh auth token); mise upgrade; Remove-Item ~\.config\mise\mise.lock -ErrorAction SilentlyContinue; mise lock --global --platform "linux-x64,linux-arm64,macos-arm64,windows-x64,windows-arm64"; $env:GITHUB_TOKEN = $null
 chezmoi re-add ~\.config\mise\mise.lock
 cd (Join-Path (chezmoi source-path) ".."); git add -A; git commit -m "chore: upgrade mise tools"; git push
 ```

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -67,9 +67,10 @@ function Invoke-MiseUpgrade {
         mise upgrade
         if ($LASTEXITCODE -ne 0) { throw "mise upgrade に失敗しました" }
 
-        Write-Host "==> mise lock: 全プラットフォームの lockfile を更新..."
+        Write-Host "==> mise lock: lockfile を再生成..."
+        Remove-Item ~\.config\mise\mise.lock -ErrorAction SilentlyContinue
         mise lock --global --platform "linux-x64,linux-arm64,macos-arm64,windows-x64,windows-arm64"
-        if ($LASTEXITCODE -ne 0) { throw "lockfile の更新に失敗しました。GITHUB_TOKEN の有効期限やネットワークを確認してください" }
+        if ($LASTEXITCODE -ne 0) { throw "lockfile の再生成に失敗しました。GITHUB_TOKEN の有効期限やネットワークを確認してください" }
 
         Write-Host "==> chezmoi re-add: lockfile をソースに反映..."
         chezmoi re-add ~\.config\mise\mise.lock

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -279,9 +279,10 @@ mise-upgrade() {
     return 1
   }
 
-  echo "==> mise lock: 全プラットフォームの lockfile を更新..."
+  echo "==> mise lock: lockfile を再生成..."
+  rm -f ~/.config/mise/mise.lock
   GITHUB_TOKEN="$token" mise lock --global --platform linux-x64,linux-arm64,macos-arm64,windows-x64,windows-arm64 || {
-    echo "❌ lockfile の更新に失敗しました。GITHUB_TOKEN の有効期限やネットワークを確認してください" >&2
+    echo "❌ lockfile の再生成に失敗しました。GITHUB_TOKEN の有効期限やネットワークを確認してください" >&2
     return 1
   }
 


### PR DESCRIPTION
## 問題

`mise-upgrade` 実行後、他端末で `chezmoi update` → `mise install` するとツールのバージョンが先祖返りすることがある。

### 根本原因

`mise lock` は既存の lockfile エントリのリフレッシュ（URL・チェックサム更新）しか行わない。`mise upgrade` がバックエンドによっては新バージョンのエントリを lockfile に追加しないことがあり（`core:node` で確認）、lockfile に古いバージョンが残り続ける。

具体的な確認結果:

| ツール (backend) | 旧バージョン in lockfile | 新バージョン in lockfile | `mise upgrade` が追加? |
|-----------------|----------------------|----------------------|----------------------|
| uv (aqua) | 0.10.12 ✅ | 0.11.1 ✅ | ✅ |
| copilot-cli (github) | 1.0.10 ✅ | 1.0.11 ✅ | ✅ |
| **node (core)** | **24.14.0 ✅** | **24.14.1 ❌** | **❌** |

## 修正内容

`mise-upgrade` 関数で `mise lock` の前に lockfile を削除し、ゼロから再生成するように変更。これにより `mise lock` が config.toml からバージョンを再解決し、`mise upgrade` でインストールされた最新バージョンが確実に lockfile に反映される。

| ファイル | 変更 |
|----------|------|
| `home/PowerShell_profile.ps1.tmpl` | `Remove-Item` で lockfile 削除後に `mise lock` |
| `home/dot_zshrc.tmpl` | `rm -f` で lockfile 削除後に `mise lock` |
| `docs/operations.md` | 手動手順とワークフロー説明を更新 |

## 補足

- lockfile は git 管理下にあるため、`mise lock` が失敗しても `git checkout` で復元可能
- 再生成により stale エントリ（旧バージョン）も除去される
- #37 の `--global` フラグ修正に加えての追加対策
