### PR TITLE
fix(windows): add uv tool bin to PATH via update-shell

### DIFF
--- a/home/run_once_after_30-install-tools.ps1.tmpl
+++ b/home/run_once_after_30-install-tools.ps1.tmpl
@@ -18,6 +18,14 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
     } catch {
         Write-Warning "Failed to install ty. Retry manually with 'uv tool install ty'."
     }
+
+    # uv tool の bin ディレクトリ (~/.local/bin) を User PATH に登録。
+    # PowerShell プロファイルを読まない子プロセス (Copilot CLI 等) からも uv tool が見えるようにする。
+    try {
+        uv tool update-shell | Out-Null
+    } catch {
+        Write-Warning "Failed to run 'uv tool update-shell'. Add '$HOME\.local\bin' to PATH manually."
+    }
 }
 
 Write-Host "Tool installation complete!"


### PR DESCRIPTION
## 概要

Windows の初期セットアップスクリプト (`run_once_after_30-install-tools.ps1.tmpl`) で、`uv tool install` 後に `uv tool update-shell` を実行し、`~/.local/bin` を User PATH に登録する。

## 背景

`uv tool install` は実行ファイルを `~/.local/bin` に配置するが、この場所は既定の User PATH に含まれない。PowerShell プロファイル (`$PROFILE`) で PATH を補完しているが、プロファイルを読み込まない子プロセス (例: Copilot CLI が spawn するサブプロセス) からは `ty` などの uv tool が解決できなかった。

`uv tool update-shell` は冪等で、必要に応じて User PATH に `~/.local/bin` を追記するため、永続的な解決になる。

## 変更点

- `uv tool install ty` の後に `uv tool update-shell` を呼び出し
- 失敗時は warning を出して手動対応を促す

## 動作確認

- 対象ファイル: `home/run_once_after_30-install-tools.ps1.tmpl`
- 既存の `ty` インストールブロックと整合し、`Get-Command uv` 成功時のみ実行される
