### PR TITLE
feat: add LibreOffice and Poppler for PPTX skill support

### DIFF
--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -20,6 +20,8 @@ sudo apt-get install -y -qq \
   curl \
   git \
   keychain \
+  libreoffice-impress \
+  poppler-utils \
   software-properties-common \
   unzip \
   vim \
@@ -73,8 +75,10 @@ brew install \
   azure/azd/azd \
   copilot-cli \
   gh \
+  poppler \
   watch \
   zsh-completions
+brew install --cask libreoffice
 
 {{ end -}}
 {{ end -}}

--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -79,6 +79,20 @@ properties:
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
+        description: "Install LibreOffice"
+        allowPrerelease: false
+      settings:
+        id: TheDocumentFoundation.LibreOffice
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: "Install Poppler"
+        allowPrerelease: false
+      settings:
+        id: oschwartz10612.Poppler
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
         description: "Install draw.io"
         allowPrerelease: false
       settings:


### PR DESCRIPTION
## Summary

Add cross-platform installation of LibreOffice and Poppler (`pdftoppm`) as system-level dependencies for the [Anthropic PPTX skill](https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md).

## Changes

| OS | Package Manager | Added Packages |
|----|----------------|----------------|
| Linux | apt | `libreoffice-impress`, `poppler-utils` |
| macOS | brew | `poppler`, `libreoffice` (cask) |
| Windows | winget (DSC) | `TheDocumentFoundation.LibreOffice`, `oschwartz10612.Poppler` |

## Context

The PPTX skill requires LibreOffice (`soffice --headless`) for PPTX→PDF conversion and Poppler (`pdftoppm`) for PDF→image conversion during visual QA. macOS/Windows do not offer headless-only LibreOffice packages, so the full version is installed (~500MB).

Python/npm packages (`markitdown[pptx]`, `Pillow`, `pptxgenjs`) are not included as they can be installed per-project as needed.
