### PR TITLE
chore: remove copilot-cli from mise, use official install script on Linux

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,7 @@ mise 設定を変更する際は、以下のツールの対応状況を確認し
 - **cargo-make**: linux/arm64 未提供（[sagiegurari/cargo-make#541](https://github.com/sagiegurari/cargo-make/issues/541)）
 - **edit**: macOS 未提供（[releases](https://github.com/microsoft/edit/releases) を確認）
 - **azure-dev**: mise `github:` バックエンドがバイナリ名を正規化しないため、全 OS で mise 外で管理。macOS は brew、Windows は winget、Linux は公式インストーラー (`install-azd.sh`)。更新は `azd update` で行う
+- **copilot-cli**: mise の `github:` バックエンドでは更新が遅れ、自己更新後のバージョン誤認が発生するため、全 OS で mise 外で管理。macOS は brew、Windows は winget、Linux は公式インストールスクリプト (`gh.io/copilot-install`)。更新は `copilot update` で行う
 
 ## ワークアラウンド（定期チェック対象）
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,13 +6,13 @@
 
 | 環境 | 管理ツール | 主な対象 |
 |------|-----------|----------|
-| Linux / WSL | `apt` + `mise` | OS パッケージ、Azure CLI、開発ツール、`copilot-cli` |
+| Linux / WSL | `apt` + `mise` | OS パッケージ、Azure CLI、開発ツール |
 | macOS | `brew` + `mise` | OS パッケージ、GUI アプリ、Azure CLI、開発ツール |
 | Codespaces / Dev Container | ベースイメージ / Feature + `mise` | コンテナ基盤側ツール、開発ツール |
 | Windows | `winget` (DSC) + `mise` | GUI/CLI アプリ、Azure CLI、開発ツール |
 | 全環境共通 | `uv` | Python スクリプト実行 |
 
-`copilot-cli` は例外で、Linux 系は `mise`、macOS は `brew`、Windows は `winget` で管理する。
+`copilot-cli` は全 OS で mise 外で管理する。macOS は `brew`、Windows は `winget`、Linux は公式インストールスクリプト (`gh.io/copilot-install`) を使い、更新は `copilot update` で行う。
 
 ## 定期チェック対象の制約
 
@@ -21,6 +21,7 @@
 - **cargo-make**: linux/arm64 向け配布がない
 - **edit**: macOS 向け配布がない
 - **azure-dev**: mise `github:` バックエンドがバイナリ名を正規化しないため、全 OS で mise 外で管理。macOS は `brew`、Windows は `winget`、Linux は公式インストーラー (`install-azd.sh`) を使い、更新は `azd update` で行う
+- **copilot-cli**: mise の `github:` バックエンドでは更新が遅れ、自己更新後のバージョン誤認が発生するため、全 OS で mise 外で管理。macOS は `brew`、Windows は `winget`、Linux は公式インストールスクリプト (`gh.io/copilot-install`) を使い、更新は `copilot update` で行う
 
 解消されていれば、条件分岐や導入元のワークアラウンドを外せる。
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -26,12 +26,6 @@ shellcheck = "latest"
 gitleaks = "latest"
 jq = "latest"
 rust = "latest"
-{{ if eq .chezmoi.os "linux" -}}
-# Copilot Desktop などの GUI アプリから検出できるよう、macOS は brew、
-# Windows は winget で管理する。Codespaces / Dev Container を含む Linux 系は
-# 既存どおり mise 管理を維持する。
-"github:github/copilot-cli" = "latest"
-{{ end -}}
 {{ if ne .chezmoi.os "darwin" -}}
 # macOS 向けプリビルドバイナリが未提供のためスキップ
 edit = "latest"

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -28,6 +28,13 @@ sudo apt-get install -y -qq \
   xdg-utils \
   zsh
 
+# Copilot CLI — mise の github: バックエンドでは更新が遅れるため、
+# 公式インストールスクリプトで導入し、更新は copilot update で行う
+if ! command -v copilot >/dev/null 2>&1; then
+  echo "Installing GitHub Copilot CLI via official script..."
+  curl -fsSL https://gh.io/copilot-install | bash
+fi
+
 {{ if not .codespaces -}}
 # GitHub CLI — mise install 前にトークン取得手段を確保する
 # Codespaces はベースイメージに gh 同梱 + GITHUB_TOKEN 自動設定のため対象外


### PR DESCRIPTION
## Summary

Linux/WSL での `copilot-cli` の管理を mise から公式インストールスクリプトに変更する。

## Background

mise の `github:` バックエンドは GitHub Releases の公開タイミングに依存するため、copilot-cli の更新が遅れることがある。その結果、古いバイナリで起動した後に `copilot update` で新しいバイナリに自己更新される流れとなり、起動時のバージョンと実際の動作バージョンが乖離してバージョン誤認が発生するケースがあった。

macOS (brew) / Windows (winget) は既に mise 外で管理しており、Linux/WSL も同様に公式インストールスクリプトで初回導入し、以降は `copilot update` による自己更新に任せる運用に統一する。

## Changes

| ファイル | 変更内容 |
|---|---|
| `home/dot_config/mise/config.toml.tmpl` | `copilot-cli` エントリを削除 |
| `home/run_once_before_10-install-packages.sh.tmpl` | Linux 全環境で公式スクリプト (`gh.io/copilot-install`) によるインストールを追加 |
| `docs/operations.md` | 管理境界テーブルと定期チェック対象の制約を更新 |
| `.github/copilot-instructions.md` | プラットフォーム制約に `copilot-cli` を追加 |
