### PR TITLE
refactor: rename copilot-safe to copilot-cruise

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ chezmoi update
 
 - [`docs/operations.md`](docs/operations.md): `mise` の更新、lockfile 再生成、pre-commit フック管理、`run_once_*` の再実行
 - [`docs/architecture.md`](docs/architecture.md): ディレクトリ構造、設計判断、プラットフォーム分岐、Copilot Guard の構成
-- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象、フック、`copilot-safe`、監査ログ
+- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象、フック、`copilot-cruise`、監査ログ
 - [`docs/troubleshooting.md`](docs/troubleshooting.md): よくある失敗と復旧手順

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ reference/windows/              ← 参照専用ファイル
 - **コミット署名** は 1Password SSH エージェントを基本にし、コンテナ系環境では自動無効化
 - **Copilot Guard / uv Enforcer** で危険な操作を抑止
 - **postToolUse 監査ログ** で事後確認を可能にする
-- **`copilot-safe`** で Autopilot の既定値を安全寄りに固定する
+- **`copilot-cruise`** で Autopilot の既定値を安全寄りに固定する
 - **gitleaks 付き pre-commit** で共通の secret scan を配布する
 
 ## Copilot Guard の設計

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -89,9 +89,9 @@ echo '{"toolName":"bash","toolArgs":{"command":"python script.py"}}' | uv run ~/
 uv run -m unittest tests.test_copilot_guard -v
 ```
 
-## `copilot-safe`
+## `copilot-cruise`
 
-`.zshrc` / `PowerShell_profile.ps1` の `copilot-safe` は、Autopilot での事故を減らすための起動ラッパーである。主に次を固定する。
+`.zshrc` / `PowerShell_profile.ps1` の `copilot-cruise` は、Autopilot での事故を減らすための起動ラッパーである。主に次を固定する。
 
 - `--deny-tool` による外部送信系コマンドの制限
 - `--secret-env-vars` による機微な環境変数の隠蔽

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -128,7 +128,7 @@ Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 # Supported --deny-tool kinds: shell(cmd), write, url(domain), <MCP>(tool)
 # NOTE: shell() performs exact command-name matching. On Windows, .exe suffix and
 #       PowerShell aliases are distinct names and must be listed separately.
-function Invoke-CopilotSafe {
+function Invoke-CopilotCruise {
     copilot --autopilot `
       --allow-all `
       --deny-tool 'shell(curl)' `
@@ -173,7 +173,7 @@ function Invoke-CopilotSafe {
       --max-autopilot-continues 20 `
       @args
 }
-Set-Alias -Name copilot-safe -Value Invoke-CopilotSafe
+Set-Alias -Name copilot-cruise -Value Invoke-CopilotCruise
 
 # === Completers and tool setup ===
 

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -134,7 +134,7 @@ alias ll='ls -ahl'
 # Supported --deny-tool kinds: shell(cmd), write, url(domain), <MCP>(tool)
 # NOTE: shell() performs exact command-name matching — aliases and .exe suffixes
 #       are distinct names and must be listed separately where applicable.
-alias copilot-safe='copilot --autopilot \
+alias copilot-cruise='copilot --autopilot \
   --allow-all \
   --deny-tool "shell(curl)" \
   --deny-tool "shell(wget)" \


### PR DESCRIPTION
## Summary

Rename the Copilot CLI wrapper alias/function from `copilot-safe` to `copilot-cruise`.

## Motivation

`copilot-safe` は `--allow-all` + `--deny-tool` で「全許可しつつ危険なものだけブロック」する起動ラッパーだが、名前から allow-all のニュアンスが欠落していた。

`copilot-cruise` はクルーズコントロール（自動巡航だが介入・ガードレールあり）のメタファーで、copilot（操縦）の世界観とも合う。

## Changes

- **`home/dot_zshrc.tmpl`**: alias `copilot-safe` → `copilot-cruise`
- **`home/PowerShell_profile.ps1.tmpl`**: function `Invoke-CopilotSafe` → `Invoke-CopilotCruise`, alias 更新
- **`docs/copilot-cli.md`**: 見出し・説明文の参照を更新
- **`docs/architecture.md`**: 説明文の参照を更新
- **`README.md`**: リンク説明文の参照を更新
