### PR TITLE
fix: remove allow() from all hook scripts to restore CLI approval prompts

### DIFF
--- a/.github/workflows/test-copilot-hooks.yml
+++ b/.github/workflows/test-copilot-hooks.yml
@@ -76,11 +76,11 @@ jobs:
             | uv run home/private_dot_copilot/hooks/scripts/executable_uv-enforcer.py)
           echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
 
-      - name: Smoke — uv-enforcer allows uv run
+      - name: Smoke — uv-enforcer passes through uv run (no output)
         run: |
           RESULT=$(echo '{"toolName":"bash","toolArgs":{"command":"uv run python script.py"}}' \
             | uv run home/private_dot_copilot/hooks/scripts/executable_uv-enforcer.py)
-          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='allow', f'Expected allow, got {d}'"
+          [ -z "$RESULT" ] || { echo "Expected empty output, got: $RESULT"; exit 1; }
 
       # ── Smoke tests — node-global-enforcer ────────────────────────────
       - name: Smoke — node-global-enforcer denies npm install -g
@@ -89,8 +89,8 @@ jobs:
             | uv run home/private_dot_copilot/hooks/scripts/executable_node-global-enforcer.py)
           echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='deny', f'Expected deny, got {d}'"
 
-      - name: Smoke — node-global-enforcer allows local npm install
+      - name: Smoke — node-global-enforcer passes through local npm install (no output)
         run: |
           RESULT=$(echo '{"toolName":"bash","toolArgs":{"command":"npm install typescript"}}' \
             | uv run home/private_dot_copilot/hooks/scripts/executable_node-global-enforcer.py)
-          echo "$RESULT" | python3 -c "import sys, json; d=json.load(sys.stdin); assert d['permissionDecision']=='allow', f'Expected allow, got {d}'"
+          [ -z "$RESULT" ] || { echo "Expected empty output, got: $RESULT"; exit 1; }

--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -45,11 +45,6 @@ def ask(reason: str) -> None:
     sys.exit(0)
 
 
-def allow() -> None:
-    print(json.dumps({"permissionDecision": "allow"}))
-    sys.exit(0)
-
-
 # ---------------------------------------------------------------------------
 # Input handling (absorb Windows encoding differences)
 # ---------------------------------------------------------------------------

--- a/home/private_dot_copilot/hooks/scripts/executable_node-global-enforcer.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_node-global-enforcer.py
@@ -28,11 +28,6 @@ def deny(reason: str) -> None:
     sys.exit(0)
 
 
-def allow() -> None:
-    print(json.dumps({"permissionDecision": "allow"}))
-    sys.exit(0)
-
-
 # ---------------------------------------------------------------------------
 # Input handling (absorb Windows encoding differences)
 # ---------------------------------------------------------------------------
@@ -222,19 +217,19 @@ def main() -> None:
 
     # bash / powershell commands only
     if tool_name not in ("bash", "powershell"):
-        allow()
+        return  # Not our concern — defer to CLI default
 
     tool_args = parse_tool_args(input_data.get("toolArgs", {}))
 
     command: str = tool_args.get("command", "")
     if not command:
-        allow()
+        return  # Nothing to check — defer to CLI default
 
     reason = check_command(command)
     if reason:
         deny(reason)
 
-    allow()
+    return  # Command is fine — defer to CLI default
 
 
 if __name__ == "__main__":

--- a/home/private_dot_copilot/hooks/scripts/executable_uv-enforcer.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_uv-enforcer.py
@@ -25,11 +25,6 @@ def deny(reason: str) -> None:
     sys.exit(0)
 
 
-def allow() -> None:
-    print(json.dumps({"permissionDecision": "allow"}))
-    sys.exit(0)
-
-
 # ---------------------------------------------------------------------------
 # Input handling (absorb Windows encoding differences)
 # ---------------------------------------------------------------------------
@@ -163,19 +158,19 @@ def main() -> None:
 
     # Only bash / powershell commands
     if tool_name not in ("bash", "powershell"):
-        allow()
+        return  # Not our concern — defer to CLI default
 
     tool_args = parse_tool_args(input_data.get("toolArgs", {}))
 
     command: str = tool_args.get("command", "")
     if not command:
-        allow()
+        return  # Nothing to check — defer to CLI default
 
     reason = check_command(command)
     if reason:
         deny(reason)
 
-    allow()
+    return  # Command is fine — defer to CLI default
 
 
 if __name__ == "__main__":

--- a/tests/test_node_global_enforcer.py
+++ b/tests/test_node_global_enforcer.py
@@ -299,18 +299,30 @@ class TestMainIntegration(unittest.TestCase):
         self.assertEqual(out["permissionDecision"], "deny")
 
     def test_allow_local_install(self) -> None:
-        out = self._run_hook({
-            "toolName": "bash",
-            "toolArgs": {"command": "npm install typescript"},
-        })
-        self.assertEqual(out["permissionDecision"], "allow")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=json.dumps({
+                "toolName": "bash",
+                "toolArgs": {"command": "npm install typescript"},
+            }),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
 
     def test_allow_non_bash_tool(self) -> None:
-        out = self._run_hook({
-            "toolName": "edit",
-            "toolArgs": {"path": "/tmp/foo.txt"},
-        })
-        self.assertEqual(out["permissionDecision"], "allow")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=json.dumps({
+                "toolName": "edit",
+                "toolArgs": {"path": "/tmp/foo.txt"},
+            }),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
 
     def test_invalid_json_denies(self) -> None:
         result = subprocess.run(

--- a/tests/test_uv_enforcer.py
+++ b/tests/test_uv_enforcer.py
@@ -197,18 +197,30 @@ class TestMainIntegration(unittest.TestCase):
         self.assertEqual(out["permissionDecision"], "deny")
 
     def test_allow_uv_run(self) -> None:
-        out = self._run_hook({
-            "toolName": "bash",
-            "toolArgs": {"command": "uv run python script.py"},
-        })
-        self.assertEqual(out["permissionDecision"], "allow")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=json.dumps({
+                "toolName": "bash",
+                "toolArgs": {"command": "uv run python script.py"},
+            }),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
 
     def test_allow_non_bash_tool(self) -> None:
-        out = self._run_hook({
-            "toolName": "edit",
-            "toolArgs": {"path": "/tmp/foo.txt"},
-        })
-        self.assertEqual(out["permissionDecision"], "allow")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=json.dumps({
+                "toolName": "edit",
+                "toolArgs": {"path": "/tmp/foo.txt"},
+            }),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
 
     def test_invalid_json_denies(self) -> None:
         result = subprocess.run(


### PR DESCRIPTION
## Summary

Remove `allow()` from `uv-enforcer.py` and `node-global-enforcer.py`, and clean up the now-unused `allow()` function from all three hook scripts (including `copilot-guard.py`).

## Problem

The previous fix ([#51](https://github.com/torumakabe/dotfiles/pull/51)) addressed `copilot-guard.py` only, but `hooks.json` registers three `preToolUse` hooks. Since CLI v1.0.18, **any single hook** returning `permissionDecision: "allow"` suppresses the built-in approval prompt.

For an `edit` tool call:
- `copilot-guard.py` → fixed in #51, no output ✅
- `uv-enforcer.py` → `allow()` (not bash/powershell) ❌
- `node-global-enforcer.py` → `allow()` (not bash/powershell) ❌

The approval prompt was still being suppressed by the other two hooks.

## Changes

| File | Change |
|------|--------|
| `executable_uv-enforcer.py` | `allow()` → `return` (3 sites), remove `allow()` definition |
| `executable_node-global-enforcer.py` | `allow()` → `return` (3 sites), remove `allow()` definition |
| `executable_copilot-guard.py` | Remove unused `allow()` definition (calls already removed in #51) |
| `test_uv_enforcer.py` | Update 2 tests to assert empty stdout instead of `allow` JSON |
| `test_node_global_enforcer.py` | Update 2 tests to assert empty stdout instead of `allow` JSON |
| `test-copilot-hooks.yml` | Update 2 CI smoke tests to assert empty output instead of `allow` JSON |

## Testing

All 217 unit tests pass. CI smoke tests pass.
