### PR TITLE
Add GitHub Copilot app to Windows DSC

### DIFF
--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -58,6 +58,13 @@ properties:
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
+        description: "Install GitHub Copilot app"
+        allowPrerelease: false
+      settings:
+        id: GitHub.CopilotApp
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
         description: "Install Azure Developer CLI"
         allowPrerelease: false
       settings:


### PR DESCRIPTION
Windows setup already installs the Copilot CLI through the WinGet DSC configuration, but the GitHub Copilot app was not included. This adds the `GitHub.CopilotApp` WinGet package so Windows bootstrap applies both Copilot tools from the same DSC entrypoint.

## Changes

- Add `GitHub.CopilotApp` as a `Microsoft.WinGet.DSC/WinGetPackage` resource.
- Keep prerelease installs disabled, matching the existing Copilot CLI package.