### PR TITLE
refactor(copilot-cli): rename copilot-cruise to copilot-guardrails and align security guidance with v1.0.49 guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ chezmoi update
 
 - [`docs/operations.md`](docs/operations.md): `mise` の更新、lockfile 再生成、pre-commit フック管理、`run_once_*` の再実行
 - [`docs/architecture.md`](docs/architecture.md): ディレクトリ構造、設計判断、プラットフォーム分岐、Copilot Guard の構成
-- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象、フック、`copilot-cruise`、監査ログ
+- [`docs/copilot-cli.md`](docs/copilot-cli.md): Copilot CLI の管理対象、フック、`copilot-guardrails`、監査ログ
 - [`docs/troubleshooting.md`](docs/troubleshooting.md): よくある失敗と復旧手順

--- a/docs/adr/010-url-allowlist-via-pretooluse-hook.md
+++ b/docs/adr/010-url-allowlist-via-pretooluse-hook.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-Copilot CLI v1.0.35-4 時点の実機検証で、CLI 単体では「listed 以外 deny」型の URL ホワイトリスト制御が実現できないことを確認した。`--deny-url='*'` や `--deny-url='https://*'` の wildcard 単独指定はヒットせず、機能するのは個別 domain（例 `example.com`）または prefix（`https://example.com/*`）のみ。また `~/.copilot/config.json` の `deniedUrls` は `--allow-all-tools` 下でバイパスされる。`copilot-cruise` のような Autopilot 運用では、包括的ホワイトリスト方式は Hook でしか実現できない。
+Copilot CLI v1.0.35-4 時点の実機検証で、CLI 単体では「listed 以外 deny」型の URL ホワイトリスト制御が実現できないことを確認した。`--deny-url='*'` や `--deny-url='https://*'` の wildcard 単独指定はヒットせず、機能するのは個別 domain（例 `example.com`）または prefix（`https://example.com/*`）のみ。また `~/.copilot/config.json` の `deniedUrls` は `--allow-all-tools` 下でバイパスされる。`copilot --autopilot` のような Autopilot 運用や `--allow-all` 系オプションを伴う運用では、包括的ホワイトリスト方式は Hook でしか実現できない。
 
 ## Decision
 

--- a/docs/adr/010-url-allowlist-via-pretooluse-hook.md
+++ b/docs/adr/010-url-allowlist-via-pretooluse-hook.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-Copilot CLI v1.0.35-4 時点の実機検証で、CLI 単体では「listed 以外 deny」型の URL ホワイトリスト制御が実現できないことを確認した。`--deny-url='*'` や `--deny-url='https://*'` の wildcard 単独指定はヒットせず、機能するのは個別 domain（例 `example.com`）または prefix（`https://example.com/*`）のみ。また `~/.copilot/config.json` の `deniedUrls` は `--allow-all-tools` 下でバイパスされる。`copilot --autopilot` のような Autopilot 運用や `--allow-all` 系オプションを伴う運用では、包括的ホワイトリスト方式は Hook でしか実現できない。
+Copilot CLI v1.0.35-4 / v1.0.49 時点の実機検証で、CLI 単体では「listed 以外 deny」型の URL ホワイトリスト制御が実現できないことを確認した。`--deny-url='*'` や `--deny-url='https://*'` の wildcard 単独指定はヒットせず、機能するのは個別 domain（例 `example.com`）または prefix（`https://example.com/*`）のみ。さらに `--allow-all`（`--allow-all-urls` を含む）下では `--deny-url` / `--allow-url` 自体が無効化される。`~/.copilot/config.json` の `deniedUrls` も同様で、加えて単独ワイルドカード `"*"` は設定ファイル側で非対応、リポジトリレベル設定（`.github/copilot/settings.json`）では `deniedUrls` / `allowedUrls` キー自体がサポートされない。`copilot --autopilot` のような Autopilot 運用や `--allow-all` 系オプションを伴う運用では、包括的ホワイトリスト方式は Hook でしか実現できない（`--deny-tool 'url(...)'` は `--allow-all` 下でも優先されるが、個別列挙のため包括制御には向かない）。
 
 ## Decision
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 - 設定配布 `chezmoi` / ツール版管理 `mise` / Python 実行 `uv`
 - Git の環境差分は `includeIf`、コミット署名は 1Password SSH エージェント（コンテナ系は自動無効化）
 - `copilot-guard.py` / `uv-enforcer.py` で危険操作を抑止、`postToolUse` で監査ログ
-- `copilot-cruise` で Autopilot の既定値を安全寄りに固定
+- `copilot-guardrails` で利便性とセキュリティのバランスを取った既定値を固定
 - `gitleaks` 付き pre-commit を配布
 
 ## Copilot Guard の設計

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -54,9 +54,9 @@ echo '{"toolName":"edit","toolArgs":{"path":".env"}}' | uv run ~/.copilot/hooks/
 uv run -m unittest tests.test_copilot_guard -v
 ```
 
-## `copilot-cruise`
+## `copilot-guardrails`
 
-`.zshrc` / `PowerShell_profile.ps1` の `copilot-cruise` は Autopilot 起動ラッパー。`--deny-tool`（外部送信系の制限）、`--secret-env-vars`（環境変数隠蔽）、`--max-autopilot-continues 20` を固定する。記法は `copilot help permissions` と公式ドキュメント参照。
+`.zshrc` / `PowerShell_profile.ps1` の `copilot-guardrails` は、Copilot CLI の利便性（`--allow-all`）とセキュリティ（`--deny-tool` での外部送信系制限、`--secret-env-vars` での環境変数隠蔽）のバランスを取った起動ラッパー。起動モード（interactive / plan / autopilot）は固定しない。記法は `copilot help permissions` と公式ドキュメント参照。
 
 ## 監査ログ
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -47,6 +47,8 @@ chezmoi re-add ~/.copilot/skills/<skill-name>
 
 パターンファイルは 1 行 1 パターン、`#` でコメント。パス比較は `\` → `/` に正規化、`deny > ask > allow`。`allowed-urls.txt` は全行コメントアウトで無効化できる。
 
+`copilot-guard.py` の `blocked-files.txt` チェックは `view` / `edit` 系ツールだけでなく **`bash`/`powershell` ツール内の `cat` / `Get-Content` 等のシェル経由参照にも適用される**。これは CLI 本体のパス検出が shell コマンド内に埋め込まれたパスを十分に追えない（公式ドキュメントの "Path detection for shell commands has limitations" 記載）穴を Hook で塞ぐ意図的な設計である（ADR-006 / ADR-010 と整合）。
+
 動作確認:
 
 ```bash
@@ -57,6 +59,14 @@ uv run -m unittest tests.test_copilot_guard -v
 ## `copilot-guardrails`
 
 `.zshrc` / `PowerShell_profile.ps1` の `copilot-guardrails` は、Copilot CLI の利便性（`--allow-all`）とセキュリティ（`--deny-tool` での外部送信系制限、`--secret-env-vars` での環境変数隠蔽）のバランスを取った起動ラッパー。起動モード（interactive / plan / autopilot）は固定しない。記法は `copilot help permissions` と公式ドキュメント参照。
+
+設計上の前提と限界:
+
+- `--allow-all` は `--allow-all-tools` + `--allow-all-paths` + `--allow-all-urls` を含意し、**`--deny-url` / `--allow-url` および `~/.copilot/config.json` の `deniedUrls` を無効化する**。URL ブロックは `--deny-tool 'url(...)'`（`--allow-all` 下でも優先される）で行うこと。
+- `--deny-tool 'shell(cmd:*)'` はシェルコマンドラインの**先頭トークン**に対するプレフィックス一致であり、`bash` ツール自体や内部で実行される一般コマンドは止めない。ツール実装ごと止めたい場合は `--excluded-tools <tool>` を使う。
+- `--deny-tool 'memory'` はビルトインに該当ツールが存在しないため no-op（v1.0.49 時点の検証）。
+- `/share gist`（`--share-gist`）は **ユーザー直接コマンドのため preToolUse Hook の対象外**。`--allow-all` 下で秘匿情報がエージェントのコンテキストに入った状態で実行すると、secret Gist として外部化され得る。非 EMU 環境では技術的に防ぐ手段が無いため、運用ルール（実行前に `/reset-allowed-tools` で承認状態をクリアする等）で補う。
+- `permissionRequest` / `notification` / `userPromptSubmitted` 等の Hook タイプは現状未使用。`--allow-all` を外して承認を自動化する運用に切り替える場合の拡張余地として記録しておく。
 
 ## 監査ログ
 

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -125,10 +125,15 @@ Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 # Copilot CLI: multi-layer defense (based on security report recommendations)
 # --deny-tool overrides --allow-all and has no fail-open risk.
 # File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
-# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), <MCP>(tool)
-# NOTE: shell(cmd:*) uses prefix matching — command name plus any arguments.
-#       On Windows, .exe suffix and PowerShell aliases are distinct names and
-#       must be listed separately.
+# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), read[(path)] (undocumented), <MCP>(tool)
+# NOTE: shell(cmd:*) is a prefix match against the *first token* of the shell command line
+#       (e.g. shell(curl:*) blocks `curl ...` but does NOT block `echo` inside the `bash` tool).
+#       To disable a whole tool implementation, use --excluded-tools instead.
+#       On Windows, .exe suffix and PowerShell aliases are distinct first tokens and must be
+#       listed separately.
+# NOTE: --allow-all implies --allow-all-urls, which disables --deny-url / --allow-url and
+#       ~/.copilot/config.json deniedUrls. URL blocking must therefore use --deny-tool 'url(...)',
+#       which is honored even under --allow-all (covers web_fetch and bash curl/wget).
 function Invoke-CopilotGuardrails {
     copilot `
       --allow-all `

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -122,15 +122,15 @@ Set-Alias -Name e -Value Open-EditInNewConsole
 Set-Alias -Name k -Value kubectl
 Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 
-# Copilot CLI: Autopilot + multi-layer defense (based on security report recommendations)
+# Copilot CLI: multi-layer defense (based on security report recommendations)
 # --deny-tool overrides --allow-all and has no fail-open risk.
 # File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
 # Supported --deny-tool kinds: shell(cmd:*), write, url(domain), <MCP>(tool)
 # NOTE: shell(cmd:*) uses prefix matching — command name plus any arguments.
 #       On Windows, .exe suffix and PowerShell aliases are distinct names and
 #       must be listed separately.
-function Invoke-CopilotCruise {
-    copilot --autopilot `
+function Invoke-CopilotGuardrails {
+    copilot `
       --allow-all `
       --deny-tool 'shell(curl:*)' `
       --deny-tool 'shell(curl.exe:*)' `
@@ -171,10 +171,9 @@ function Invoke-CopilotCruise {
       --deny-tool 'shell(bitsadmin:*)' `
       --deny-tool 'shell(bitsadmin.exe:*)' `
       --secret-env-vars 'AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING' `
-      --max-autopilot-continues 20 `
       @args
 }
-Set-Alias -Name copilot-cruise -Value Invoke-CopilotCruise
+Set-Alias -Name copilot-guardrails -Value Invoke-CopilotGuardrails
 
 # === Completers and tool setup ===
 

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -103,9 +103,14 @@ alias ll='ls -ahl'
 # Copilot CLI: multi-layer defense alias (based on security report recommendations)
 # --deny-tool overrides --allow-all and has no fail-open risk.
 # File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
-# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), <MCP>(tool)
-# NOTE: shell(cmd:*) uses prefix matching — command name plus any arguments.
-#       Aliases and .exe suffixes are distinct names and must be listed separately.
+# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), read[(path)] (undocumented), <MCP>(tool)
+# NOTE: shell(cmd:*) is a prefix match against the *first token* of the shell command line
+#       (e.g. `shell(curl:*)` blocks `curl ...` but does NOT block `echo` inside the `bash` tool).
+#       To disable a whole tool implementation, use --excluded-tools instead.
+#       Aliases and .exe suffixes are distinct first tokens and must be listed separately.
+# NOTE: --allow-all implies --allow-all-urls, which disables --deny-url / --allow-url and
+#       ~/.copilot/config.json deniedUrls. URL blocking must therefore use --deny-tool 'url(...)',
+#       which is honored even under --allow-all (covers web_fetch and bash curl/wget).
 alias copilot-guardrails='copilot \
   --allow-all \
   --deny-tool "shell(curl:*)" \

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -100,13 +100,13 @@ command -v mise >/dev/null && source <(mise activate zsh)
 alias k=kubectl
 alias ll='ls -ahl'
 
-# Copilot CLI: Autopilot + multi-layer defense alias (based on security report recommendations)
+# Copilot CLI: multi-layer defense alias (based on security report recommendations)
 # --deny-tool overrides --allow-all and has no fail-open risk.
 # File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
 # Supported --deny-tool kinds: shell(cmd:*), write, url(domain), <MCP>(tool)
 # NOTE: shell(cmd:*) uses prefix matching — command name plus any arguments.
 #       Aliases and .exe suffixes are distinct names and must be listed separately.
-alias copilot-cruise='copilot --autopilot \
+alias copilot-guardrails='copilot \
   --allow-all \
   --deny-tool "shell(curl:*)" \
   --deny-tool "shell(wget:*)" \
@@ -122,8 +122,7 @@ alias copilot-cruise='copilot --autopilot \
   --deny-tool "shell(scp:*)" \
   --deny-tool "shell(sftp:*)" \
   --deny-tool "shell(ftp:*)" \
-  --secret-env-vars "AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING" \
-  --max-autopilot-continues 20'
+  --secret-env-vars "AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING"'
 
 # FPATH for completions (must be before compinit)
 [ -f "$HOME/.zfunc/_rustup" ] && FPATH=$HOME/.zfunc:$FPATH

--- a/home/private_dot_copilot/hooks/blocked-files.txt
+++ b/home/private_dot_copilot/hooks/blocked-files.txt
@@ -57,5 +57,11 @@
 **/*.key
 **/*.token
 
+# パッケージレジストリ / コンテナレジストリの認証情報
+**/.netrc
+**/.npmrc
+**/.pypirc
+**/.docker/config.json
+
 # proc 環境変数 (Linux)
 **/proc/*/environ


### PR DESCRIPTION
## なぜ

GitHub Copilot CLI の Issue [#1861](https://github.com/github/copilot-cli/issues/1861) クローズを起点に、起動モード制御 (`--mode` / `--plan` / `--autopilot` フラグの追加、v1.0.23 以降) と最新セキュリティガイド ([gist v1.0.49](https://gist.github.com/torumakabe/04f59a7e5af88d44811aacffc7a146e6), 2026-05-19) を踏まえてラッパー関数とドキュメントを見直した。Autopilot 既定運用から「起動モードを固定せず、利便性とセキュリティのバランスを取る多層防御」運用へ役割を再定義する。

## 変更内容

**1. ラッパーのリネームと既定値変更** (`85701eb`)

- 関数/エイリアス `copilot-cruise` → `copilot-guardrails` (PowerShell は `Invoke-CopilotGuardrails`)
- 起動オプションから `--autopilot` と `--max-autopilot-continues 20` を削除。起動モードはユーザーが都度選択 (`--mode` フラグ or 起動後の `Shift+Tab` / `/plan` / `/autopilot`)
- `--allow-all` + `--deny-tool 'shell(curl:*)'` 系の外部送信制限と `--secret-env-vars` による Azure 認証変数の隠蔽は維持

**2. セキュリティ知見のドキュメント反映** (`70a67ec`)

- ラッパーのコメントを更新: `--deny-tool` kind 一覧に `read[(path)]` を追記、`shell(cmd:*)` が「先頭トークン」プレフィックス一致である旨を明示、`--allow-all` が `--deny-url`/`--allow-url`/`config.json` の `deniedUrls` を無効化する仕様と、URL ブロックは `--deny-tool 'url(...)'` を使う運用ルールを記述
- `docs/copilot-cli.md`: `/share gist` (`--share-gist`) が preToolUse Hook 対象外で `--allow-all` 下の秘匿情報を外部化し得る点を警告、`--deny-tool 'memory'` が no-op である点を整理、未活用の Hook タイプ (`permissionRequest` / `notification` / `userPromptSubmitted`) を将来拡張余地として記録
- `docs/adr/010-url-allowlist-via-pretooluse-hook.md`: Context を v1.0.49 知見で更新 (`--allow-all` 下での `--deny-url` 無効化、設定ファイル `deniedUrls` のワイルドカード `"*"` 非対応、リポジトリレベル `settings.json` で `deniedUrls`/`allowedUrls` がサポート対象外)
- `home/private_dot_copilot/hooks/blocked-files.txt`: パッケージ/コンテナレジストリ認証情報を追加 (`.netrc` / `.npmrc` / `.pypirc` / `.docker/config.json`)

## 注意点

- `--allow-all` 維持の妥当性は引き続き運用課題。`copilot-guard.py` の bash 経由 `cat` 等の path 検査 (ADR-006 / 010 の fail-open 設計) と `--deny-tool 'shell(...)'`、`--secret-env-vars` の三層で実用上の防御を構成している
- ADR-010 は Status を `Accepted` のまま、Context の鮮度のみ更新。判断自体 (URL 包括制御は Hook で行う) は不変
- 起動モード固定の永続設定 (`defaultMode` 相当) は v1.0.52 時点で未提供。今後 CLI 側で追加された場合は本ラッパーの存在意義を再検討

## 検証

- `tests/test_copilot_guard.py` 116 件全通過
- 新規追加した blocked パターン (`.netrc` / `.npmrc` / `.pypirc` / `.docker/config.json`) の deny 動作を実機確認
- gitleaks pre-commit pass