### PR TITLE
fix: stop copilot-guard from suppressing CLI approval prompts

### DIFF
--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -13,8 +13,10 @@ Architecture:
     ``CheckResult`` means "deny or ask with this reason"; returning ``None``
     means "pass".  All checkers are registered in the ``CHECKERS`` list and
     executed in order by ``main()``.  Results are aggregated with the priority
-    deny > ask > allow.  To add a new check, write a checker function and
-    append it to ``CHECKERS``.
+    deny > ask > (no output).  When no checker has an opinion the hook
+    produces no output, deferring to the CLI's built-in approval flow.
+    To add a new check, write a checker function and append it to
+    ``CHECKERS``.
 
 Run via: uv run copilot-guard.py
 """
@@ -639,7 +641,7 @@ def main() -> None:
         if result:
             results.append(result)
     if not results:
-        allow()
+        return  # No opinion — let the CLI's default approval flow decide
     # Priority: deny > ask > allow
     denies = [r for r in results if r.decision == "deny"]
     if denies:
@@ -647,7 +649,8 @@ def main() -> None:
     asks = [r for r in results if r.decision == "ask"]
     if asks:
         ask(asks[0].reason)
-    allow()
+    # All results are neither deny nor ask — defer to CLI default
+    return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Stop `copilot-guard.py` from inadvertently suppressing the CLI's built-in approval prompts for `edit`/`create` tools.

## Problem

CLI v1.0.18 (2026-04-04) introduced a behavior change: a `preToolUse` hook returning `permissionDecision: "allow"` now **suppresses** the built-in approval prompt. Previously, the hook's `allow` was ignored and the CLI showed its own prompt independently.

`copilot-guard.py` returns `{"permissionDecision": "allow"}` by default when no checker matches. Since `edit`/`create` tools don't match any checker, their approval prompts were silently suppressed after the CLI upgrade.

## Fix

Replace `allow()` calls with bare `return` statements so the hook produces **no output** when it has no opinion. This defers the decision to the CLI's built-in approval flow:

- `if not results: allow()` → `if not results: return`
- Final fallback `allow()` → `return`
- Docstring updated to reflect the new priority model: `deny > ask > (no output)`

## Testing

All 111 existing tests pass (`uv run -m unittest tests.test_copilot_guard -v`).
