### PR TITLE
chore: Linux の azd を mise から公式インストーラーに移行

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ mise 設定を変更する際は、以下のツールの対応状況を確認し
 
 - **cargo-make**: linux/arm64 未提供（[sagiegurari/cargo-make#541](https://github.com/sagiegurari/cargo-make/issues/541)）
 - **edit**: macOS 未提供（[releases](https://github.com/microsoft/edit/releases) を確認）
-- **azure-dev**: macOS/Windows では mise `github:` バックエンドがバイナリ名を正規化しない（`azd-darwin-arm64` → `azd`、`azd-windows-amd64.exe` → `azd.exe`）ため、macOS は brew、Windows は winget で管理。Linux は `github:` バックエンド使用（aqua レジストリが linux/arm64 未対応: [aqua registry](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/Azure/azure-dev/registry.yaml) を確認）
+- **azure-dev**: mise `github:` バックエンドがバイナリ名を正規化しないため、全 OS で mise 外で管理。macOS は brew、Windows は winget、Linux は公式インストーラー (`install-azd.sh`)。更新は `azd update` で行う
 
 ## ワークアラウンド（定期チェック対象）
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -20,7 +20,7 @@
 
 - **cargo-make**: linux/arm64 向け配布がない
 - **edit**: macOS 向け配布がない
-- **azure-dev**: macOS / Windows では `github:` バックエンドが実行ファイル名を正規化しないため、macOS は `brew`、Windows は `winget` を使う。Linux は `github:` バックエンドを使う
+- **azure-dev**: mise `github:` バックエンドがバイナリ名を正規化しないため、全 OS で mise 外で管理。macOS は `brew`、Windows は `winget`、Linux は公式インストーラー (`install-azd.sh`) を使い、更新は `azd update` で行う
 
 解消されていれば、条件分岐や導入元のワークアラウンドを外せる。
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -27,10 +27,6 @@ gitleaks = "latest"
 jq = "latest"
 rust = "latest"
 {{ if eq .chezmoi.os "linux" -}}
-# macOS/Windows では github: バックエンドがバイナリ名を正規化しないため
-# macOS は brew、Windows は winget で管理
-# aqua レジストリが linux/arm64 未対応のため github バックエンドを使用
-"github:Azure/azure-dev" = "latest"
 # Copilot Desktop などの GUI アプリから検出できるよう、macOS は brew、
 # Windows は winget で管理する。Codespaces / Dev Container を含む Linux 系は
 # 既存どおり mise 管理を維持する。

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -52,6 +52,14 @@ if ! command -v az >/dev/null 2>&1; then
   echo "Installing Azure CLI via official script..."
   curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 fi
+
+# Azure Developer CLI — 公式インストールスクリプト (https://aka.ms/install-azd.sh)
+# github: バックエンドはバイナリ名を正規化しないため、macOS (brew) / Windows (winget) と同様に
+# mise 外で管理する。更新は azd update で行う
+if ! command -v azd >/dev/null 2>&1; then
+  echo "Installing Azure Developer CLI via official script..."
+  curl -fsSL https://aka.ms/install-azd.sh | bash
+fi
 {{ end -}}
 
 {{ else if eq .chezmoi.os "darwin" -}}


### PR DESCRIPTION
## 概要

Linux 環境で `mise upgrade` しても `azd` が古いままだった問題を修正。

## 背景

mise の `github:` バックエンドは GitHub Releases からバイナリを取得するが、`azd-linux-amd64` → `azd` へのリネーム（正規化）を行わない。そのため：

- `mise which azd` が解決できず shim が機能していなかった
- 実際に使われていたのはシステム側の `/usr/local/bin/azd`（古いバージョン）

macOS / Windows ではこの問題を認識済みで brew / winget で管理していたが、Linux でも同じ問題が起きていた。

## 変更内容

| ファイル | 変更 |
|---|---|
| `config.toml.tmpl` | `github:Azure/azure-dev` エントリを削除 |
| `run_once_before_10-install-packages.sh.tmpl` | 公式インストーラー (`install-azd.sh`) を追加（Codespaces/DevContainer 以外） |
| `docs/operations.md` | azd の管理方法を「全 OS で mise 外」に更新 |
| `.github/copilot-instructions.md` | 同上 |

## 更新方法

初回インストール後の更新は `azd update` で行う（macOS の `brew upgrade azd` / Windows の `winget upgrade` と同じ位置づけ）。
