### PR TITLE
fix: add main branch guard to mise-upgrade functions

### DIFF
--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -79,6 +79,12 @@ function Invoke-MiseUpgrade {
         $sourceRoot = Join-Path (chezmoi source-path) ".."
         Push-Location $sourceRoot
 
+        $branch = git rev-parse --abbrev-ref HEAD
+        if ($branch -ne "main") {
+            Pop-Location
+            throw "chezmoi ソースが main ブランチではありません (現在: $branch)。git checkout main してから再実行してください"
+        }
+
         git add -A
         $diff = git diff --cached --quiet 2>&1
         if ($LASTEXITCODE -eq 0) {

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -299,6 +299,13 @@ mise-upgrade() {
     return 1
   }
 
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  if [[ "$branch" != "main" ]]; then
+    echo "❌ chezmoi ソースが main ブランチではありません (現在: $branch)。git checkout main してから再実行してください" >&2
+    return 1
+  fi
+
   git add -A
   if git diff --cached --quiet; then
     echo "✅ 更新するツールはありませんでした"


### PR DESCRIPTION
## Summary

`mise-upgrade` 関数に main ブランチガードを追加し、feature ブランチ上で誤ってコミット・push される問題を防止する。

## Problem

PR マージ後にローカルで feature ブランチを削除し忘れた状態で `mise-upgrade` を実行すると、コミットと push が main ではなく feature ブランチに対して行われてしまう。

## Changes

- **PowerShell** (`Invoke-MiseUpgrade`): `chezmoi source-path` に移動後、`git rev-parse --abbrev-ref HEAD` で現在のブランチを確認。main 以外ならエラーメッセージを表示して中断。
- **zsh** (`mise-upgrade`): 同様のブランチチェックを追加。
