### PR TITLE
fix(zshenv): 非login zsh 向けに PATH ブートストラップを追加

### DIFF
--- a/home/dot_zshenv.tmpl
+++ b/home/dot_zshenv.tmpl
@@ -1,0 +1,23 @@
+# zsh は全起動 (login/非login/interactive/非interactive) で .zshenv を読む。
+# VS Code の非login 統合ターミナル等、login shell を経由しないケースで
+# mise/user-local ツールを解決するための最小 PATH ブートストラップ。
+#
+# 共通 env (GOPATH, 追加の PATH, brew shellenv 等) は ~/.profile に集約し、
+# login shell (~/.zprofile) 経由でのみ適用する設計は維持する。
+# ここでは「mise や ~/.local/bin 配下のバイナリに到達するための最小限」だけ
+# 足す。.profile 丸ごと source は将来的な副作用 (zsh -c 全般への波及) を
+# 避けるため行わない。
+
+__zshenv_add_path() {
+  case ":${PATH}:" in
+    *":$1:"*) ;;
+    *) [ -d "$1" ] && PATH="$1:${PATH}" ;;
+  esac
+}
+
+__zshenv_add_path "${HOME}/.local/share/mise/shims"
+__zshenv_add_path "${HOME}/.local/bin"
+__zshenv_add_path "${HOME}/.cargo/bin"
+
+export PATH
+unset -f __zshenv_add_path


### PR DESCRIPTION
## 背景

VS Code の WSL 統合ターミナル（`/usr/bin/zsh`、args `[]` = 非login shell）で `gh` / `copilot` など mise 管理ツールが PATH にない現象が発生していた。Copilot Chat 拡張も「Cannot find GitHub Copilot CLI」を表示していた。

## 原因

- `mise` 本体は `~/.local/bin/mise`
- `~/.local/bin` を PATH に追加しているのは `~/.profile` のみ
- `~/.profile` は `~/.zprofile` （login shell）経由でしか source されない
- 結果、非login zsh では `.zshrc` の `command -v mise` が失敗し `mise activate zsh` がスキップ → mise 管理ツールがすべて PATH 外になっていた

## 修正内容

`home/dot_zshenv.tmpl` を新規追加し、非login zsh でも最低限の PATH を張るための最小ブートストラップを実装。

- `~/.local/share/mise/shims`
- `~/.local/bin`
- `~/.cargo/bin`

を idempotent に PATH 先頭へ追加する。

## 設計判断

rubber-duck レビューの指摘を受け、以下の方針を採用：

- **`.profile` 丸ごと source はしない**：`.zshenv` は全 zsh 起動（`zsh -c '...'` 含む）で走るため、将来 `.profile` に重い処理・出力系が加わると全 zsh 実行が巻き込まれる。最小ブートストラップに留めることで副作用範囲を限定
- **`mise activate --shims` の eval も使わない**：shims ディレクトリを直接 PATH に追加する方が fork コストゼロで堅い
- **`.profile` の設計意図（login shell 用共通 env）は維持**：`GOPATH` 等の追加 env は従来通り `.profile` に残す

## 検証

- クリーン env の非login zsh で `mise` / `gh` / `copilot` が解決されることを確認
- VS Code 統合ターミナルで `gh` / `copilot` の解決、Copilot Chat 拡張の動作を実機確認済み
- login zsh（Windows Terminal WSL）では `.profile` 側の `__DOTFILES_PROFILE_LOADED` ガードにより二重ロードなし、実質挙動不変
- `uv run -m unittest tests.test_copilot_guard -v` → 111 tests OK