### PR TITLE
feat: expose Copilot CLI path to Copilot Desktop via launchctl on macOS

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -324,3 +324,8 @@ mise-upgrade() {
 
   echo "✅ mise ツールの更新が完了しました"
 }
+
+{{ if eq .chezmoi.os "darwin" -}}
+# Copilot Desktop に mise 管理の copilot CLI パスを公開
+launchctl setenv COPILOT_CLI_PATH "$HOME/.local/share/mise/shims/copilot"
+{{ end -}}


### PR DESCRIPTION
## 概要

Copilot CLIを使うアプリケーションが mise 管理下の copilot CLI を検出できるよう、macOS 環境で `launchctl setenv` を使い `COPILOT_CLI_PATH` 環境変数を設定する。

## 変更内容

- `home/dot_zshrc.tmpl` の末尾に、macOS 限定（`{{ if eq .chezmoi.os "darwin" }}`）で `launchctl setenv COPILOT_CLI_PATH` を追加
- Linux 環境では該当行は出力されない
