### PR TITLE
chore(macos): remove Stats cask from managed installs

### DIFF
--- a/home/run_once_after_30-install-tools.sh.tmpl
+++ b/home/run_once_after_30-install-tools.sh.tmpl
@@ -56,9 +56,6 @@ fi
 if ! brew install --cask --force drawio; then
   echo "Warning: failed to install draw.io via Homebrew. Retry manually with 'brew install --cask --force drawio'." >&2
 fi
-if ! brew install --cask --force stats; then
-  echo "Warning: failed to install Stats via Homebrew. Retry manually with 'brew install --cask --force stats'." >&2
-fi
 {{ end -}}
 
 {{ if and (eq .chezmoi.os "linux") (not .isWSL) -}}


### PR DESCRIPTION
## 概要

macOS 向け [Stats](https://github.com/exelban/stats) (brew cask) を dotfiles の管理対象から除外する。

## 背景

Stats が不安定なため、自動インストールからは外して各自の判断に委ねる。

## 変更内容

- `home/run_once_after_30-install-tools.sh.tmpl` から `brew install --cask --force stats` のブロックを削除

## 影響

- 新規セットアップ時に Stats が自動インストールされなくなる
- 既にインストール済みの Stats.app は自動アンインストールされない（必要なら `brew uninstall --cask stats` を手動実行）
- docs/README に Stats への参照は無いため、ドキュメント更新は不要

## 動作確認

- `git diff --stat` で変更が該当ブロックのみであることを確認
