### PR TITLE
feat: add Show-Markdown instruction for Windows Markdown viewing

### DIFF
--- a/home/private_dot_copilot/copilot-instructions.md
+++ b/home/private_dot_copilot/copilot-instructions.md
@@ -12,6 +12,7 @@
 ### Windows
 
 - ファイルをエディタで開く → `Start-Process edit <path>`（Microsoft Edit が別ウィンドウで起動する）
+- Markdown ファイルを閲覧する → `Show-Markdown -Path <path> -UseBrowser`（既定のブラウザでレンダリング表示）
 - Copilot CLI のシェルセッションでは `$PROFILE` が読み込まれないため、エイリアスや関数は使えない
 
 ### macOS / Linux


### PR DESCRIPTION
## Summary

Windows 環境で Markdown ファイルを閲覧する際の指示を `copilot-instructions.md` に追加。

## Changes

- `Show-Markdown -Path <path> -UseBrowser` を Windows セクションに追加
  - 既定のブラウザで Markdown をレンダリング表示する用途
  - 既存の `Start-Process edit`（編集目的）と使い分けを明確化

## References

- [Show-Markdown (Microsoft Learn)](https://learn.microsoft.com/ja-jp/powershell/module/microsoft.powershell.utility/show-markdown?view=powershell-7.6)
