### PR TITLE
feat: add mise shims to PATH for non-interactive shells

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ home/                           ← chezmoi source (.chezmoiroot で指定)
 ├── .chezmoiignore              ← 条件付き除外
 ├── .chezmoiremove              ← 不要ファイルの削除
 ├── dot_gitconfig*.tmpl         ← Git 設定
-├── dot_zshrc.tmpl              ← zsh 設定
+├── dot_zshrc.tmpl              ← zsh 設定（対話シェル）
+├── dot_zprofile.tmpl           ← zsh 設定（login / 非対話向け PATH）
 ├── dot_config/
 │   ├── git/hooks/pre-commit    ← gitleaks + ローカルフック委譲
 │   └── mise/
@@ -121,6 +122,31 @@ WSL は Linux 側の設定を読みつつ、内部で `.isWSL` を使って 1Pas
 
 Dev Container / Codespaces では 1Password SSH エージェントを前提にできないため、`commit.gpgsign = false` に切り替える。
 
+## mise shims による非対話シェル対応
+
+非対話シェル（Copilot CLI エージェント、IDE、スクリプト）では `mise activate` を仕込むフック元（`.zshrc` / `$PROFILE`）が読まれないため、mise 管理ツールが見えない問題が起きる。これを解消するため、mise 公式推奨の shims ディレクトリを常時 PATH に通す。
+
+| OS | 仕込み先 | 仕込み内容 |
+|----|----------|-----------|
+| macOS / Linux / WSL | `~/.zprofile` | `eval "$(mise activate zsh --shims)"` |
+| Windows | ユーザー環境変数 `Path` | `%LOCALAPPDATA%\mise\shims` を先頭追記（`run_once_after_05` が実施） |
+
+zsh で `.zshrc` ではなく `.zprofile` を使うのは、`.zshrc` が **non-interactive zsh では読まれない** ため。`.zprofile` は login 時に 1 回実行され、設定した PATH は子プロセスに環境変数継承で伝播する。
+
+`mise activate` と shims は **共存可能**。`mise activate` は shims を PATH から除去してから自前挿入を行うため、対話シェルでは従来どおり hooks や環境変数注入が有効。
+
+### shims 方式の制限
+
+`mise activate` のみで有効で shims では動かない機能:
+
+1. `mise.toml` の `[env]` セクションによる環境変数自動注入
+2. `hooks`（ディレクトリ移動時フック）
+3. `_.file` / `_.source`（env ファイル読込）
+
+このリポジトリの `~/.config/mise/config.toml` は `[tools]` と `[settings]` のみ使用しており、上記機能は未使用のため実害なし。将来 `[env]` 等を使う場合は、対話シェルでは `mise activate` が優先されるため問題ない。非対話シェルで環境変数が必要なら `mise exec -- <cmd>` を使う。
+
+参考: <https://mise.jdx.dev/dev-tools/shims.html>
+
 ## `run_once_*` スクリプトの実行順と依存関係
 
 chezmoi は `run_once_before_*` → 通常ファイル適用 → `run_once_after_*` の順に処理し、同じフェーズ内では数字順で実行する。
@@ -129,8 +155,9 @@ chezmoi は `run_once_before_*` → 通常ファイル適用 → `run_once_after
 |------|-----------|------|----------|
 | 1 | `run_once_before_10-install-packages.sh` | OS パッケージ導入 | 後続で `git` / `zsh` を使える |
 | 2 | `run_once_before_20-install-mise.sh` | `mise` 自体を導入 | 後続で `mise` が存在する |
-| 3 | `run_once_after_10-setup-shell.sh` | shell 設定 | `git` / `zsh` は導入済み |
-| 4 | `run_once_after_20-mise-install.sh` | `config.toml` / `mise.lock` を使ってツール導入 | dotfiles 配置後に動く |
-| 5 | `run_once_after_30-install-tools.sh` | 追加ツール導入 | `mise install` 済み |
+| 3 | `run_once_after_05-setup-mise-shims-path.ps1` | Windows: mise shims をユーザー PATH に追加 | `mise` 導入済み（Windows は DSC 経由） |
+| 4 | `run_once_after_10-setup-shell.sh` | shell 設定 | `git` / `zsh` は導入済み |
+| 5 | `run_once_after_20-mise-install.sh` | `config.toml` / `mise.lock` を使ってツール導入 | dotfiles 配置後に動く |
+| 6 | `run_once_after_30-install-tools.sh` | 追加ツール導入 | `mise install` 済み |
 
 変更時は、`mise` 設定が配置される前に `mise install` しないことと、Codespaces / Dev Container の分岐を壊さないことを優先して確認する。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,3 +41,37 @@ Codespaces 以外ではパッケージ導入に sudo が必要である。パス
 ## Dev Container で mise ツールが入っていない
 
 コンテナ作成時は `mise install` を自動実行しない。README の Dev Container セクション、または [`docs/operations.md`](operations.md#github-api-と-github_token) の手順で起動後に実行する。
+
+## 非対話シェルで mise 管理ツールが見つからない
+
+症状: Copilot CLI エージェント、IDE のタスク、`bash script.sh` などから `uv`, `node`, `kubectl` などが `command not found` / `CommandNotFoundException`。
+
+原因: `mise activate` は `.zshrc` / `$PROFILE` 経由でのみ PATH を注入するが、これらは非対話シェルでは読まれない。
+
+### 確認
+
+```bash
+# Unix
+command -v uv     # shims 配下なら OK
+echo "$PATH" | tr ':' '\n' | grep mise/shims
+```
+
+```powershell
+# Windows
+(Get-Command uv).Source
+[Environment]::GetEnvironmentVariable('Path', 'User') -split ';' | Select-String 'mise\\shims'
+```
+
+### 復旧
+
+設計は [`docs/architecture.md`](architecture.md#mise-shims-による非対話シェル対応) を参照。新規環境で反映されていない場合:
+
+- **Unix**: `chezmoi apply` で `~/.zprofile` が配置されるか確認。新規 login シェル（新しい Terminal タブなど）を開くと有効化される
+- **Windows**: `run_once_after_05-setup-mise-shims-path.ps1` を再実行する
+
+```bash
+chezmoi state delete-bucket --bucket=scriptState
+chezmoi apply
+```
+
+新規シェルを開き直してから再確認する。

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -12,4 +12,9 @@
 {{ end -}}
 {{ if ne .chezmoi.os "windows" -}}
 PowerShell_profile.ps1
+run_once_after_05-setup-mise-shims-path.ps1
 {{ end -}}
+{{ if eq .chezmoi.os "windows" -}}
+.zprofile
+{{ end -}}
+

--- a/home/dot_zprofile.tmpl
+++ b/home/dot_zprofile.tmpl
@@ -1,0 +1,4 @@
+{{ if ne .chezmoi.os "windows" -}}
+# 非対話シェル用に shims を PATH 追加（対話シェルの mise activate とは共存可）
+command -v mise >/dev/null && eval "$(mise activate zsh --shims)"
+{{ end -}}

--- a/home/run_once_after_05-setup-mise-shims-path.ps1.tmpl
+++ b/home/run_once_after_05-setup-mise-shims-path.ps1.tmpl
@@ -1,0 +1,22 @@
+{{ if eq .chezmoi.os "windows" -}}
+# 非対話シェル用に mise shims をユーザー PATH へ冪等追加（対話シェルの mise activate とは共存可）
+$ErrorActionPreference = 'Stop'
+
+$shimsDir = Join-Path $env:LOCALAPPDATA 'mise\shims'
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+
+$normalizedShims = $shimsDir.TrimEnd('\').ToLowerInvariant()
+$entries = if ($userPath) { $userPath -split ';' | Where-Object { $_ -ne '' } } else { @() }
+$alreadyPresent = $entries | Where-Object { $_.TrimEnd('\').ToLowerInvariant() -eq $normalizedShims }
+
+if (-not $alreadyPresent) {
+    Write-Host "Adding mise shims directory to user PATH: $shimsDir"
+    $newPath = if ($userPath) { "$shimsDir;$userPath" } else { $shimsDir }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    if (($env:Path -split ';') -notcontains $shimsDir) {
+        $env:Path = "$shimsDir;$env:Path"
+    }
+} else {
+    Write-Host "mise shims directory already in user PATH: $shimsDir"
+}
+{{ end -}}


### PR DESCRIPTION
## 背景

非対話シェル（Copilot CLI エージェント、IDE、スクリプト等）では `.zshrc` / `$PROFILE` が読み込まれないため、`mise activate` のフックが走らず、mise 管理ツール（`uv`, `node`, `kubectl` 等）が PATH から見えない問題があった。

## 方針

mise 公式推奨の **shims ディレクトリを常時 PATH に通す** 方式を採用する。`mise activate` は PATH から shims を除去してから自前挿入するため、対話シェルでは従来どおり `[env]` / `hooks` なども有効（共存可能）。

現行の `~/.config/mise/config.toml` は `[tools]` と `[settings]` のみで、shims 方式の制限に該当する機能（`[env]` / `hooks` / `_.file`）は未使用のため実害なし。

## 変更

| OS | 仕込み先 | 内容 |
|----|----------|------|
| macOS / Linux / WSL | `~/.zprofile`（新規） | `eval "$(mise activate zsh --shims)"` |
| Windows | ユーザー環境変数 `Path`（`run_once_after_05` スクリプトで設定） | `%LOCALAPPDATA%\mise\shims` を先頭に冪等追加 |

zsh は `.zshrc` ではなく `.zprofile` に仕込む。理由: `.zshrc` は non-interactive zsh では読まれないため今回の目的を達成できない。`.zprofile` は login 時 1 回実行され、設定した PATH は子プロセスへ env 継承で伝播する。

### ファイル

- 新規 `home/dot_zprofile.tmpl`
- 新規 `home/run_once_after_05-setup-mise-shims-path.ps1.tmpl`
- 更新 `home/.chezmoiignore`（OS で `.ps1` / `.zprofile` を振り分け）
- 更新 `docs/architecture.md`（shims 方針と `run_once_*` 表）
- 更新 `docs/troubleshooting.md`（復旧手順）

## 検証

- `chezmoi execute-template` で Windows / Linux 両分岐のレンダリング確認
- PowerShell `Parser::ParseFile` で ps1 の構文 OK
- WSL `bash -n` で zprofile の構文 OK
- gitleaks の pre-commit 通過

適用時は Unix は新規 Terminal を開き直し、Windows は `run_once` が自動実行される。