### PR TITLE
fix(mise): isolate rust cargo_home/rustup_home on Windows

### DIFF
--- a/docs/adr/009-mise-rust-windows-isolate-home.md
+++ b/docs/adr/009-mise-rust-windows-isolate-home.md
@@ -1,0 +1,25 @@
+# ADR-009: Windows では mise の rust home を外部 rustup から分離する
+
+## Status
+
+Accepted
+
+## Context
+
+Windows で mise が `rust` を install するとき、toolchain 本体を rustup 経由で配置した後に `~/.cargo/bin` を `<mise-install-dir>\rust\<version>` から symlink で参照させる。既に外部 rustup が `%USERPROFILE%\.cargo\bin` を実体ディレクトリとして保持している環境では、Windows の symlink API がディレクトリ上書きを拒否して `os error 183` で失敗する（Linux/macOS の `ln -sf` は冪等なため再現しない）。
+
+失敗すると mise 全体が exit 1 で落ち、pre-commit hook や `uv run` など mise 経由の処理が全滅する。repo 側に cargo/rustc 依存コードは無いが、rust を mise から外すのは他 OS 利用者と対称性を崩すため避けたい。
+
+mise 公式は `rust.cargo_home` / `rust.rustup_home`（env: `MISE_CARGO_HOME` / `MISE_RUSTUP_HOME`）で mise 専用の独立ディレクトリを指定できる（[公式 docs](https://mise.jdx.dev/lang/rust.html)）。
+
+## Decision
+
+Windows でのみ、`home/dot_config/mise/config.toml.tmpl` の `[settings.rust]` セクションで `cargo_home` / `rustup_home` を `%LOCALAPPDATA%\mise\rust\{cargo,rustup}` に固定する。Linux/macOS は既存挙動（外部 rustup と `~/.cargo` を共有）を維持する。
+
+PATH 追加は行わない。Windows では `run_once_after_05-setup-mise-shims-path.ps1.tmpl` が `%LOCALAPPDATA%\mise\shims` を user PATH 先頭に積むため、`cargo` / `rustc` は shim 経由で解決できる。
+
+## Consequences
+
+- Windows で mise install の symlink 衝突が消え、pre-commit / `uv run` の安定化につながる
+- Windows 上で「mise が管理する rust」と「外部 rustup が管理する rust」が別 toolchain になる。`cargo install` の成果物も別パスになるため、直接 `%USERPROFILE%\.cargo\bin` を叩いていた利用者は移行が必要
+- Linux/macOS は変更なし。全 OS 一律の分離方針を取らないのは、shim exclude (ADR-003) のレイヤでは救えない Windows 固有問題であり、他 OS の既存 UX を壊す必要がないため

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -21,6 +21,7 @@
 | [006](006-pretooluse-hook-no-allow.md) | Copilot CLI preToolUse フックは allow を出力しない | Accepted |
 | [007](007-python-with-uv-and-pep723.md) | Python スクリプトは uv run + PEP 723 で実行する | Accepted |
 | [008](008-zshenv-sources-profile.md) | ~/.zshenv は ~/.profile を source する | Accepted |
+| [009](009-mise-rust-windows-isolate-home.md) | Windows では mise の rust home を外部 rustup から分離する | Accepted |
 
 ## テンプレート
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -42,3 +42,14 @@ cargo-make = "latest"
 experimental = true
 lockfile = true
 fetch_remote_versions_timeout = "60s"
+
+{{ if eq .chezmoi.os "windows" -}}
+# Windows 限定: mise が rust install 時に `~/.cargo/bin` へ symlink を張る処理は
+# 既存ディレクトリ（外部 rustup が管理する実体）と衝突し os error 183 で失敗する。
+# mise 専用の cargo/rustup home を `%LOCALAPPDATA%\mise\rust\` 配下に分離し、
+# 外部 rustup と共存させる。PATH は shims 経由のままで良いので追加調整は不要。
+# 詳細: docs/adr/009-mise-rust-windows-isolate-home.md
+[settings.rust]
+cargo_home = '{{ .chezmoi.homeDir }}/AppData/Local/mise/rust/cargo'
+rustup_home = '{{ .chezmoi.homeDir }}/AppData/Local/mise/rust/rustup'
+{{ end -}}


### PR DESCRIPTION
## 概要

Windows 環境で `mise install rust` が毎回 `os error 183` (ERROR_ALREADY_EXISTS) で失敗していた問題を解消する。

## 問題

```
mise ERROR Failed to install core:rust@latest:
  failed to ln -sf C:\Users\<user>\.cargo\bin
    C:\Users\<user>\AppData\Local\mise\installs\rust\1.95.0:
  既に存在するファイルを作成することはできません。 (os error 183)
```

- mise rust plugin は toolchain 配置後に `<install-dir>/rust/<ver>` から `~/.cargo\bin` へ junction を張る
- 外部 rustup が既存ディレクトリとして `~/.cargo\bin` を保持している環境では Windows の symlink API がディレクトリ上書きを拒否
- 失敗すると mise 全体が exit 1 で落ち、pre-commit hook や `uv run` 等の mise 経由処理が全滅
- Linux/macOS の `ln -sf` は冪等なため再現しない

## 対処

mise 公式 ([docs](https://mise.jdx.dev/lang/rust.html)) の `rust.cargo_home` / `rust.rustup_home` 設定で mise 専用の独立ディレクトリを指定できる。**Windows 時のみ** `%LOCALAPPDATA%\mise\rust\{cargo,rustup}` へ隔離する。

Linux/macOS は現状維持（外部 rustup と `~/.cargo` を共有）。全 OS 一律の隔離は `dot_zshrc.tmpl` の `.cargo/env` source との整合 (rubber-duck 指摘) や既存 `cargo install` 成果物との分断が副作用として大きいため避ける。

PATH 側は Windows では既存の `run_once_after_05-setup-mise-shims-path.ps1.tmpl` が `%LOCALAPPDATA%\mise\shims` を user PATH 先頭に積むため、`cargo` / `rustc` は shim 経由で解決でき追加調整不要。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `home/dot_config/mise/config.toml.tmpl` | Windows 限定で `[settings.rust]` を追加し `cargo_home` / `rustup_home` を LOCALAPPDATA 配下に固定 |
| `docs/adr/009-mise-rust-windows-isolate-home.md` | 新規 ADR |
| `docs/adr/INDEX.md` | ADR-009 追記 |

## 検討した代替案

- **全 OS で隔離**: Linux/macOS の外部 rustup と mise rust が別 toolchain になる影響が大きく却下
- **rust 定義削除**: dotfiles 内に Rust 依存は無いが、Windows 固有問題のために他 OS の既存 UX を壊すのは過剰
- **ADR-003 の shim exclude 機構応用**: shim 展開の前段で失敗するためレイヤが違い適用不可

## 動作確認 (Windows)

```
mise uninstall rust@1.95.0  → OK
mise install rust            → exit 0 で完走
```

- `installs/rust/1.95.0` junction の target が `~/.cargo\bin` → `mise/rust/cargo/bin` に切替
- `cargo --version` / `rustc --version` / `uv run` すべて動作
- pre-commit hook (gitleaks) が通常通り実行される状態に復帰

## 影響範囲

- **Windows**: 今まで mise 経由の rust が使えなかった人は新パスに mise 専用 toolchain が作られる。外部 rustup と共存
- **Linux/macOS**: 影響なし（テンプレート条件分岐で設定未出力）

## Consequences (from ADR-009)

- Windows 上で「mise が管理する rust」と「外部 rustup が管理する rust」が別 toolchain になる
- `cargo install` の成果物も別パスになるため、直接 `%USERPROFILE%\.cargo\bin` を叩いていた利用者は移行が必要（通常は mise shim 経由で使うため影響は小）
