### PR TITLE
fix(mise): sync tools on lockfile changes via chezmoi run_onchange

### DIFF
--- a/docs/adr/013-mise-lockfile-sync-hook.md
+++ b/docs/adr/013-mise-lockfile-sync-hook.md
@@ -1,0 +1,26 @@
+# ADR-013: mise lockfile 変更時に install / reshim を自動同期する
+
+## Status
+
+Accepted
+
+## Context
+
+`mise upgrade` 等で `~/.config/mise/private_mise.lock` が更新されても、ローカルの `mise install` / `mise reshim` は自動で走らない。結果として shim と install marker が古いまま残り、shell 起動時の `_mise_hook`（`mise hook-env`）で `mise WARN missing:` が出る。Windows では `installs\<tool>\<ver>` が junction として作られるため shim が一度欠落すると復元されにくく、`MISE_AUTO_INSTALL=true`（既定）により毎起動で再 install が試みられて rustup の `info: syncing channel updates ...` も繰り返し表示される。
+
+`private_mise.lock` は chezmoi で管理しているため、lockfile が更新された apply の瞬間に install/reshim を流せば構造的に同期できる。
+
+## Decision
+
+`home/run_onchange_after_15-mise-sync-tools.{sh,ps1}.tmpl` を新設し、`{{ include "dot_config/mise/private_mise.lock" | sha256sum }}` を template hash に埋め込む。chezmoi の `run_onchange` は hash 変化時のみ再実行するため、lockfile が変わるたびに `mise install` と `mise reshim` を流して install marker と shim を lockfile と同期させる。
+
+- 番号 15 は `run_onchange_after_21-link-mise-shims.sh.tmpl`（macOS の shim symlink, ADR-002）より前で `run_once_after_20-mise-install.sh.tmpl` の後に走らせるための位置取り。
+- mise が PATH に無い環境（CI 等）は skip して exit 0、apply 全体を止めない。
+- 失敗しても exit 0 で警告のみ。次回 apply で hash 再評価により再試行される。
+
+## Consequences
+
+- 起動時の `mise WARN missing:` と rustup の `info: syncing channel updates ...` が解消する。
+- lockfile が変わった `chezmoi apply` の所要時間が数秒〜数十秒延びる（unchanged 時の install は短時間で完了）。
+- lockfile 以外の理由（手動 `mise uninstall` 等）で shim が欠落したケースは本フックでは復元されないため、その場合は手動で `mise install && mise reshim` を実行する（`docs/troubleshooting.md` 参照）。
+- ADR-009（Windows での mise rust home 分離）の症状（junction marker と install 判定の揺れ）を直接修正するわけではないが、結果として顕在化を抑止する。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -25,6 +25,7 @@
 | [010](010-url-allowlist-via-pretooluse-hook.md) | Copilot CLI の URL 包括制御は preToolUse Hook で行う | Accepted |
 | [011](011-edit-windows-via-winget-dsc.md) | Microsoft Edit は Windows のみ winget/DSC で管理する | Accepted |
 | [012](012-wsl-op-ssh-sign-crlf-wrapper.md) | WSL では op-ssh-sign-wsl.exe を CR 除去ラッパー経由で呼ぶ | Accepted |
+| [013](013-mise-lockfile-sync-hook.md) | mise lockfile 変更時に install / reshim を自動同期する | Accepted |
 
 ## テンプレート
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,17 @@ GITHUB_TOKEN=$(gh auth token) mise lock --global --platform linux-x64,linux-arm6
 mise install
 ```
 
+## shell 起動時に `mise WARN missing:` が出る
+
+`mise upgrade` 等で `private_mise.lock` が更新された後、対応する `mise install` / `mise reshim` が走っていないと shim と install marker が古いまま残り、`mise hook-env` で `WARN missing:` が出る。Windows では rustup の `info: syncing channel updates ...` も併発する。
+
+通常は `chezmoi apply` で `run_onchange_after_15-mise-sync-tools` フック（[ADR-013](adr/013-mise-lockfile-sync-hook.md)）が自動で同期する。手動で `mise uninstall` した等のケースで残った場合は次を実行する。
+
+```bash
+mise install
+mise reshim
+```
+
 ## `run_once_*` スクリプトの warning / error
 
 実行順と役割は [`docs/architecture.md`](architecture.md#run_once_-スクリプトの実行順) を参照。

--- a/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
@@ -1,0 +1,49 @@
+{{- if eq .chezmoi.os "windows" -}}
+# mise lockfile 同期フック (Windows)
+#
+# 背景:
+#   `mise upgrade` 等で `~/.config/mise/private_mise.lock` が更新されても、
+#   ローカルの `mise install` / `mise reshim` は自動で走らない。結果として shim と
+#   install marker が古いまま残り、PowerShell 起動時の `_mise_hook` (`mise hook-env`)
+#   で `mise WARN missing:` が発生する。Windows ではさらに `installs\rust\<ver>` が
+#   `cargo\bin` への junction として作られているため、shim が一度欠落すると `MISE_AUTO_INSTALL`
+#   による自動 install が走り、rustup の `info: syncing channel updates ...` が起動の度に表示される。
+#
+# 対応:
+#   lockfile の hash 変化を chezmoi の run_onchange でフックし、`mise install` と
+#   `mise reshim` を流して install marker と shim を lockfile と同期させる。
+#
+# 関連:
+#   - docs/adr/009-mise-rust-windows-isolate-home.md (cargo_home/rustup_home の分離)
+#   - docs/adr/013-mise-lockfile-sync-hook.md (本フックの設計判断)
+#
+# mise lockfile hash: {{ include "dot_config/mise/private_mise.lock" | sha256sum }}
+
+$ErrorActionPreference = 'Continue'
+
+# `Get-Command mise` は mise activate で定義された function を返してしまい
+# Source プロパティが取れないため、Application 種別に絞って実 exe のパスを取得する。
+$miseExe = (Get-Command -CommandType Application -Name 'mise.exe' -ErrorAction SilentlyContinue |
+  Select-Object -First 1).Source
+if (-not $miseExe) {
+  $candidate = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links\mise.exe'
+  if (Test-Path -LiteralPath $candidate) { $miseExe = $candidate }
+}
+if (-not $miseExe -or -not (Test-Path -LiteralPath $miseExe)) {
+  Write-Host 'mise.exe not found on PATH; skipping mise lockfile sync.'
+  exit 0
+}
+
+Write-Host "Syncing mise tools with lockfile via $miseExe ..."
+& $miseExe install
+$installExit = $LASTEXITCODE
+& $miseExe reshim
+$reshimExit = $LASTEXITCODE
+
+if ($installExit -ne 0 -or $reshimExit -ne 0) {
+  Write-Warning ("mise sync finished with non-zero exit codes (install={0}, reshim={1}). " +
+    "次回 chezmoi apply 時に再試行されるため、原因を確認してください。" -f $installExit, $reshimExit)
+}
+
+exit 0
+{{- end -}}

--- a/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
@@ -1,0 +1,38 @@
+{{- if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+# mise lockfile 同期フック (Linux/macOS)
+#
+# 背景:
+#   `mise upgrade` 等で `~/.config/mise/private_mise.lock` が更新されても、
+#   ローカルの `mise install` / `mise reshim` は自動で走らない。結果として shim と
+#   install marker が古いまま残り、shell 起動時の hook で `mise WARN missing:` が発生する。
+#
+# 対応:
+#   lockfile の hash 変化を chezmoi の run_onchange でフックし、`mise install` と
+#   `mise reshim` を流して install marker と shim を lockfile と同期させる。
+#
+# 関連:
+#   - docs/adr/013-mise-lockfile-sync-hook.md (本フックの設計判断)
+#
+# mise lockfile hash: {{ include "dot_config/mise/private_mise.lock" | sha256sum }}
+
+set -uo pipefail
+
+if ! command -v mise >/dev/null 2>&1; then
+  echo 'mise not found on PATH; skipping mise lockfile sync.' >&2
+  exit 0
+fi
+
+echo 'Syncing mise tools with lockfile...'
+mise install
+install_exit=$?
+mise reshim
+reshim_exit=$?
+
+if [ "$install_exit" -ne 0 ] || [ "$reshim_exit" -ne 0 ]; then
+  echo "WARN: mise sync finished with non-zero exit codes (install=${install_exit}, reshim=${reshim_exit})." >&2
+  echo '     次回 chezmoi apply 時に再試行されます。原因を確認してください。' >&2
+fi
+
+exit 0
+{{- end -}}


### PR DESCRIPTION
## 概要

Windows / `copilot-cruise` 起動時に再発していた `mise WARN missing: rust@1.95.0` と rustup の `info: syncing channel updates ...` を、構造的に解消する。

## 真の原因

`mise upgrade` が `private_mise.lock` を更新しても、対応する `mise install` / `mise reshim` を流す経路がない。結果として shim と install marker が古いまま残り、shell 起動時の `_mise_hook` (`mise hook-env`) で missing 判定 → `MISE_AUTO_INSTALL=true` (既定) で起動の度に rustup の自動 install が動き、警告も併発する。

「警告を黙らせる」のではなく「lockfile と shim/install marker をズラさない」ための構造的対応。

## 変更内容

- `home/run_onchange_after_15-mise-sync-tools.{ps1,sh}.tmpl` を新設し、`{{ include "dot_config/mise/private_mise.lock" | sha256sum }}` を template hash に埋め込む。chezmoi の `run_onchange` は hash 変化時のみ再実行する仕様のため、lockfile が変わった `chezmoi apply` の度に `mise install && mise reshim` が走る。
- 番号 15: `run_onchange_after_21-link-mise-shims.sh.tmpl`(macOS の shim symlink, ADR-002) より前に走らせる位置取り。
- 失敗時は exit 0 で警告のみ。次回 apply で hash 再評価により再試行。
- ADR-013 を追加し、`docs/adr/INDEX.md` と `docs/troubleshooting.md` も更新。

## 検証 (Windows)

| チェック | 結果 |
|---|---|
| `chezmoi apply` で新フック発火 | `mise install` → `mise reshim` 実行 |
| shim 数 | 89 → **117** (rust 系 2 → **26**) に復元 |
| `mise doctor` | `Missing shims` problem 解消 → **No problems found** |
| 新規 `pwsh` プロセス起動 | `mise WARN missing` も `info: syncing channel updates` も**出力されない** |
| 再 `chezmoi apply` | lockfile hash 不変のためフックは再実行されず (idempotent) |

## 関連

- ADR-009 (Windows での mise rust home 分離) — junction marker と install 判定の揺れを直接修正するわけではないが、結果として顕在化を抑止する