### PR TITLE
fix: copilot CLIの導入元をプラットフォーム別に分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cross-platform dotfiles managed by [chezmoi](https://www.chezmoi.io/) + [mise](h
 | WSL | [クイックスタート → Linux / macOS / WSL](#linux--macos--wsl) | 1Password パスが Windows 側、初回 `windowsUser` 入力が必要 |
 | GitHub Codespaces | [クイックスタート → GitHub Codespaces](#github-codespaces) | `corpUser` 未設定 |
 | Dev Container (ローカル) | [クイックスタート → Dev Container](#dev-container-ローカル) | 初回 `mise install --yes` を手動実行 |
-| Windows | [クイックスタート → Windows](#windows) | — |
+| Windows | [クイックスタート → Windows](#windows) | `copilot` は DSC + winget で導入 |
 
 ## クイックスタート
 
@@ -93,12 +93,14 @@ if (!(Select-String -Path $PROFILE -SimpleMatch $line -Quiet)) {
 }
 ```
 
-5. ツールインストール:
+5. 残りのツールを mise でインストール:
 
 ```powershell
 gh auth login
 $env:GITHUB_TOKEN = (gh auth token); mise install; $env:GITHUB_TOKEN = $null
 ```
+
+`copilot` は step 3 の `winget configure` で導入されるため、Windows では `mise install` の対象外である。
 
 ## 日常操作
 
@@ -110,6 +112,8 @@ $env:GITHUB_TOKEN = (gh auth token); mise install; $env:GITHUB_TOKEN = $null
 | **mise 管理** | Go, Node, Terraform などのバージョン | `.config/mise/config.toml` を更新 → `mise install` |
 | **手動管理** | `reference/windows/` 配下 | 直接編集して git commit |
 | **リポジトリメタ情報** | `README.md`, `.github/copilot-instructions.md` | 直接編集して git commit |
+
+`copilot` は例外で、Linux / WSL / Codespaces / Dev Container では `mise`、macOS では `brew`、Windows では `winget` で管理する。
 
 **重要**: chezmoi 管理下のファイルを直接編集しても、次回の `chezmoi apply` で上書きされる。永続化するには `chezmoi edit` またはソース側の編集を使う。
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -24,6 +24,18 @@ GitHub Copilot CLI の設定・運用ガイドである。chezmoi が `~/.copilo
 | `skills/` | エージェントスキル | chezmoi（上流更新時は `re-add`） |
 | `installed-plugins/` | プラグイン | `/plugin install` で管理 |
 
+## CLI 本体の導入元
+
+`copilot` CLI の本体は、プラットフォームごとに導入元を分けている。
+
+| 環境 | 導入元 |
+|------|--------|
+| Linux / WSL / Codespaces / Dev Container | `mise` |
+| macOS | `brew` |
+| Windows | `winget` (`reference/windows/configuration.dsc.yaml`) |
+
+macOS では Copilot Desktop が GUI プロセスとして起動するため、`.zshrc` から `launchctl setenv COPILOT_CLI_PATH` を設定して Homebrew 側の `copilot` パスを公開する。
+
 ## プラグインの管理
 
 プラグインは `/plugin` コマンドで管理する。chezmoi の管理外である。

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,13 +6,13 @@
 
 | 環境 | 管理ツール | 対象 |
 |------|-----------|------|
-| Linux / WSL | `apt` + `mise` | apt: OS パッケージ + Azure CLI、mise: 開発ツール |
-| macOS | `brew` + `mise` | brew: OS パッケージ・GUI アプリ + Azure CLI、mise: 開発ツール |
-| Codespaces / Dev Container | ベースイメージ / Feature + `mise` | Feature: Azure CLI など、mise: 開発ツール |
-| Windows | `winget` (DSC) + `mise` | winget: GUI/CLI アプリ + Azure CLI、mise: 開発ツール |
+| Linux / WSL | `apt` + `mise` | apt: OS パッケージ + Azure CLI、mise: 開発ツール + `copilot-cli` |
+| macOS | `brew` + `mise` | brew: OS パッケージ・GUI アプリ + Azure CLI + `copilot-cli`、mise: その他の開発ツール |
+| Codespaces / Dev Container | ベースイメージ / Feature + `mise` | Feature: Azure CLI など、mise: 開発ツール + `copilot-cli` |
+| Windows | `winget` (DSC) + `mise` | winget: GUI/CLI アプリ + Azure CLI + `copilot-cli`、mise: その他の開発ツール |
 | 全環境共通 | `uv` | Python スクリプト実行 |
 
-> **Azure CLI**: mise ではなく各プラットフォームの公式パッケージマネージャーで管理する。Codespaces / Dev Container では devcontainer Feature を使う。
+> **Azure CLI / Copilot CLI**: GUI アプリやプラットフォーム固有の導入都合があるため、必要に応じて各プラットフォームの公式パッケージマネージャーで管理する。Codespaces / Dev Container では Linux 系の流れに合わせて `mise` または devcontainer Feature を使う。
 
 ## chezmoi コマンドリファレンス
 
@@ -105,6 +105,8 @@ chezmoi re-add ~/.config/mise/mise.lock
 ```
 
 PowerShell の場合は `$env:GITHUB_TOKEN = (gh auth token); <command>; $env:GITHUB_TOKEN = $null` で囲む。`--platform` の値は必ずクォートする。
+
+`copilot-cli` は例外で、Linux 系のみ `mise` で管理する。macOS は `brew`、Windows は `winget` (DSC) 側を更新する。
 
 ## mise lockfile の再構築
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -31,8 +31,11 @@ rust = "latest"
 # macOS は brew、Windows は winget で管理
 # aqua レジストリが linux/arm64 未対応のため github バックエンドを使用
 "github:Azure/azure-dev" = "latest"
-{{ end -}}
+# Copilot Desktop などの GUI アプリから検出できるよう、macOS は brew、
+# Windows は winget で管理する。Codespaces / Dev Container を含む Linux 系は
+# 既存どおり mise 管理を維持する。
 "github:github/copilot-cli" = "latest"
+{{ end -}}
 {{ if ne .chezmoi.os "darwin" -}}
 # macOS 向けプリビルドバイナリが未提供のためスキップ
 edit = "latest"

--- a/home/dot_config/mise/mise.lock
+++ b/home/dot_config/mise/mise.lock
@@ -262,21 +262,6 @@ checksum = "sha256:42a1593bd04d5b3fbc7b8042f4ab7160ef4cdf2e637b2e6cc7b8cca71dfb5
 url = "https://github.com/github/copilot-cli/releases/download/v1.0.12/copilot-linux-x64.tar.gz"
 url_api = "https://api.github.com/repos/github/copilot-cli/releases/assets/382420209"
 
-[tools."github:github/copilot-cli"."platforms.macos-arm64"]
-checksum = "sha256:9ab09d670bff7f432e9a6b6d02f3319496c07e8959686a881bd43e513a1e6153"
-url = "https://github.com/github/copilot-cli/releases/download/v1.0.12/copilot-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/github/copilot-cli/releases/assets/382420199"
-
-[tools."github:github/copilot-cli"."platforms.windows-arm64"]
-checksum = "sha256:be39865d93390679f5d84f7dc5ea986ffb444a806e16d558ccf034984ab64b16"
-url = "https://github.com/github/copilot-cli/releases/download/v1.0.12/copilot-win32-arm64.zip"
-url_api = "https://api.github.com/repos/github/copilot-cli/releases/assets/382420252"
-
-[tools."github:github/copilot-cli"."platforms.windows-x64"]
-checksum = "sha256:80877eb2db2197cddccf001dc170a6fe14fef125253a3a3f52c456d78fcd4ab1"
-url = "https://github.com/github/copilot-cli/releases/download/v1.0.12/copilot-win32-x64.zip"
-url_api = "https://api.github.com/repos/github/copilot-cli/releases/assets/382420257"
-
 [[tools.gitleaks]]
 version = "8.30.1"
 backend = "aqua:gitleaks/gitleaks"

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -326,6 +326,8 @@ mise-upgrade() {
 }
 
 {{ if eq .chezmoi.os "darwin" -}}
-# Copilot Desktop に mise 管理の copilot CLI パスを公開
-launchctl setenv COPILOT_CLI_PATH "$HOME/.local/share/mise/shims/copilot"
+# Copilot Desktop に brew 管理の copilot CLI パスを公開
+if command -v copilot >/dev/null 2>&1; then
+  launchctl setenv COPILOT_CLI_PATH "$(command -v copilot)"
+fi
 {{ end -}}

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -58,10 +58,12 @@ fi
 echo "Installing system packages via brew..."
 brew update --quiet
 # gh: mise install 前にトークン取得手段を確保する（mise 版 gh が shim で shadow する）
-# azure/azd/azd: mise github: バックエンドが macOS で正しく動作しないため brew で管理
+# azure-cli / azd / copilot-cli: GUI アプリや github: バックエンド都合を避けるため
+# macOS では brew で管理
 brew install \
   azure-cli \
   azure/azd/azd \
+  copilot-cli \
   gh \
   watch \
   zsh-completions

--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -3,7 +3,7 @@
 #
 # Usage: winget configure -f configuration.dsc.yaml (管理者権限の PowerShell で実行)
 #
-# Note: CLI tool versions are managed by mise (~/.config/mise/config.toml).
+# Note: Most CLI tool versions are managed by mise (~/.config/mise/config.toml).
 # DSC contains only: OS settings, GUI/CLI apps not managed by mise, and
 # bootstrap tooling (mise itself).
 properties:
@@ -48,6 +48,13 @@ properties:
         allowPrerelease: false
       settings:
         id: GitHub.cli
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: "Install GitHub Copilot CLI"
+        allowPrerelease: false
+      settings:
+        id: GitHub.Copilot
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:


### PR DESCRIPTION
## 概要

Copilot CLI の導入元をプラットフォーム別に分離し、 GUI アプリから `copilot` バイナリを見つけやすくします。

## 変更内容

- Linux / WSL / Codespaces / Dev Container では `copilot-cli` を引き続き `mise` で管理
- macOS では `copilot-cli` を `brew` で導入し、`launchctl setenv COPILOT_CLI_PATH` で GUI プロセスへパスを公開
- Windows では `reference/windows/configuration.dsc.yaml` に `GitHub.Copilot` を追加し、`winget configure` で導入
- `README.md`、`docs/operations.md`、`docs/copilot-cli.md` を更新し、各プラットフォームの導入経路を明記

## テスト

- `uv run -m unittest tests.test_copilot_guard -v`
- `git diff --check`
