### PR TITLE
fix(git): wrap op-ssh-sign-wsl to strip CR for verify on WSL

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,3 +25,4 @@ mise 設定を変更する際は、以下のツールの対応状況を確認し
 ## ワークアラウンド（定期チェック対象）
 
 - **Azure CLI SyntaxWarning**: `dot_zshrc.tmpl` の `az()` ラッパー。[Azure/azure-sdk-for-python#38618](https://github.com/Azure/azure-sdk-for-python/issues/38618) が Close されたら削除する
+- **op-ssh-sign-wsl.exe CRLF (ADR-012)**: `home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl` で stdout/stderr の CR を剥がして `git verify-commit` を成立させている。1Password が WSL バイナリの改行を LF に揃えた、または git 本体が find-principals 結果の `\r` を剥がすようになったら wrapper と `.gitconfig-linux` の `program` 切替を撤去する

--- a/docs/adr/012-wsl-op-ssh-sign-crlf-wrapper.md
+++ b/docs/adr/012-wsl-op-ssh-sign-crlf-wrapper.md
@@ -1,0 +1,34 @@
+# ADR-012: WSL では op-ssh-sign-wsl.exe を CR 除去ラッパー経由で呼ぶ
+
+## Status
+
+Accepted
+
+## Context
+
+WSL 上で 1Password の SSH 署名 (`gpg.format = ssh`) を使うと、`git verify-commit` / `git log --show-signature` が `Could not verify signature.` で失敗する。原因は git と 1Password の Windows バイナリの間の改行の不整合:
+
+1. git は `op-ssh-sign-wsl.exe -Y find-principals` を呼び stdout から principal を取り出す
+2. Windows 流に CRLF で出力されるため `993850+...github.com\r\n` となる
+3. git は `\n` のみを剥がし、`-I '993850+...github.com\r'` を後段の `-Y verify` に渡す
+4. allowed_signers の principal は `\r` を含まないので照合が失敗する
+
+`strace` で `\r` 混入を確認済み、ローカル `ssh-keygen -Y verify` ではファイルもキーも有効、commit object 自体は正常に署名されている（GitHub 側の Verified 表示には影響しない）。WSL+op-ssh-sign-wsl.exe 固有の interop 問題で、Linux ネイティブ (`/opt/1Password/op-ssh-sign`) や Windows ネイティブ (`op-ssh-sign.exe`) では発生しない。
+
+## Decision
+
+WSL 限定で `op-ssh-sign-wsl.exe` の stdout/stderr から CR を剥がすラッパー `~/.local/bin/op-ssh-sign-wrapper.sh` を経由させる。`isWSL` データで 3 ヶ所をゲート:
+
+| 配置 | WSL | ネイティブ Linux | macOS / Windows |
+| --- | --- | --- | --- |
+| `~/.local/bin/op-ssh-sign-wrapper.sh` | 配置 | `home/.chezmoiignore` で除外 | `.gitconfig-linux` ごと除外 |
+| `gpg.ssh.program` | wrapper を指す | `/opt/1Password/op-ssh-sign` | 各 OS の値 |
+
+署名 (`-Y sign`) は `-s <file>` にバイナリを書き出し stdout を経由しないため、CR 除去で改ざんされない。
+
+## Consequences
+
+- WSL でも `git verify-commit` / `git log --show-signature` がローカル検証できる
+- 1Password が CRLF 出力を改善した場合は wrapper を撤去できる（`.github/copilot-instructions.md` のワークアラウンド節で追跡）
+- 将来 git 本体が find-principals 出力の `\r` を剥がすよう修正された場合も同様に撤去可能
+- wrapper は bash の `set -o pipefail` と process substitution に依存するため、`/usr/bin/env bash` が必須

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -24,6 +24,7 @@
 | [009](009-mise-rust-windows-isolate-home.md) | Windows では mise の rust home を外部 rustup から分離する | Accepted |
 | [010](010-url-allowlist-via-pretooluse-hook.md) | Copilot CLI の URL 包括制御は preToolUse Hook で行う | Accepted |
 | [011](011-edit-windows-via-winget-dsc.md) | Microsoft Edit は Windows のみ winget/DSC で管理する | Accepted |
+| [012](012-wsl-op-ssh-sign-crlf-wrapper.md) | WSL では op-ssh-sign-wsl.exe を CR 除去ラッパー経由で呼ぶ | Accepted |
 
 ## テンプレート
 

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -20,4 +20,7 @@ run_once_after_05-setup-mise-shims-path.ps1
 .bash_profile
 .bashrc
 {{ end -}}
+{{ if not .isWSL -}}
+.local/bin/op-ssh-sign-wrapper.sh
+{{ end -}}
 

--- a/home/dot_gitconfig-linux.tmpl
+++ b/home/dot_gitconfig-linux.tmpl
@@ -2,7 +2,10 @@
 [core]
 	editor = vim -c \"set fenc=utf-8\"
 [gpg "ssh"]
-	program = /mnt/c/Users/{{ .windowsUser }}/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe
+	# CRLF interop ワークアラウンド (ADR-012): op-ssh-sign-wsl.exe を直接呼ぶと
+	# find-principals 出力の \r が後段 verify -I に混入し検証失敗するため、
+	# CR を剥がす wrapper を経由する。
+	program = {{ .chezmoi.homeDir }}/.local/bin/op-ssh-sign-wrapper.sh
 {{- else -}}
 [core]
 	editor = vim -c "set fenc=utf-8"

--- a/home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl
+++ b/home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# WSL workaround: 1Password の op-ssh-sign-wsl.exe は Windows 流に CRLF で出力する。
+# git の SSH 署名検証は find-principals 結果から \n のみを剥がすため、
+# trailing \r を含んだ principal を後段の verify -I に渡してしまい、
+# `git verify-commit` / `git log --show-signature` が "Could not verify signature."
+# で失敗する。stdout/stderr の CR を剥がして Linux 流の改行に整える。
+#
+# 適用範囲: WSL のみ（home/.chezmoiignore で非 WSL では配置しない）。
+# 署名 (-Y sign) は -s <file> に書き出すため stdout を経由せず影響を受けない。
+
+set -o pipefail
+
+WIN_BIN="/mnt/c/Users/{{ .windowsUser }}/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe"
+
+"${WIN_BIN}" "$@" 2> >(tr -d '\r' >&2) | tr -d '\r'


### PR DESCRIPTION
## 概要

WSL 環境で `git verify-commit HEAD` が `Could not verify signature.` を返す問題を解消する。原因は git 上ではなく、署名 program として呼ぶ `op-ssh-sign-wsl.exe` (1Password Windows 版) の **CRLF 出力** による interop バグだった。CR を剥がす wrapper を経由させる方針で恒久回避する（ADR-012）。

## 問題

```text
$ git verify-commit HEAD
Could not verify signature.
```

- `gpg.ssh.allowedsignersfile=~/.ssh/allowed_signers` も中身も正しい
- native `ssh-keygen -Y verify` は `Good "git" signature ...` を返す
- `strace -f -e trace=write` で git の verify 呼び出しを追跡すると、principal に `\r` が混入していた

```text
... ssh-keygen -Y verify -n git -f /tmp/.../allowed_signers
        -I '993850+torumakabe@users.noreply.github.com\r' ...
```

切り分け手順:

1. `op-ssh-sign-wsl.exe -Y find-principals` の生 stdout/stderr が CRLF
2. git 2.34.1 は出力末尾の `\n` のみ剥がし `\r` は principal に残す
3. その `\r` 付き principal を後段 `-Y verify -I '...\r'` に渡す
4. allowed_signers 側の principal は `\r` を含まないため不一致 → 失敗

(過去セッションで「allowed_signers 未設定」と誤診した経緯があったため、ADR にも誤診履歴を記載している)

## 対処

`gpg.ssh.program` から直接 `op-ssh-sign-wsl.exe` を指定する代わりに、stdout/stderr から `\r` を除去する 1 行 wrapper を経由させる。

- 署名 (`-Y sign`) は `-s <file>` にバイナリで書き出されるため `tr -d '\r'` の影響なし
- 検証パス (`-Y find-principals` → `-Y verify`) のみで効くため安全
- WSL 限定のワークアラウンドなので chezmoi の `isWSL` データで 3 段ゲート

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl` | 新規。`set -o pipefail` + process substitution で stderr/stdout の CR を除去。`{{ .windowsUser }}` をテンプレ展開して Windows 側 PATH を解決 |
| `home/.chezmoiignore` | 非 WSL では `.local/bin/op-ssh-sign-wrapper.sh` を ignore |
| `home/dot_gitconfig-linux.tmpl` | WSL 分岐の `gpg.ssh.program` を wrapper のパスに切替（ADR-012 へのコメント付き）。非 WSL Linux 分岐は従来どおり `/opt/1Password/op-ssh-sign` |
| `docs/adr/012-wsl-op-ssh-sign-crlf-wrapper.md` | 新規 ADR (Status / Context / Decision / Consequences) |
| `docs/adr/INDEX.md` | ADR-012 追記 |
| `.github/copilot-instructions.md` | ワークアラウンド（定期チェック対象）節に追跡項目を追加 |

## 3 段ゲートの仕組み

| 段 | OS | 動作 |
|---|---|---|
| `.chezmoiignore` (`chezmoi.os`) | macOS / Windows | `.gitconfig-linux` ごと無視（既存） |
| `.chezmoiignore` (`isWSL`) | 非 WSL Linux | wrapper を ignore（追加） |
| `dot_gitconfig-linux.tmpl` (`isWSL`) | WSL | `program` を wrapper、それ以外は `/opt/1Password/op-ssh-sign` |

## 検討した代替案

- **`gpg.ssh.allowedsignersfile` 側の principal に `\r` を入れる** — `\r` を含む principal は `ssh-keygen` の文字列パースでもエラー寄りで、commit 受け側 (GitHub Verified) との互換性も崩れるため却下
- **git 本体に patch** — upstream 修正待ちは長期化が見込まれ、定期チェック対象として追跡しつつ自衛
- **Linux ネイティブ `op-ssh-sign` を WSL からも呼ぶ** — 1Password の SSH agent ソケット連携が WSL 側ネイティブだと別構成になり、chezmoi 管理範囲外の Windows 1Password との二重管理が発生するため見送り

## 動作確認 (WSL)

```text
$ chezmoi apply ~/.local/bin/op-ssh-sign-wrapper.sh ~/.gitconfig-linux
(OK)

$ git verify-commit HEAD
Good "git" signature for 993850+torumakabe@users.noreply.github.com
  with ED25519 key SHA256:okwp...

$ shellcheck ~/.local/bin/op-ssh-sign-wrapper.sh
(no findings)

$ uv run -m unittest discover -s tests
Ran 225 tests in 0.5s — OK
```

`chezmoi execute-template` で 4 シナリオの分岐 rendering も確認:

| シナリオ | wrapper 配置 | gitconfig-linux | program |
|---|---|---|---|
| WSL | yes | rendered | wrapper |
| 非 WSL Linux | no (ignored) | rendered | `/opt/1Password/op-ssh-sign` |
| macOS | no | ignored | — |
| Windows | no | ignored | — |

## 影響範囲

- **WSL**: `gpg.ssh.program` が wrapper 経由に切り替わる。stdout/stderr から `\r` を除去する以外の挙動変化なし。署名 (`-Y sign`) は影響を受けない
- **非 WSL Linux / macOS / Windows**: 影響なし（`.chezmoiignore` と `.gitconfig-linux` の既存条件で除外）

## Consequences (from ADR-012)

- 1Password が `op-ssh-sign-wsl.exe` の改行を LF に揃える、または git 本体が `find-principals` 結果から `\r` を剥がす修正を入れたら wrapper と `program` 切替を撤去する
- 撤去判断は `.github/copilot-instructions.md` のワークアラウンド節（定期チェック対象）を起点とする
