### PR TITLE
feat: setup Copilot CLI LSP servers (Python/ty, TypeScript)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,6 +14,8 @@
 
 `copilot-cli` は全 OS で mise 外で管理する。macOS は `brew`、Windows は `winget`、Linux は公式インストールスクリプト (`gh.io/copilot-install`) を使い、更新は `copilot update` で行う。
 
+Copilot CLI の LSP サーバーは `~/.copilot/lsp-config.json` (chezmoi 管理) で設定する。Python 向けの `ty` (Astral) は mise に専用バックエンドがないため、`uv tool install ty` で導入する (run_once スクリプトで自動化済み)。TypeScript など npm パッケージの LSP サーバーは mise の `npm:` バックエンドで管理する。
+
 ## 定期チェック対象の制約
 
 `mise` 設定や導入元を見直すときは、次の制約がまだ残っているか確認する。

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -26,6 +26,8 @@ shellcheck = "latest"
 gitleaks = "latest"
 jq = "latest"
 rust = "latest"
+"npm:typescript" = "latest"
+"npm:typescript-language-server" = "latest"
 {{ if ne .chezmoi.os "darwin" -}}
 # macOS 向けプリビルドバイナリが未提供のためスキップ
 edit = "latest"

--- a/home/dot_config/mise/mise.lock
+++ b/home/dot_config/mise/mise.lock
@@ -489,6 +489,14 @@ url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-win-arm64.zip"
 checksum = "sha256:cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
 url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-win-x64.zip"
 
+[[tools."npm:typescript"]]
+version = "6.0.3"
+backend = "npm:typescript"
+
+[[tools."npm:typescript-language-server"]]
+version = "5.1.3"
+backend = "npm:typescript-language-server"
+
 [[tools.ripgrep]]
 version = "15.1.0"
 backend = "aqua:BurntSushi/ripgrep"

--- a/home/private_dot_copilot/lsp-config.json
+++ b/home/private_dot_copilot/lsp-config.json
@@ -1,0 +1,22 @@
+{
+  "lspServers": {
+    "python": {
+      "command": "ty",
+      "args": ["server"],
+      "fileExtensions": {
+        ".py": "python",
+        ".pyi": "python"
+      }
+    },
+    "typescript": {
+      "command": "typescript-language-server",
+      "args": ["--stdio"],
+      "fileExtensions": {
+        ".ts": "typescript",
+        ".tsx": "typescriptreact",
+        ".js": "javascript",
+        ".jsx": "javascriptreact"
+      }
+    }
+  }
+}

--- a/home/private_dot_copilot/skills/lsp-setup/SKILL.md
+++ b/home/private_dot_copilot/skills/lsp-setup/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: lsp-setup
+description: 'Enable code intelligence (go-to-definition, find-references, hover, type info) for any programming language by installing and configuring an LSP server for Copilot CLI. Detects the OS, installs the right server, and generates the JSON configuration (user-level or repo-level). Use when you need deeper code understanding and no LSP server is configured, or when the user asks to set up, install, or configure an LSP server.'
+---
+
+# LSP Setup for GitHub Copilot CLI
+
+**UTILITY SKILL** — installs and configures Language Server Protocol servers for Copilot CLI.
+USE FOR: "setup LSP", "install language server", "configure LSP for Java", "add TypeScript LSP", "enable code intelligence", "I need go-to-definition", "find references not working", "need better code understanding"
+DO NOT USE FOR: general coding tasks, IDE/editor LSP configuration, non-Copilot-CLI setups
+
+## Workflow
+
+1. **Ask the language** — use `ask_user` to ask which programming language(s) the user wants LSP support for
+2. **Detect the OS** — run `uname -s` (or check for Windows via `$env:OS` / `%OS%`) to determine macOS, Linux, or Windows
+3. **Look up the LSP server** — read `references/lsp-servers.md` for known servers, install commands, and config snippets
+4. **Ask scope** — use `ask_user` to ask whether the config should be user-level (`~/.copilot/lsp-config.json`) or repo-level (`lsp.json` at the repo root or `.github/lsp.json`)
+5. **Install the server** — run the appropriate install command for the detected OS
+6. **Write the config** — merge the new server entry into the chosen config file (`~/.copilot/lsp-config.json` for user-level; `lsp.json` or `.github/lsp.json` for repo-level). If a repo-level config already exists, keep using that location; otherwise ask the user which repo-level location they prefer. Create the file if missing and preserve existing entries.
+7. **Verify** — confirm the LSP binary is on `$PATH` and the config file is valid JSON
+
+## Configuration Format
+
+Copilot CLI reads LSP configuration from user-level or repo-level locations, and repo-level config takes precedence over user-level config:
+
+- **User-level**: `~/.copilot/lsp-config.json`
+- **Repo-level**: `lsp.json` (repo root) or `.github/lsp.json`
+
+The JSON structure:
+
+```json
+{
+  "lspServers": {
+    "<server-key>": {
+      "command": "<binary>",
+      "args": ["--stdio"],
+      "fileExtensions": {
+        ".<ext>": "<languageId>",
+        ".<ext2>": "<languageId>"
+      }
+    }
+  }
+}
+```
+
+### Key rules
+
+- `command` is the binary name (must be on `$PATH`) or an absolute path.
+- `args` almost always includes `"--stdio"` to use standard I/O transport.
+- `fileExtensions` maps each file extension (with leading dot) to a [Language ID](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers).
+- Multiple servers can coexist in `lspServers`.
+- When merging into an existing file, **never overwrite** other server entries — only add or update the target language key.
+
+## Behavior
+
+- Always use `ask_user` with `choices` when asking the user to pick a language or scope.
+- If the language is not listed in `references/lsp-servers.md`, search the web for "<language> LSP server" and guide the user through manual configuration.
+- If a package manager is not available (e.g. no Homebrew on macOS), suggest alternative install methods from the reference file.
+- After installation, run `which <binary>` (or `where.exe` on Windows) to confirm the binary is accessible.
+- Show the user the final config JSON before writing it.
+- If the config file already exists, read it first and merge — do not clobber.
+
+## Verification
+
+After setup, tell the user:
+
+1. Type `/exit` to quit Copilot CLI — this is **required** so the new LSP configuration is loaded on next launch
+2. Re-launch `copilot` in a project with files of the configured language
+3. Run `/lsp` to check the server status
+4. Try code intelligence features like go-to-definition or hover

--- a/home/private_dot_copilot/skills/lsp-setup/references/lsp-servers.md
+++ b/home/private_dot_copilot/skills/lsp-setup/references/lsp-servers.md
@@ -1,0 +1,405 @@
+# Known LSP Servers for Copilot CLI
+
+Reference data for the `lsp-setup` skill. Each section contains install commands per OS and a ready-to-use config snippet.
+
+> **Config snippet format**: Each snippet below shows the object to insert as a value under the top-level `lspServers` key. A complete config file looks like: `{ "lspServers": { <snippet here> } }`. When adding multiple languages, merge their snippets as sibling keys under `lspServers`.
+
+---
+
+## TypeScript / JavaScript
+
+**Server**: [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
+
+### Install
+
+| OS      | Command                                               |
+|---------|-------------------------------------------------------|
+| Any     | `npm install -g typescript typescript-language-server` |
+
+### Config snippet
+
+```json
+{
+  "typescript": {
+    "command": "typescript-language-server",
+    "args": ["--stdio"],
+    "fileExtensions": {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact"
+    }
+  }
+}
+```
+
+---
+
+## Java
+
+**Server**: [Eclipse JDT Language Server (jdtls)](https://github.com/eclipse-jdtls/eclipse.jdt.ls)
+
+Requires **Java 21+** on `JAVA_HOME` or `$PATH`.
+
+### Install
+
+| OS      | Command                           |
+|---------|-----------------------------------|
+| macOS   | `brew install jdtls`              |
+| Linux   | Check distro repos for `jdtls` or `eclipse.jdt.ls`; alternatively download from https://download.eclipse.org/jdtls/milestones/ |
+| Windows | Download from https://download.eclipse.org/jdtls/milestones/ and add `bin/` to `PATH` |
+
+On macOS with Homebrew, the binary is installed as `jdtls` on `$PATH`.
+
+### Config snippet
+
+```json
+{
+  "java": {
+    "command": "jdtls",
+    "args": [],
+    "fileExtensions": {
+      ".java": "java"
+    }
+  }
+}
+```
+
+> **Note**: The `jdtls` wrapper script handles `--stdio` mode internally. If using a manual install, you may need to invoke the launcher jar directly — see the [jdtls README](https://github.com/eclipse-jdtls/eclipse.jdt.ls#running-from-command-line-with-wrapper-script) for details.
+
+---
+
+## Python
+
+**Server**: [pyright](https://github.com/microsoft/pyright)
+
+### Install
+
+| OS      | Command                    |
+|---------|----------------------------|
+| Any     | `npm install -g pyright`   |
+| Any     | `pip install pyright`      |
+
+### Config snippet
+
+```json
+{
+  "python": {
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "fileExtensions": {
+      ".py": "python"
+    }
+  }
+}
+```
+
+---
+
+## Go
+
+**Server**: [gopls](https://github.com/golang/tools/tree/master/gopls)
+
+### Install
+
+| OS      | Command                                    |
+|---------|--------------------------------------------|
+| Any     | `go install golang.org/x/tools/gopls@latest` |
+| macOS   | `brew install gopls`                       |
+
+### Config snippet
+
+```json
+{
+  "go": {
+    "command": "gopls",
+    "args": ["serve"],
+    "fileExtensions": {
+      ".go": "go"
+    }
+  }
+}
+```
+
+---
+
+## Rust
+
+**Server**: [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
+
+### Install
+
+| OS      | Command                        |
+|---------|--------------------------------|
+| Any     | `rustup component add rust-analyzer` |
+| macOS   | `brew install rust-analyzer`   |
+| Linux   | Distribution package or `rustup` |
+| Windows | `rustup component add rust-analyzer` or download from GitHub releases |
+
+### Config snippet
+
+```json
+{
+  "rust": {
+    "command": "rust-analyzer",
+    "args": [],
+    "fileExtensions": {
+      ".rs": "rust"
+    }
+  }
+}
+```
+
+---
+
+## C / C++
+
+**Server**: [clangd](https://clangd.llvm.org/)
+
+### Install
+
+| OS      | Command                                |
+|---------|----------------------------------------|
+| macOS   | `brew install llvm` (clangd included) or Xcode command line tools |
+| Linux   | `apt install clangd` / `dnf install clang-tools-extra` |
+| Windows | Download LLVM from https://releases.llvm.org/ |
+
+### Config snippet
+
+```json
+{
+  "cpp": {
+    "command": "clangd",
+    "args": ["--background-index"],
+    "fileExtensions": {
+      ".c": "c",
+      ".h": "c",
+      ".cpp": "cpp",
+      ".cxx": "cpp",
+      ".cc": "cpp",
+      ".hpp": "cpp",
+      ".hxx": "cpp"
+    }
+  }
+}
+```
+
+---
+
+## C# (.NET)
+
+**Server**: [Roslyn Language Server](https://github.com/dotnet/roslyn) (via `dotnet dnx`)
+
+### Install
+
+| OS      | Command                                                        |
+|---------|----------------------------------------------------------------|
+| Any     | Requires the [.NET SDK](https://dot.net/download) installed    |
+
+### Config snippet
+
+```json
+{
+  "csharp": {
+    "command": "dotnet",
+    "args": ["dnx", "roslyn-language-server", "--yes", "--prerelease", "--", "--stdio", "--autoLoadProjects"],
+    "fileExtensions": {
+      ".cs": "csharp"
+    }
+  }
+}
+```
+
+---
+
+## Ruby
+
+**Server**: [solargraph](https://github.com/castwide/solargraph)
+
+### Install
+
+| OS      | Command                   |
+|---------|---------------------------|
+| Any     | `gem install solargraph`  |
+
+### Config snippet
+
+```json
+{
+  "ruby": {
+    "command": "solargraph",
+    "args": ["stdio"],
+    "fileExtensions": {
+      ".rb": "ruby",
+      ".rake": "ruby",
+      ".gemspec": "ruby"
+    }
+  }
+}
+```
+
+---
+
+## PHP
+
+**Server**: [intelephense](https://github.com/bmewburn/vscode-intelephense)
+
+### Install
+
+| OS      | Command                                    |
+|---------|--------------------------------------------|
+| Any     | `npm install -g intelephense`              |
+
+### Config snippet
+
+```json
+{
+  "php": {
+    "command": "intelephense",
+    "args": ["--stdio"],
+    "fileExtensions": {
+      ".php": "php"
+    }
+  }
+}
+```
+
+---
+
+## Kotlin
+
+**Server**: [kotlin-language-server](https://github.com/fwcd/kotlin-language-server)
+
+### Install
+
+| OS      | Command                                           |
+|---------|---------------------------------------------------|
+| macOS   | `brew install kotlin-language-server`             |
+| Any     | Download from GitHub releases and add to `PATH`   |
+
+### Config snippet
+
+```json
+{
+  "kotlin": {
+    "command": "kotlin-language-server",
+    "args": [],
+    "fileExtensions": {
+      ".kt": "kotlin",
+      ".kts": "kotlin"
+    }
+  }
+}
+```
+
+---
+
+## Swift
+
+**Server**: [sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp) (bundled with Swift toolchain)
+
+### Install
+
+| OS      | Command                                                        |
+|---------|----------------------------------------------------------------|
+| macOS   | Included with Xcode; binary at `xcrun sourcekit-lsp`          |
+| Linux   | Included with Swift toolchain; install from https://swift.org  |
+
+### Config snippet
+
+```json
+{
+  "swift": {
+    "command": "sourcekit-lsp",
+    "args": [],
+    "fileExtensions": {
+      ".swift": "swift"
+    }
+  }
+}
+```
+
+> On macOS you may need to use the full path: `/usr/bin/sourcekit-lsp` or set `command` to `xcrun` with `args: ["sourcekit-lsp"]`.
+
+---
+
+## Lua
+
+**Server**: [lua-language-server](https://github.com/LuaLS/lua-language-server)
+
+### Install
+
+| OS      | Command                              |
+|---------|--------------------------------------|
+| macOS   | `brew install lua-language-server`   |
+| Linux   | Download from GitHub releases        |
+| Windows | Download from GitHub releases        |
+
+### Config snippet
+
+```json
+{
+  "lua": {
+    "command": "lua-language-server",
+    "args": [],
+    "fileExtensions": {
+      ".lua": "lua"
+    }
+  }
+}
+```
+
+---
+
+## YAML
+
+**Server**: [yaml-language-server](https://github.com/redhat-developer/yaml-language-server)
+
+### Install
+
+| OS      | Command                                      |
+|---------|----------------------------------------------|
+| Any     | `npm install -g yaml-language-server`        |
+
+### Config snippet
+
+```json
+{
+  "yaml": {
+    "command": "yaml-language-server",
+    "args": ["--stdio"],
+    "fileExtensions": {
+      ".yaml": "yaml",
+      ".yml": "yaml"
+    }
+  }
+}
+```
+
+---
+
+## Bash / Shell
+
+**Server**: [bash-language-server](https://github.com/bash-lsp/bash-language-server)
+
+### Install
+
+| OS      | Command                                       |
+|---------|-----------------------------------------------|
+| Any     | `npm install -g bash-language-server`         |
+
+### Config snippet
+
+```json
+{
+  "bash": {
+    "command": "bash-language-server",
+    "args": ["start"],
+    "fileExtensions": {
+      ".sh": "shellscript",
+      ".bash": "shellscript",
+      ".zsh": "shellscript"
+    }
+  }
+}
+```

--- a/home/run_once_after_30-install-tools.ps1.tmpl
+++ b/home/run_once_after_30-install-tools.ps1.tmpl
@@ -1,0 +1,24 @@
+{{ if eq .chezmoi.os "windows" -}}
+# Windows 向け追加ツールのインストール
+# 実行順序: run_once_after_20-mise-install の後。mise でインストールされた uv 等が PATH に必要
+$ErrorActionPreference = 'Stop'
+
+# mise shims を PATH に追加 (非対話シェル対応)
+$shimsDir = Join-Path $env:LOCALAPPDATA 'mise\shims'
+if (($env:Path -split ';') -notcontains $shimsDir) {
+    $env:Path = "$shimsDir;$env:Path"
+}
+
+# --- uv tools ---
+# ty: Python LSP サーバー (Astral)。mise に ty 用バックエンドがないため uv tool で管理
+if (Get-Command uv -ErrorAction SilentlyContinue) {
+    Write-Host "Installing uv tools..."
+    try {
+        uv tool install --quiet ty
+    } catch {
+        Write-Warning "Failed to install ty. Retry manually with 'uv tool install ty'."
+    }
+}
+
+Write-Host "Tool installation complete!"
+{{ end -}}

--- a/home/run_once_after_30-install-tools.sh.tmpl
+++ b/home/run_once_after_30-install-tools.sh.tmpl
@@ -39,6 +39,15 @@ if command -v go >/dev/null 2>&1; then
   fi
 fi
 
+# --- uv tools ---
+# ty: Python LSP サーバー (Astral)。mise に ty 用バックエンドがないため uv tool で管理
+if command -v uv >/dev/null 2>&1; then
+  echo "Installing uv tools..."
+  if ! uv tool install --quiet ty; then
+    echo "Warning: failed to install ty. Retry manually with 'uv tool install ty'." >&2
+  fi
+fi
+
 {{ if eq .chezmoi.os "darwin" -}}
 # --- macOS-specific brew cask packages ---
 if ! brew install --cask --force devtoys; then


### PR DESCRIPTION
## 概要

Copilot CLI の LSP サーバー設定を chezmoi 管理下に追加し、Python (ty) / TypeScript の code intelligence (go-to-definition, find-references, hover 等) を有効化する。併せて lsp-setup skill をリポジトリで追跡する。

## 変更点

### LSP 設定
- `home/private_dot_copilot/lsp-config.json` を新規追加 (`~/.copilot/lsp-config.json`)
  - Python: `ty server` (`.py`, `.pyi`)
  - TypeScript: `typescript-language-server --stdio` (`.ts`, `.tsx`, `.js`, `.jsx`)

### ツール管理
- `home/dot_config/mise/config.toml.tmpl`: `npm:typescript` / `npm:typescript-language-server` を追加
- `home/dot_config/mise/mise.lock`: `mise lock --global --platform windows-x64` で更新
- `home/run_once_after_30-install-tools.sh.tmpl`: Linux/macOS で `uv tool install ty` を実行
- `home/run_once_after_30-install-tools.ps1.tmpl`: **新規**。Windows 向けに `uv tool install ty` を実行

### skill / ドキュメント
- `home/private_dot_copilot/skills/lsp-setup/` 配下 (`SKILL.md`, `references/lsp-servers.md`) を追跡対象に追加
- `docs/operations.md`: LSP サーバーの管理方針 (ty は uv tool、npm 系は mise) を追記

## 設計メモ

- `ty` は現時点で mise 専用バックエンドがなく、かつ Astral の uv tool install で簡単に入るため `uv tool` で管理
- `typescript-language-server` は npm パッケージなので mise `npm:` バックエンドで管理しバージョンロック
- LSP 設定 JSON は PATH 上のバイナリ名のみ参照するため OS 非依存

## 動作確認

- [x] `chezmoi apply` でファイル配置と run_once スクリプト実行を確認 (Windows)
- [x] `mise install` で `typescript-language-server@5.1.3` / `typescript@6.0.3` インストール確認
- [x] `uv tool install ty` で `ty==0.0.32` インストール済み
- [ ] Copilot CLI 再起動後 `/lsp` で両サーバーが稼働することの確認 (マージ後に実施)

## 既知の注意点

- `ty` は preview (v0.0.x)。不安定な場合は pyright への切り替えを検討
