### PR TITLE
fix(hooks): raise timeoutSec to mitigate parallel bypass

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,3 +70,22 @@ command -v copilot uv
 (Get-Command uv).Source
 [Environment]::GetEnvironmentVariable('Path', 'User') -split ';' | Select-String 'mise\\shims'
 ```
+
+## Copilot CLI: preToolUse フックが並列実行時にすり抜ける
+
+症状: 短時間に複数のツール呼び出しが走った際、`copilot-guard.py` / `uv-enforcer.py` の deny が適用されず、ブロックすべき操作が実行される。
+
+原因 (CLI v1.0.35 系で観測):
+
+- **タイムアウト時の挙動は fail-open**: `timeoutSec` を超えても hook プロセスは kill されず、CLI 側が待機を打ち切って allow フォールバックし、遅れて届く deny は破棄される
+- **hook 起動が逐次キュー化**: 同時に 5 件のツール呼び出しが来ても hook は 1.5〜4 秒間隔で順番に起動される。並列数が増えるほどキュー末尾が `timeoutSec` を超え、上記 fail-open が発動しやすい
+
+対策 (本リポジトリで適用済み):
+
+- `home/private_dot_copilot/hooks/hooks.json` の `timeoutSec` を preToolUse 30 秒 / postToolUse 15 秒に設定し、キューが長くなっても fail-open に落ちにくくする
+- 上流の挙動変更を追跡する (`github/copilot-cli` の issue)
+
+暫定回避:
+
+- 高並列が予想される作業（一括コマンド送信など）では、1 応答内のツール呼び出し数を抑える
+- deny すべき操作が通ってしまった場合は `~/.copilot/hooks/audit.jsonl` で事後検出し、手動で巻き戻す

--- a/home/private_dot_copilot/hooks/hooks.json
+++ b/home/private_dot_copilot/hooks/hooks.json
@@ -6,19 +6,19 @@
         "type": "command",
         "bash": "uv run \"$HOME/.copilot/hooks/scripts/copilot-guard.py\"",
         "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\copilot-guard.py\"",
-        "timeoutSec": 10
+        "timeoutSec": 30
       },
       {
         "type": "command",
         "bash": "uv run \"$HOME/.copilot/hooks/scripts/uv-enforcer.py\"",
         "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\uv-enforcer.py\"",
-        "timeoutSec": 10
+        "timeoutSec": 30
       },
       {
         "type": "command",
         "bash": "uv run \"$HOME/.copilot/hooks/scripts/node-global-enforcer.py\"",
         "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\node-global-enforcer.py\"",
-        "timeoutSec": 10
+        "timeoutSec": 30
       }
     ],
     "postToolUse": [
@@ -26,7 +26,7 @@
         "type": "command",
         "bash": "uv run \"$HOME/.copilot/hooks/scripts/audit-log.py\"",
         "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-log.py\"",
-        "timeoutSec": 5
+        "timeoutSec": 15
       }
     ]
   }


### PR DESCRIPTION
## Summary

`preToolUse` フックが並列実行時に silently bypass される問題の暫定緩和。

## Background

実験で以下を確認 (Copilot CLI v1.0.35-2 / Windows):

- **timeout 時は fail-open**: `timeoutSec` 超過で hook プロセスは kill されず、CLI は待機を打ち切って allow フォールバックする。遅れて届く `deny` は破棄される
- **hook 起動が逐次キュー化**: 98ms 幅の並列 5 tool call に対し hook 起動は +0 / +1.5 / +4.6 / +7.1 / +11.1 秒に展開。並列数が増えるほど後続が `timeoutSec=10` を超過しやすい

両者が重なり、高並列時に `copilot-guard.py` / `uv-enforcer.py` の `deny` が確率的にすり抜ける。

## Changes

- `home/private_dot_copilot/hooks/hooks.json`: `timeoutSec` を preToolUse 10→**30**, postToolUse 5→**15**
- `docs/troubleshooting.md`: 症状・原因・対策・暫定回避手順を追記

## What is NOT changed

- `uv run` による hook 起動方式は維持 (実測で 150-200ms/hook の寄与にとどまり、CLI 側逐次化が主因のため効果限定的)
- ADR-006 / ADR-007 は維持 (本件は運用設定の調整で、意思決定ごと覆すものではない)

## Upstream

本件は CLI 側の挙動が根本原因。`github/copilot-cli` に別途 Issue 起票予定 (ドラフトは session workspace に保管)。

## Test

`uv run -m unittest tests.test_copilot_guard -v` → 111 tests OK
