### PR TITLE
fix: consolidate PATH setup into POSIX ~/.profile for all shell contexts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,9 @@ home/                           ← chezmoi source (.chezmoiroot で指定)
 ├── .chezmoiremove              ← 不要ファイルの削除
 ├── dot_gitconfig*.tmpl         ← Git 設定
 ├── dot_zshrc.tmpl              ← zsh 設定（対話シェル）
-├── dot_zprofile.tmpl           ← zsh 設定（login / 非対話向け PATH）
+├── dot_zprofile.tmpl           ← zsh login 時に ~/.profile を source
+├── dot_bash_profile.tmpl       ← bash login 時に ~/.profile を source
+├── dot_profile.tmpl            ← POSIX 互換の共通 env（PATH, brew shellenv, mise shims）
 ├── dot_config/
 │   ├── git/hooks/pre-commit    ← gitleaks + ローカルフック委譲
 │   └── mise/
@@ -122,18 +124,36 @@ WSL は Linux 側の設定を読みつつ、内部で `.isWSL` を使って 1Pas
 
 Dev Container / Codespaces では 1Password SSH エージェントを前提にできないため、`commit.gpgsign = false` に切り替える。
 
-## mise shims による非対話シェル対応
+## PATH 管理（非対話シェル対応）
 
-非対話シェル（Copilot CLI エージェント、IDE、スクリプト）では `mise activate` を仕込むフック元（`.zshrc` / `$PROFILE`）が読まれないため、mise 管理ツールが見えない問題が起きる。これを解消するため、mise 公式推奨の shims ディレクトリを常時 PATH に通す。
+非対話シェル（Copilot CLI エージェント、IDE、スクリプト）では `.zshrc` / `$PROFILE` が読まれず、mise 管理ツールや brew 管理ツールが PATH から欠落する。これを解消するため、**POSIX 互換の `~/.profile` に共通 env を集約**し、各シェルから読み込む。
 
 | OS | 仕込み先 | 仕込み内容 |
 |----|----------|-----------|
-| macOS / Linux / WSL | `~/.zprofile` | `eval "$(mise activate zsh --shims)"` |
+| macOS / Linux / WSL | `~/.profile` | brew shellenv（macOS）、`GOPATH`、`~/.local/bin` / `~/go/bin` / `~/.cargo/bin`、mise shims |
+| macOS / Linux / WSL | `~/.zprofile` | `~/.profile` を source するだけ（zsh は `.profile` を直接読まないため） |
+| macOS / Linux / WSL | `~/.bash_profile` | `~/.profile` を source するだけ（`.bash_profile` が存在すると bash は `.profile` を読まないため） |
 | Windows | ユーザー環境変数 `Path` | `%LOCALAPPDATA%\mise\shims` を先頭追記（`run_once_after_05` が実施） |
 
-zsh で `.zshrc` ではなく `.zprofile` を使うのは、`.zshrc` が **non-interactive zsh では読まれない** ため。`.zprofile` は login 時に 1 回実行され、設定した PATH は子プロセスに環境変数継承で伝播する。
+### なぜ `~/.profile` か
 
-`mise activate` と shims は **共存可能**。`mise activate` は shims を PATH から除去してから自前挿入を行うため、対話シェルでは従来どおり hooks や環境変数注入が有効。
+- **sh / dash / bash(login)** は `~/.profile` を直接読む
+- **zsh(login)** は `.profile` を読まないため `~/.zprofile` から source する
+- **非対話 shell（`bash -c`, IDE agent の直接 exec）** は親プロセスから env 継承する。親が login shell 経由で起動される限り PATH は伝播する
+- **macOS GUI アプリ**（Dock / Finder / Spotlight から起動、launchd 直下）は shell を介さないため `~/.profile` が実行されない。プロセスは launchd の既定 PATH（`/etc/paths` + `/etc/paths.d/*`）だけを継承する。Ghostty など shell を spawn する GUI ターミナルは login shell を起動するので今回の修正で解決するが、Copilot Desktop のように shell を介さず子プロセスに外部ツールを exec するアプリは影響を受ける可能性がある。その場合のワークアラウンド:
+  - 当該アプリから呼ぶコマンドを絶対パスで指定する
+  - `~/Library/LaunchAgents/*.plist` に `launchctl setenv PATH` 相当を仕込む（環境全体に影響するため慎重に）
+  - 参考: [`launchd.plist(5)`](https://ss64.com/mac/launchd.plist.html) の `EnvironmentVariables` キー、[Apple Developer: Daemons and Services Programming Guide](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+
+  現状このリポジトリでは対応していない（Copilot Desktop は `dot_zshrc.tmpl` の `launchctl setenv COPILOT_CLI_PATH` で個別対応済みのため）。
+
+### brew shellenv を入れる理由
+
+Apple Silicon の Homebrew は `/opt/homebrew/bin` にあるが、launchd 既定 PATH や `/etc/paths` には含まれない。`brew shellenv` を `~/.profile` で実行することで、非対話シェルや GUI 起動子プロセスからも `copilot`・`azd`・`gh` 等の brew 管理ツールが解決できる。
+
+### mise shims と `mise activate` の共存
+
+`mise activate` と shims は共存可能。対話 zsh では `.zshrc` の `mise activate zsh`（フル版）が shims を PATH から除去して自前挿入するため、hooks や `[env]` による環境変数注入が有効。非対話シェルでは shims のみ PATH に乗り、バイナリ解決だけ成立する。
 
 ### shims 方式の制限
 
@@ -143,7 +163,7 @@ zsh で `.zshrc` ではなく `.zprofile` を使うのは、`.zshrc` が **non-i
 2. `hooks`（ディレクトリ移動時フック）
 3. `_.file` / `_.source`（env ファイル読込）
 
-このリポジトリの `~/.config/mise/config.toml` は `[tools]` と `[settings]` のみ使用しており、上記機能は未使用のため実害なし。将来 `[env]` 等を使う場合は、対話シェルでは `mise activate` が優先されるため問題ない。非対話シェルで環境変数が必要なら `mise exec -- <cmd>` を使う。
+このリポジトリの `~/.config/mise/config.toml` は `[tools]` と `[settings]` のみ使用しており、上記機能は未使用のため実害なし。非対話シェルで環境変数が必要な場合は `mise exec -- <cmd>` を使う。
 
 参考: <https://mise.jdx.dev/dev-tools/shims.html>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,18 +42,21 @@ Codespaces 以外ではパッケージ導入に sudo が必要である。パス
 
 コンテナ作成時は `mise install` を自動実行しない。README の Dev Container セクション、または [`docs/operations.md`](operations.md#github-api-と-github_token) の手順で起動後に実行する。
 
-## 非対話シェルで mise 管理ツールが見つからない
+## 非対話シェルで PATH が通らない
 
-症状: Copilot CLI エージェント、IDE のタスク、`bash script.sh` などから `uv`, `node`, `kubectl` などが `command not found` / `CommandNotFoundException`。
+症状: Copilot CLI エージェント、IDE のタスク、`bash script.sh` などから `copilot`, `uv`, `node`, `kubectl`, `azd` などが `command not found` / `CommandNotFoundException`。
 
-原因: `mise activate` は `.zshrc` / `$PROFILE` 経由でのみ PATH を注入するが、これらは非対話シェルでは読まれない。
+原因: `.zshrc` / `$PROFILE` は非対話シェルでは読まれない。macOS では加えて `/opt/homebrew/bin`（brew shellenv）が launchd 既定 PATH に含まれないため GUI 起動子プロセスでも brew 管理ツールが見えない。
 
 ### 確認
 
 ```bash
-# Unix
-command -v uv     # shims 配下なら OK
-echo "$PATH" | tr ':' '\n' | grep mise/shims
+# Unix（login shell を新規に開いた直後）
+echo "$PATH" | tr ':' '\n'
+# 期待: ~/.local/share/mise/shims, ~/.local/bin, ~/go/bin が含まれる
+# macOS なら /opt/homebrew/bin も含まれる
+command -v copilot   # macOS: /opt/homebrew/bin/copilot, Linux: ~/.local/bin/copilot
+command -v uv        # ~/.local/share/mise/shims/uv
 ```
 
 ```powershell
@@ -64,9 +67,9 @@ echo "$PATH" | tr ':' '\n' | grep mise/shims
 
 ### 復旧
 
-設計は [`docs/architecture.md`](architecture.md#mise-shims-による非対話シェル対応) を参照。新規環境で反映されていない場合:
+設計は [`docs/architecture.md`](architecture.md#path-管理非対話シェル対応) を参照。新規環境で反映されていない場合:
 
-- **Unix**: `chezmoi apply` で `~/.zprofile` が配置されるか確認。新規 login シェル（新しい Terminal タブなど）を開くと有効化される
+- **Unix**: `chezmoi apply` で `~/.profile` と `~/.zprofile` が配置されるか確認。新規 login シェル（新しい Terminal タブなど）を開くと有効化される
 - **Windows**: `run_once_after_05-setup-mise-shims-path.ps1` を再実行する
 
 ```bash

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -15,6 +15,8 @@ PowerShell_profile.ps1
 run_once_after_05-setup-mise-shims-path.ps1
 {{ end -}}
 {{ if eq .chezmoi.os "windows" -}}
+.profile
 .zprofile
+.bash_profile
 {{ end -}}
 

--- a/home/dot_bash_profile.tmpl
+++ b/home/dot_bash_profile.tmpl
@@ -1,0 +1,7 @@
+{{ if ne .chezmoi.os "windows" -}}
+# bash は ~/.bash_profile / ~/.bash_login のいずれかが存在すると ~/.profile を
+# 読まないため、共通 env (~/.profile) を明示的に source する。
+# 対話 bash は ~/.bashrc を別途読むが、このリポジトリでは管理していない
+# (既定の /etc/bash.bashrc 等に任せる)。必要なら後日 dot_bashrc.tmpl を追加する。
+[ -r "$HOME/.profile" ] && . "$HOME/.profile"
+{{ end -}}

--- a/home/dot_profile.tmpl
+++ b/home/dot_profile.tmpl
@@ -1,0 +1,72 @@
+{{ if ne .chezmoi.os "windows" -}}
+# POSIX-compatible shared environment for login shells and non-interactive
+# shells that inherit env from a login parent (bash -c, scripts, IDE agents).
+#
+# Read order per shell:
+#   sh / dash                -> ~/.profile directly
+#   bash(login)              -> ~/.bash_profile -> sources this file
+#                               (bash reads ~/.profile only when neither
+#                                ~/.bash_profile nor ~/.bash_login exists)
+#   zsh(login)               -> ~/.zprofile    -> sources this file
+#   bash(interactive)        -> ~/.bashrc       (parent env is already set)
+#   zsh(interactive)         -> ~/.zshrc        (parent env is already set)
+#
+# Keep this file POSIX-compliant and fast: it runs on every login.
+
+# Idempotency guard: avoid double-appending PATH on re-entry.
+# Wrap the body in a conditional instead of `return` at top level, which is
+# implementation-defined in POSIX sh when the script is sourced.
+if [ -z "${__DOTFILES_PROFILE_LOADED:-}" ]; then
+  # Idempotency guard: avoid double-appending PATH on re-entry.
+  # Wrap the body in a conditional instead of `return` at top level, which is
+  # implementation-defined in POSIX sh when the script is sourced.
+  # `export` so nested login shells (zsh -l inside bash -l, etc.) inherit the
+  # guard and skip re-prepending `mise activate ... --shims` (which is not
+  # itself idempotent; brew shellenv dedupes but mise does not).
+  export __DOTFILES_PROFILE_LOADED=1
+
+{{ if eq .chezmoi.os "darwin" -}}
+  # Homebrew: GUI/launchd-started processes inherit a minimal PATH from launchd
+  # that does not include /opt/homebrew/bin. brew shellenv fixes this and also
+  # exports HOMEBREW_PREFIX / HOMEBREW_CELLAR / HOMEBREW_REPOSITORY.
+  for __brew in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+    if [ -x "$__brew" ]; then
+      eval "$("$__brew" shellenv)"
+      break
+    fi
+  done
+  unset __brew
+{{ end -}}
+
+  # Prepend a directory to PATH only if it exists and is not already present.
+  # Missing directories are intentionally skipped silently: Go/cargo/Python
+  # user-bin dirs are created on first install of their respective toolchains,
+  # so a fresh machine legitimately lacks them. Any command not found at
+  # runtime will surface the actual problem with a clear error.
+  __add_path() {
+    case ":${PATH}:" in
+      *":$1:"*) ;;
+      *) [ -d "$1" ] && PATH="$1:${PATH}" ;;
+    esac
+  }
+
+  export GOPATH="${HOME}/go"
+  __add_path "${HOME}/go/bin"
+  __add_path "${HOME}/.cargo/bin"
+  __add_path "${HOME}/.local/bin"
+  export PATH
+  unset -f __add_path
+
+  # mise shims: ensure mise-managed tools (uv, node, kubectl, ...) are on PATH
+  # for non-interactive shells. `mise activate bash --shims` emits only
+  # `export PATH="..."` lines (POSIX-compatible; no arrays, no `[[`, no
+  # bash-specific syntax). Verified against mise 2026.4.16 with dash:
+  #   dash -n -c "$(mise activate bash --shims)"
+  # Interactive shells replace this with a full `mise activate` in ~/.zshrc,
+  # which strips shims and injects its own hooks.
+  if command -v mise >/dev/null 2>&1; then
+    eval "$(mise activate bash --shims)"
+  fi
+fi
+
+{{ end -}}

--- a/home/dot_zprofile.tmpl
+++ b/home/dot_zprofile.tmpl
@@ -1,4 +1,5 @@
 {{ if ne .chezmoi.os "windows" -}}
-# 非対話シェル用に shims を PATH 追加（対話シェルの mise activate とは共存可）
-command -v mise >/dev/null && eval "$(mise activate zsh --shims)"
+# zsh は ~/.profile を読まないため、login 時に明示的に source する。
+# PATH/shims など共通 env は ~/.profile に集約する（bash/sh との共有のため）。
+[ -r "$HOME/.profile" ] && . "$HOME/.profile"
 {{ end -}}

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -114,9 +114,9 @@ setopt autopushd
 
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
-export GOPATH=$HOME/go
 export EDITOR=vim
-export PATH=$HOME/.local/bin:$GOPATH/bin:$PATH
+# PATH / GOPATH / brew shellenv / mise shims は ~/.profile に集約し、
+# ~/.zprofile 経由で login 時に source される（非対話シェルは env 継承）。
 
 # Shell hooks that need to run in the current zsh process.
 # Prefer sourcing generated shell code over eval so command output is read as a script.


### PR DESCRIPTION
## 背景

PR #55 で非対話 zsh 向けに `~/.zprofile` に mise shims を追加したが、以下が残課題として残っていた:

- **対話 login zsh（Ghostty 等）でも `copilot` が見つからない**: macOS Apple Silicon の `/opt/homebrew/bin` が `/etc/paths` や launchd 既定 PATH に含まれず、`brew shellenv` をどこでも実行していなかった
- **bash 系の経路が未対応**: IDE エージェント経由の `bash -c` など、親プロセスが login shell でない場合に PATH が伝播しない

## 修正方針（ミニマル・定番パターン）

POSIX 互換の `~/.profile` に共通 env を集約し、各 shell から読み込む:

- `~/.profile` (NEW): macOS では `brew shellenv`、全 Unix で `GOPATH` / `~/.local/bin` / `~/go/bin` / `~/.cargo/bin` / mise shims を冪等に追加
- `~/.zprofile`: `~/.profile` を source するだけに簡素化
- `~/.bash_profile` (NEW): 同上（`.bash_profile` が存在すると bash は `.profile` を読まないため）
- `~/.zshrc`: 重複する `PATH`/`GOPATH` export を削除

## 変更ファイル

- `home/dot_profile.tmpl` (NEW)
- `home/dot_bash_profile.tmpl` (NEW)
- `home/dot_zprofile.tmpl`
- `home/dot_zshrc.tmpl`
- `home/.chezmoiignore` (Windows で新規ファイル除外)
- `docs/architecture.md`
- `docs/troubleshooting.md`

## 設計上のポイント

- **Idempotency**: `export __DOTFILES_PROFILE_LOADED=1` ガードで子プロセス（nested login shells）からの再読込時に mise shims が重複しないようにする（`mise activate --shims` は非冪等）
- **POSIX 互換**: mise 2026.4.16 の `mise activate bash --shims` 出力が `export PATH="..."` のみで配列や `[[` を含まないことを `dash -n` で確認
- **missing directory は意図的にスキップ**: Go/cargo/Python user-bin は初回インストールで作られるため

## 検証

| ケース | `copilot` | `uv` | `azd` | shim 重複 |
|---|---|---|---|---|
| `zsh -lc` | ✓ | ✓ | ✓ | 1 |
| `bash -lc` | ✓ | ✓ | ✓ | 1 |
| `dash -c`（`. ~/.profile`） | ✓ | ✓ | ✓ | 1 |
| `zsh -l → bash -l`（nested） | ✓ | ✓ | ✓ | 1 |
| `zsh -lc → bash -c`（IDE agent 典型） | ✓ | ✓ | ✓ | 1 |

## 対象外（意図的）

- **macOS GUI アプリ**（Dock/Finder/Spotlight 起動、launchd 直下）は shell を介さないため本修正の対象外。Ghostty など shell を spawn する GUI ターミナルは login shell 経由で正しく PATH を取得する。`docs/architecture.md` にワークアラウンドを記載。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>