### PR TITLE
feat(copilot): 3-file audit logging with postToolUseFailure

### DIFF
--- a/docs/adr/010-url-allowlist-via-pretooluse-hook.md
+++ b/docs/adr/010-url-allowlist-via-pretooluse-hook.md
@@ -1,0 +1,21 @@
+# ADR-010: Copilot CLI の URL 包括制御は preToolUse Hook で行う
+
+## Status
+
+Accepted
+
+## Context
+
+Copilot CLI v1.0.35-4 時点の実機検証で、CLI 単体では「listed 以外 deny」型の URL ホワイトリスト制御が実現できないことを確認した。`--deny-url='*'` や `--deny-url='https://*'` の wildcard 単独指定はヒットせず、機能するのは個別 domain（例 `example.com`）または prefix（`https://example.com/*`）のみ。また `~/.copilot/config.json` の `deniedUrls` は `--allow-all-tools` 下でバイパスされる。`copilot-cruise` のような Autopilot 運用では、包括的ホワイトリスト方式は Hook でしか実現できない。
+
+## Decision
+
+URL の包括的ホワイトリスト制御は preToolUse Hook の `check_url_allowlist`（`home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py:563-578`）と `home/private_dot_copilot/hooks/allowed-urls.txt` に集約する。CLI の `--deny-url` はサブエージェント（task 経由）経路で Hook が発火しない穴を埋めるための個別 domain **補助列挙**として使い、ホワイトリスト化目的では使わない。`~/.copilot/config.json` の `allowedUrls`/`deniedUrls` は `--allow-all-tools` 下で機能しないため運用で依存しない。ADR-006 の fail-open 方針（allow は出さない）を踏襲する。
+
+## Consequences
+
+- Hook は fail-open（exit 1 / 不正 JSON / timeout / 空出力で通過）なため、allowlist は「うっかり外部アクセス防止」レベルの保険で完全隔離ではない
+- サブエージェント経路は Hook 未発火。危険 URL は CLI `--deny-url` で個別列挙が必須
+- 判断の前提は CLI v1.0.35-4 の挙動。アップグレード時に再検証、CLI が wildcard `--deny-url='*'` をサポートしたら allowlist 簡素化／撤去を検討する（`review-repo` の定期チェック対象）
+- 現時点では `allowed-urls.txt` は空（全行コメントアウト）で URL 制御は適用していない。本 ADR は将来ブロック対象が発生した際の実装先を定めるもの
+- 検証ログ: セッション 978f18e4-1610-4819-98be-6620c6d68271（A1/A15）

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -22,6 +22,7 @@
 | [007](007-python-with-uv-and-pep723.md) | Python スクリプトは uv run + PEP 723 で実行する | Accepted |
 | [008](008-zshenv-sources-profile.md) | ~/.zshenv は ~/.profile を source する | Accepted |
 | [009](009-mise-rust-windows-isolate-home.md) | Windows では mise の rust home を外部 rustup から分離する | Accepted |
+| [010](010-url-allowlist-via-pretooluse-hook.md) | Copilot CLI の URL 包括制御は preToolUse Hook で行う | Accepted |
 
 ## テンプレート
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -8,7 +8,7 @@
 
 - `copilot-instructions.md` — ユーザーレベルのカスタム指示
 - `mcp-config.json` — 手動 MCP サーバー設定（`/mcp add` 後は `chezmoi re-add`）
-- `hooks/hooks.json` / `hooks/scripts/*.py` — `preToolUse` / `postToolUse` フック（`copilot-guard.py`, `uv-enforcer.py`, `audit-log.py`）
+- `hooks/hooks.json` / `hooks/scripts/*.py` — `preToolUse` / `postToolUse` / `postToolUseFailure` フック（`copilot-guard.py`, `uv-enforcer.py`, `audit-log.py`, `audit-failure.py`）
 - `hooks/{blocked-files,ask-files,allowed-urls}.txt` — アクセス制御リスト
 - `skills/` — 手動追加分のみ（プラグイン由来は対象外）
 
@@ -60,11 +60,23 @@ uv run -m unittest tests.test_copilot_guard -v
 
 ## 監査ログ
 
-`postToolUse` フックで `~/.copilot/audit.jsonl` に記録。`COPILOT_AUDIT_DIR` で出力先を変更できる。
+用途別に 3 ファイル。`COPILOT_AUDIT_DIR` で出力先を変更できる。
+
+| ファイル | 記録内容 | 書込元 |
+|---|---|---|
+| `~/.copilot/audit.jsonl` | ツール実行成功履歴 | `postToolUse` → `audit-log.py` |
+| `~/.copilot/audit-denies.jsonl` | `copilot-guard.py` が deny 判定した呼び出し（URL/env/blocked-files/secrets 等）| `preToolUse` → `copilot-guard.py` |
+| `~/.copilot/audit-failures.jsonl` | ツールハンドラーが返したエラー（例: `view` の path 不在） | `postToolUseFailure` → `audit-failure.py` |
 
 ```bash
 tail -5 ~/.copilot/audit.jsonl | uv run python -m json.tool
+tail -5 ~/.copilot/audit-denies.jsonl
+tail -5 ~/.copilot/audit-failures.jsonl
 ```
+
+> `shell` ツールが起動したコマンドの非 0 exit は `postToolUseFailure` の対象外（成功扱い）。検証済み (v1.0.35-4, 2026-04-23)。
+>
+> `audit-denies.jsonl` は **`copilot-guard.py` の deny のみ**を記録する。`uv-enforcer.py` / `node-global-enforcer.py` の deny（グローバル install 系・python 直接実行系）は監査対象外（= プロンプト履歴のみに残る）。理由: これらは「絶対ブロック対象の既知パターン」であり、事後監査より即時ブロック自体が目的のため。
 
 ## 参考
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,4 +88,4 @@ command -v copilot uv
 暫定回避:
 
 - 高並列が予想される作業（一括コマンド送信など）では、1 応答内のツール呼び出し数を抑える
-- deny すべき操作が通ってしまった場合は `~/.copilot/hooks/audit.jsonl` で事後検出し、手動で巻き戻す
+- deny すべき操作が通ってしまった場合は `~/.copilot/audit.jsonl`（成功ログ）/ `audit-denies.jsonl`（preToolUse deny）/ `audit-failures.jsonl`（tool handler error）で事後検出し、手動で巻き戻す

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -125,50 +125,51 @@ Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 # Copilot CLI: Autopilot + multi-layer defense (based on security report recommendations)
 # --deny-tool overrides --allow-all and has no fail-open risk.
 # File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
-# Supported --deny-tool kinds: shell(cmd), write, url(domain), <MCP>(tool)
-# NOTE: shell() performs exact command-name matching. On Windows, .exe suffix and
-#       PowerShell aliases are distinct names and must be listed separately.
+# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), <MCP>(tool)
+# NOTE: shell(cmd:*) uses prefix matching — command name plus any arguments.
+#       On Windows, .exe suffix and PowerShell aliases are distinct names and
+#       must be listed separately.
 function Invoke-CopilotCruise {
     copilot --autopilot `
       --allow-all `
-      --deny-tool 'shell(curl)' `
-      --deny-tool 'shell(curl.exe)' `
-      --deny-tool 'shell(wget)' `
-      --deny-tool 'shell(wget.exe)' `
-      --deny-tool 'shell(Invoke-WebRequest)' `
-      --deny-tool 'shell(iwr)' `
-      --deny-tool 'shell(Invoke-RestMethod)' `
-      --deny-tool 'shell(irm)' `
-      --deny-tool 'shell(Start-BitsTransfer)' `
-      --deny-tool 'shell(nslookup)' `
-      --deny-tool 'shell(nslookup.exe)' `
-      --deny-tool 'shell(dig)' `
-      --deny-tool 'shell(dig.exe)' `
-      --deny-tool 'shell(host)' `
-      --deny-tool 'shell(host.exe)' `
-      --deny-tool 'shell(Resolve-DnsName)' `
-      --deny-tool 'shell(nc)' `
-      --deny-tool 'shell(nc.exe)' `
-      --deny-tool 'shell(netcat)' `
-      --deny-tool 'shell(netcat.exe)' `
-      --deny-tool 'shell(ncat)' `
-      --deny-tool 'shell(ncat.exe)' `
-      --deny-tool 'shell(socat)' `
-      --deny-tool 'shell(socat.exe)' `
-      --deny-tool 'shell(telnet)' `
-      --deny-tool 'shell(telnet.exe)' `
-      --deny-tool 'shell(Test-NetConnection)' `
-      --deny-tool 'shell(tnc)' `
-      --deny-tool 'shell(ssh)' `
-      --deny-tool 'shell(ssh.exe)' `
-      --deny-tool 'shell(scp)' `
-      --deny-tool 'shell(scp.exe)' `
-      --deny-tool 'shell(sftp)' `
-      --deny-tool 'shell(sftp.exe)' `
-      --deny-tool 'shell(ftp)' `
-      --deny-tool 'shell(ftp.exe)' `
-      --deny-tool 'shell(bitsadmin)' `
-      --deny-tool 'shell(bitsadmin.exe)' `
+      --deny-tool 'shell(curl:*)' `
+      --deny-tool 'shell(curl.exe:*)' `
+      --deny-tool 'shell(wget:*)' `
+      --deny-tool 'shell(wget.exe:*)' `
+      --deny-tool 'shell(Invoke-WebRequest:*)' `
+      --deny-tool 'shell(iwr:*)' `
+      --deny-tool 'shell(Invoke-RestMethod:*)' `
+      --deny-tool 'shell(irm:*)' `
+      --deny-tool 'shell(Start-BitsTransfer:*)' `
+      --deny-tool 'shell(nslookup:*)' `
+      --deny-tool 'shell(nslookup.exe:*)' `
+      --deny-tool 'shell(dig:*)' `
+      --deny-tool 'shell(dig.exe:*)' `
+      --deny-tool 'shell(host:*)' `
+      --deny-tool 'shell(host.exe:*)' `
+      --deny-tool 'shell(Resolve-DnsName:*)' `
+      --deny-tool 'shell(nc:*)' `
+      --deny-tool 'shell(nc.exe:*)' `
+      --deny-tool 'shell(netcat:*)' `
+      --deny-tool 'shell(netcat.exe:*)' `
+      --deny-tool 'shell(ncat:*)' `
+      --deny-tool 'shell(ncat.exe:*)' `
+      --deny-tool 'shell(socat:*)' `
+      --deny-tool 'shell(socat.exe:*)' `
+      --deny-tool 'shell(telnet:*)' `
+      --deny-tool 'shell(telnet.exe:*)' `
+      --deny-tool 'shell(Test-NetConnection:*)' `
+      --deny-tool 'shell(tnc:*)' `
+      --deny-tool 'shell(ssh:*)' `
+      --deny-tool 'shell(ssh.exe:*)' `
+      --deny-tool 'shell(scp:*)' `
+      --deny-tool 'shell(scp.exe:*)' `
+      --deny-tool 'shell(sftp:*)' `
+      --deny-tool 'shell(sftp.exe:*)' `
+      --deny-tool 'shell(ftp:*)' `
+      --deny-tool 'shell(ftp.exe:*)' `
+      --deny-tool 'shell(bitsadmin:*)' `
+      --deny-tool 'shell(bitsadmin.exe:*)' `
       --secret-env-vars 'AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING' `
       --max-autopilot-continues 20 `
       @args

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -103,25 +103,25 @@ alias ll='ls -ahl'
 # Copilot CLI: Autopilot + multi-layer defense alias (based on security report recommendations)
 # --deny-tool overrides --allow-all and has no fail-open risk.
 # File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
-# Supported --deny-tool kinds: shell(cmd), write, url(domain), <MCP>(tool)
-# NOTE: shell() performs exact command-name matching — aliases and .exe suffixes
-#       are distinct names and must be listed separately where applicable.
+# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), <MCP>(tool)
+# NOTE: shell(cmd:*) uses prefix matching — command name plus any arguments.
+#       Aliases and .exe suffixes are distinct names and must be listed separately.
 alias copilot-cruise='copilot --autopilot \
   --allow-all \
-  --deny-tool "shell(curl)" \
-  --deny-tool "shell(wget)" \
-  --deny-tool "shell(nslookup)" \
-  --deny-tool "shell(dig)" \
-  --deny-tool "shell(host)" \
-  --deny-tool "shell(nc)" \
-  --deny-tool "shell(netcat)" \
-  --deny-tool "shell(ncat)" \
-  --deny-tool "shell(socat)" \
-  --deny-tool "shell(telnet)" \
-  --deny-tool "shell(ssh)" \
-  --deny-tool "shell(scp)" \
-  --deny-tool "shell(sftp)" \
-  --deny-tool "shell(ftp)" \
+  --deny-tool "shell(curl:*)" \
+  --deny-tool "shell(wget:*)" \
+  --deny-tool "shell(nslookup:*)" \
+  --deny-tool "shell(dig:*)" \
+  --deny-tool "shell(host:*)" \
+  --deny-tool "shell(nc:*)" \
+  --deny-tool "shell(netcat:*)" \
+  --deny-tool "shell(ncat:*)" \
+  --deny-tool "shell(socat:*)" \
+  --deny-tool "shell(telnet:*)" \
+  --deny-tool "shell(ssh:*)" \
+  --deny-tool "shell(scp:*)" \
+  --deny-tool "shell(sftp:*)" \
+  --deny-tool "shell(ftp:*)" \
   --secret-env-vars "AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING" \
   --max-autopilot-continues 20'
 

--- a/home/private_dot_copilot/hooks/hooks.json
+++ b/home/private_dot_copilot/hooks/hooks.json
@@ -28,6 +28,14 @@
         "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-log.py\"",
         "timeoutSec": 15
       }
+    ],
+    "postToolUseFailure": [
+      {
+        "type": "command",
+        "bash": "uv run \"$HOME/.copilot/hooks/scripts/audit-failure.py\"",
+        "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-failure.py\"",
+        "timeoutSec": 15
+      }
     ]
   }
 }

--- a/home/private_dot_copilot/hooks/scripts/executable_audit-failure.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_audit-failure.py
@@ -1,0 +1,127 @@
+# /// script
+# requires-python = ">=3.9"
+# ///
+"""Copilot Audit Failure Log — postToolUseFailure hook for tool error logging.
+
+Reads a JSON tool-failure payload from stdin and appends a one-line JSON log
+entry to ~/.copilot/audit-failures.jsonl. Only fires when a tool handler
+explicitly reports an error (e.g. view on a nonexistent path); shell commands
+that merely exit non-zero do NOT trigger this event.
+
+Security: Sensitive patterns (tokens, secrets, auth headers) are redacted
+before writing to prevent the audit log from becoming a secondary secret store.
+
+Run via: uv run audit-failure.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MAX_LOG_BYTES = int(os.environ.get("COPILOT_AUDIT_MAX_BYTES", 50 * 1024 * 1024))
+
+_REDACT_PATTERNS = re.compile(
+    r"(?i)"
+    r"(?:"
+    r"authorization[=:\s]+\S+(?:\s+\S+){0,2}"
+    r"|(?:bearer|token|basic|key|secret|password)[=:\s]+\S+"
+    r"|ghp_\S+"
+    r"|github_pat_\S+"
+    r"|ghu_\S+|ghs_\S+"
+    r"|xox[bprs]-\S+"
+    r"|sk-[A-Za-z0-9]{20,}"
+    r"|DefaultEndpointsProtocol=\S+"
+    r"|AccountKey=[A-Za-z0-9+/=]+"
+    r"|SharedAccessSignature=\S+"
+    r")"
+)
+
+
+def redact(value: str) -> str:
+    return _REDACT_PATTERNS.sub("[REDACTED]", value)
+
+
+def rotate_if_needed(log_file: Path) -> None:
+    try:
+        if log_file.exists() and log_file.stat().st_size > MAX_LOG_BYTES:
+            rotated = log_file.with_suffix(".jsonl.1")
+            if rotated.exists():
+                rotated.unlink()
+            log_file.rename(rotated)
+    except Exception:
+        pass
+
+
+def _parse_tool_args(raw: Any) -> dict:
+    """Normalize toolArgs to a dict (may arrive as JSON string or dict)."""
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def main() -> None:
+    log_dir = Path(os.environ.get("COPILOT_AUDIT_DIR", Path.home() / ".copilot"))
+    log_file = log_dir / "audit-failures.jsonl"
+
+    raw = ""
+    try:
+        if hasattr(sys.stdin, "reconfigure"):
+            sys.stdin.reconfigure(encoding="utf-8")
+        raw = sys.stdin.read().strip().lstrip("\ufeff\ufffe")
+    except Exception:
+        raw = ""
+
+    if not raw:
+        return
+
+    data: Any = None
+    try:
+        data = json.loads(raw)
+    except Exception:
+        # Payload unparseable (likely CLI schema drift). Record a minimal
+        # marker so we don't lose the event silently.
+        data = {"toolName": "unknown", "error": "audit-failure: unparseable payload"}
+
+    if not isinstance(data, dict):
+        data = {"toolName": "unknown", "error": "audit-failure: non-object payload"}
+
+    tool_name: str = str(data.get("toolName", "unknown"))
+    tool_args = _parse_tool_args(data.get("toolArgs", {}))
+    error = data.get("error", "")
+
+    summary: dict[str, str] = {"tool": tool_name}
+    for key in ("command", "path", "file", "url", "pattern", "query"):
+        val = tool_args.get(key)
+        if val and isinstance(val, str):
+            truncated = val[:500] if len(val) > 500 else val
+            summary[key] = redact(truncated)
+
+    if isinstance(error, str) and error:
+        summary["error"] = redact(error[:500])
+
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "cwd": os.getcwd(),
+        **summary,
+    }
+
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        rotate_if_needed(log_file)
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -22,13 +22,31 @@ Run via: uv run copilot-guard.py
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from functools import lru_cache
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional
 from urllib.parse import unquote, urlsplit
+
+
+# Patterns to redact from audit-denies.jsonl (mirrors audit-log.py / audit-failure.py)
+_AUDIT_REDACT_RE = re.compile(
+    r"(?i)(?:"
+    r"authorization[=:\s]+\S+(?:\s+\S+){0,2}"
+    r"|(?:bearer|token|basic|key|secret|password)[=:\s]+\S+"
+    r"|ghp_\S+|github_pat_\S+|ghu_\S+|ghs_\S+"
+    r"|xox[bprs]-\S+"
+    r"|sk-[A-Za-z0-9]{20,}"
+    r"|DefaultEndpointsProtocol=\S+"
+    r"|AccountKey=[A-Za-z0-9+/=]+"
+    r"|SharedAccessSignature=\S+"
+    r")"
+)
+_AUDIT_MAX_BYTES = int(os.environ.get("COPILOT_AUDIT_MAX_BYTES", 50 * 1024 * 1024))
 
 
 # ---------------------------------------------------------------------------
@@ -625,6 +643,42 @@ def build_context() -> CheckContext:
 
 
 # ---------------------------------------------------------------------------
+# Audit logging (deny events only; best-effort)
+# ---------------------------------------------------------------------------
+
+def _log_deny(ctx: CheckContext, reason: str) -> None:
+    """Append a deny event to audit-denies.jsonl. Never raises."""
+    try:
+        log_dir = Path(os.environ.get("COPILOT_AUDIT_DIR", Path.home() / ".copilot"))
+        log_file = log_dir / "audit-denies.jsonl"
+        entry: dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "cwd": os.getcwd(),
+            "tool": ctx.tool_name,
+            "reason": reason,
+        }
+        # Capture the denied target(s): command for shell, plus path/url/etc. for file tools.
+        if ctx.command:
+            entry["command"] = _AUDIT_REDACT_RE.sub("[REDACTED]", ctx.command[:500])
+        if isinstance(ctx.tool_args, dict):
+            for key in ("path", "file", "url", "pattern", "query"):
+                val = ctx.tool_args.get(key)
+                if val and isinstance(val, str):
+                    truncated = val[:500] if len(val) > 500 else val
+                    entry[key] = _AUDIT_REDACT_RE.sub("[REDACTED]", truncated)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        if log_file.exists() and log_file.stat().st_size > _AUDIT_MAX_BYTES:
+            rotated = log_file.with_suffix(".jsonl.1")
+            if rotated.exists():
+                rotated.unlink()
+            log_file.rename(rotated)
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -640,6 +694,7 @@ def main() -> None:
     # Priority: deny > ask > allow
     denies = [r for r in results if r.decision == "deny"]
     if denies:
+        _log_deny(ctx, denies[0].reason)
         deny(denies[0].reason)
     asks = [r for r in results if r.decision == "ask"]
     if asks:

--- a/tests/test_audit_redaction_sync.py
+++ b/tests/test_audit_redaction_sync.py
@@ -1,0 +1,62 @@
+"""Verify the three audit-redaction regexes stay identical across scripts.
+
+All three scripts keep a local copy of the redaction regex (self-contained
+per ADR style). This test guards against drift: if any of them change
+without the others, CI fails.
+"""
+import importlib.util
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "home/private_dot_copilot/hooks/scripts"
+
+
+def _load(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RedactionSyncTests(unittest.TestCase):
+    """Ensure audit-log.py, audit-failure.py, and copilot-guard.py share regex."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.audit_log = _load("audit_log", SCRIPTS_DIR / "executable_audit-log.py")
+        cls.audit_failure = _load("audit_failure", SCRIPTS_DIR / "executable_audit-failure.py")
+        cls.copilot_guard = _load("copilot_guard", SCRIPTS_DIR / "executable_copilot-guard.py")
+
+    def test_redaction_patterns_identical(self) -> None:
+        log_pattern = self.audit_log._REDACT_PATTERNS.pattern
+        fail_pattern = self.audit_failure._REDACT_PATTERNS.pattern
+        guard_pattern = self.copilot_guard._AUDIT_REDACT_RE.pattern
+        self.assertEqual(log_pattern, fail_pattern)
+        self.assertEqual(log_pattern, guard_pattern)
+
+    def test_redaction_flags_identical(self) -> None:
+        log_flags = self.audit_log._REDACT_PATTERNS.flags
+        fail_flags = self.audit_failure._REDACT_PATTERNS.flags
+        guard_flags = self.copilot_guard._AUDIT_REDACT_RE.flags
+        self.assertEqual(log_flags, fail_flags)
+        self.assertEqual(log_flags, guard_flags)
+
+    def test_redaction_actually_redacts(self) -> None:
+        samples = [
+            "Authorization: Bearer abc123",
+            "token=supersecret",
+            "ghp_abcdefghij",
+            "sk-abcdefghij1234567890abcdef",
+            "AccountKey=AbCd+/=",
+        ]
+        for sample in samples:
+            redacted = self.audit_log.redact(sample)
+            self.assertIn("[REDACTED]", redacted, f"Not redacted: {sample}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_copilot_guard.py
+++ b/tests/test_copilot_guard.py
@@ -777,5 +777,75 @@ class GitCommitCheckerTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class LogDenyTests(unittest.TestCase):
+    """Verify _log_deny captures enough detail to identify the denied target."""
+
+    def setUp(self) -> None:
+        import os, tempfile
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_env = os.environ.get("COPILOT_AUDIT_DIR")
+        os.environ["COPILOT_AUDIT_DIR"] = self.tmpdir
+        self.log_file = pathlib.Path(self.tmpdir) / "audit-denies.jsonl"
+
+    def tearDown(self) -> None:
+        import os, shutil
+        if self._orig_env is None:
+            os.environ.pop("COPILOT_AUDIT_DIR", None)
+        else:
+            os.environ["COPILOT_AUDIT_DIR"] = self._orig_env
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _read_entry(self) -> dict:
+        line = self.log_file.read_text(encoding="utf-8").strip()
+        return json.loads(line)
+
+    def test_logs_shell_command(self) -> None:
+        ctx = make_ctx(tool_name="powershell", command="printenv PATH")
+        copilot_guard._log_deny(ctx, "Blocked env dump command: printenv")
+        entry = self._read_entry()
+        self.assertEqual(entry["tool"], "powershell")
+        self.assertEqual(entry["command"], "printenv PATH")
+        self.assertIn("env dump", entry["reason"])
+
+    def test_logs_view_tool_path(self) -> None:
+        ctx = make_ctx(
+            tool_name="view",
+            tool_args={"path": "C:\\Users\\me\\.azure\\config"},
+        )
+        copilot_guard._log_deny(ctx, "Blocked pattern: **/.azure/*")
+        entry = self._read_entry()
+        self.assertEqual(entry["tool"], "view")
+        self.assertEqual(entry["path"], "C:\\Users\\me\\.azure\\config")
+        self.assertNotIn("command", entry)
+
+    def test_logs_url_for_fetch_tool(self) -> None:
+        ctx = make_ctx(
+            tool_name="web_fetch",
+            tool_args={"url": "https://pastebin.com/abc"},
+        )
+        copilot_guard._log_deny(ctx, "URL not in allowlist")
+        entry = self._read_entry()
+        self.assertEqual(entry["url"], "https://pastebin.com/abc")
+
+    def test_redacts_secrets_in_command(self) -> None:
+        ctx = make_ctx(
+            tool_name="powershell",
+            command="curl -H 'Authorization: Bearer ghp_abc123xyz' https://api.github.com",  # gitleaks:allow
+        )
+        copilot_guard._log_deny(ctx, "test")
+        entry = self._read_entry()
+        self.assertIn("[REDACTED]", entry["command"])
+        self.assertNotIn("ghp_abc123xyz", entry["command"])
+
+    def test_never_raises_on_unwritable_dir(self) -> None:
+        import os
+        # Point to a path that can't be a directory (a file blocking mkdir)
+        blocker = pathlib.Path(self.tmpdir) / "blocker"
+        blocker.write_text("x")
+        os.environ["COPILOT_AUDIT_DIR"] = str(blocker)
+        ctx = make_ctx(tool_name="bash", command="x")
+        copilot_guard._log_deny(ctx, "reason")  # must not raise
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

Copilot CLI の監査ログを 3 ファイル構成（成功 / deny / 失敗）に整理し、`postToolUseFailure` フックを活用してツール失敗も追跡できるようにする。あわせて deny 時の対象情報記録、`shell` deny-tool のプレフィックス一致化、URL allowlist 方針の ADR 化を行う。

## 変更内容

### 監査ログ拡張

- `audit-failure.py` を新規追加し、`postToolUseFailure` イベントを `audit-failures.jsonl` に記録（シークレット redaction・BOM / stringified `toolArgs` への耐性あり）
- `copilot-guard.py` に `_log_deny()` を追加し、deny 時に対象（`path` / `file` / `url` / `pattern` / `query`）を `audit-denies.jsonl` に残す
  - ADR-006 の fail-safe invariant は維持（例外は飲み込み、deny 自体は必ず実行）
- 3 スクリプト間で redaction 正規表現が drift しないよう `test_audit_redaction_sync.py` を追加

### `shell` deny-tool のプレフィックス一致化

- `dot_zshrc.tmpl` / `PowerShell_profile.ps1.tmpl` で `shell(cmd)` を `shell(cmd:*)` に変更し、引数付きの shell 呼び出しもカバー

### ADR / ドキュメント

- ADR-010: URL allowlist を `preToolUse` フックで運用する方針を明文化
- `docs/copilot-cli.md` の監査ログ節を 3 ファイル構成で書き直し。`shell` の非 0 exit は `postToolUseFailure` の対象外である旨も明記
- `docs/troubleshooting.md` の監査ログパス参照を修正

## 検証

- 実機で `view` の存在しないパス → `audit-failures.jsonl` への書き込みを確認
- `shell` / `view` / `web_fetch` の deny → `audit-denies.jsonl` に対象情報が記録されることを確認
- `uv run -m unittest discover -s tests`: 217 → 225 tests（新規 +8: `LogDenyTests` 5 + `test_audit_redaction_sync` 3）全件 PASS
- `chezmoi apply` 済・ローカル `~/.copilot` に反映済

## コミット

1. `feat(copilot-hooks): log postToolUseFailure to audit-failures.jsonl`
2. `feat(copilot-guard): log preToolUse denies with target details`
3. `refactor(copilot): migrate shell deny-tool to prefix match`
4. `docs(adr): add ADR-010 URL allowlist via preToolUse hook`
5. `test(audit): add redaction sync check and LogDenyTests`
6. `docs(copilot-cli): document 3-file audit log structure`
