### PR TITLE
fix(git): manage allowed_signers via chezmoi with correct format

### DIFF
--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -38,8 +38,9 @@
 	format = ssh
 [gpg "ssh"]
 	allowedSignersFile = ~/.ssh/allowed_signers
-# Need to add a public key separately
-# echo '993850+torumakabe@users.noreply.github.com ssh-ed25519 [pub-key]' > ~/.ssh/allowed_signers
+# allowed_signers is managed by chezmoi (home/private_dot_ssh/allowed_signers).
+# Format: <principal> <key-type> <base64-key>
+# Keep the entry in sync with user.email and user.signingkey above.
 [commit]
 {{- if or .codespaces .devcontainer }}
 	gpgsign = false

--- a/home/private_dot_ssh/allowed_signers
+++ b/home/private_dot_ssh/allowed_signers
@@ -1,0 +1,1 @@
+993850+torumakabe@users.noreply.github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILOHG8O9R5bS96Az5RvHDgGtGX1WigZJhZ3CuQnAM7TN


### PR DESCRIPTION
## 背景

`git commit` 時の SSH 署名で参照される allowed_signers の形式が誤っていた。`dot_gitconfig.tmpl` のコメント例が `user.signingkey` の値 (`ssh-ed25519 AAAA...`) をそのまま allowed_signers に貼り付けるように読め、以下のような `ssh-ed25519` 重複エントリを生み出しやすかった:

```
<email> ssh-ed25519 ssh-ed25519 AAAA...
```

正しい形式は `<principal> <key-type> <base64-key>` (`ssh-ed25519` は 1 回)。

## 変更点

- `home/private_dot_ssh/allowed_signers` を新規追加し、正しい形式で chezmoi 管理下に置いた
- `home/dot_gitconfig.tmpl` の誤解を招くコメントを、chezmoi 管理である旨の注記に差し替え

## 検証

- `chezmoi diff` で想定差分のみ
- `chezmoi apply` 後 `git log --show-signature` で Good signature を確認
