### PR TITLE
feat: add mise self-upgrade helper

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,7 +40,7 @@ Windows で mise 本体を winget 管理として更新する。
 mise-self-upgrade
 ```
 
-このコマンドは `winget upgrade --id jdx.mise --source winget --disable-interactivity --force` と `mise reshim` を一括実行する。winget portable package の symlink 判定により通常の upgrade が「変更済み」と誤検知されることがあるため、mise 本体の更新ではこの関数を使う。
+このコマンドは `winget upgrade --id jdx.mise --source winget --disable-interactivity --force` を実行し、更新があった場合は続けて `mise reshim` を実行する。更新がない場合は正常終了する。winget portable package の symlink 判定により通常の upgrade が「変更済み」と誤検知されることがあるため、mise 本体の更新ではこの関数を使う。
 
 Copilot CLI など mise shim 経由のプロセスが動いていると winget が `mise.exe` を削除できないため、実行前に検出して停止を促す。
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -32,6 +32,18 @@ chezmoi diff && chezmoi apply
 
 ## mise の保守
 
+### `mise-self-upgrade`
+
+Windows で mise 本体を winget 管理として更新する。
+
+```powershell
+mise-self-upgrade
+```
+
+このコマンドは `winget upgrade --id jdx.mise --source winget --disable-interactivity --force` と `mise reshim` を一括実行する。winget portable package の symlink 判定により通常の upgrade が「変更済み」と誤検知されることがあるため、mise 本体の更新ではこの関数を使う。
+
+Copilot CLI など mise shim 経由のプロセスが動いていると winget が `mise.exe` を削除できないため、実行前に検出して停止を促す。
+
 ### `mise-upgrade`
 
 シェル関数 `mise-upgrade` が次を一括実行する。

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -70,8 +70,20 @@ function Invoke-MiseSelfUpgrade {
         }
 
         Write-Host "==> winget: mise 本体を更新..."
-        winget upgrade --id jdx.mise --source winget --disable-interactivity --force
-        if ($LASTEXITCODE -ne 0) { throw "winget による mise 本体更新に失敗しました" }
+        $wingetOutput = winget upgrade --id jdx.mise --source winget --disable-interactivity --force 2>&1
+        $wingetExitCode = $LASTEXITCODE
+        $wingetOutput | ForEach-Object { Write-Host $_ }
+
+        $noUpgradeAvailable = $wingetOutput -match '利用可能なアップグレードが見つかりません|新しいパッケージ バージョンはありません|No available upgrade found|No newer package versions are available'
+        if ($wingetExitCode -ne 0) {
+            if ($noUpgradeAvailable) {
+                Write-Host "✅ mise 本体は最新です"
+                $global:LASTEXITCODE = 0
+                return
+            }
+
+            throw "winget による mise 本体更新に失敗しました"
+        }
 
         Write-Host "==> mise: shim を再生成..."
         mise reshim

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -40,6 +40,53 @@ function ghcd {
     if ($dir) { Set-Location $dir }
 }
 
+# mise 本体を winget で更新する（winget portable の誤検知回避）
+function Invoke-MiseSelfUpgrade {
+    param(
+        [switch]$SkipProcessCheck
+    )
+
+    $prevErrorAction = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            throw "winget が見つかりません。Windows App Installer を確認してください"
+        }
+
+        if (-not $SkipProcessCheck) {
+            $miseProcesses = Get-CimInstance Win32_Process |
+                Where-Object {
+                    $_.Name -ieq 'mise.exe' -and
+                    ($_.ExecutablePath -like '*\Microsoft\WinGet\Links\mise.exe' -or
+                     $_.CommandLine -like '*\Microsoft\WinGet\Links\mise.exe*' -or
+                     $_.CommandLine -like 'mise*x --*')
+                } |
+                Select-Object ProcessId, ParentProcessId, CommandLine
+
+            if ($miseProcesses) {
+                Write-Warning ($miseProcesses | Format-Table -AutoSize | Out-String)
+                throw "mise.exe を使っているプロセスがあります。Copilot CLI など mise shim 経由のプロセスを閉じてから再実行してください"
+            }
+        }
+
+        Write-Host "==> winget: mise 本体を更新..."
+        winget upgrade --id jdx.mise --source winget --disable-interactivity --force
+        if ($LASTEXITCODE -ne 0) { throw "winget による mise 本体更新に失敗しました" }
+
+        Write-Host "==> mise: shim を再生成..."
+        mise reshim
+        if ($LASTEXITCODE -ne 0) { throw "mise reshim に失敗しました" }
+
+        Write-Host "✅ mise 本体の更新が完了しました"
+    }
+    catch {
+        Write-Error "❌ $($_.Exception.Message)"
+    }
+    finally {
+        $ErrorActionPreference = $prevErrorAction
+    }
+}
+
 # mise 管理ツールの一括更新（日常操作）
 # upgrade → lockfile 更新 → chezmoi 反映 → git commit+push を一括実行
 function Invoke-MiseUpgrade {
@@ -120,6 +167,7 @@ function Invoke-MiseUpgrade {
 # === Aliases ===
 Set-Alias -Name e -Value Open-EditInNewConsole
 Set-Alias -Name k -Value kubectl
+Set-Alias -Name mise-self-upgrade -Value Invoke-MiseSelfUpgrade
 Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 
 # Copilot CLI: multi-layer defense (based on security report recommendations)

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -70,13 +70,11 @@ function Invoke-MiseSelfUpgrade {
         }
 
         Write-Host "==> winget: mise 本体を更新..."
-        $wingetOutput = winget upgrade --id jdx.mise --source winget --disable-interactivity --force 2>&1
+        winget upgrade --id jdx.mise --source winget --disable-interactivity --force
         $wingetExitCode = $LASTEXITCODE
-        $wingetOutput | ForEach-Object { Write-Host $_ }
 
-        $noUpgradeAvailable = $wingetOutput -match '利用可能なアップグレードが見つかりません|新しいパッケージ バージョンはありません|No available upgrade found|No newer package versions are available'
         if ($wingetExitCode -ne 0) {
-            if ($noUpgradeAvailable) {
+            if ($wingetExitCode -eq 0x8A15002B) {
                 Write-Host "✅ mise 本体は最新です"
                 $global:LASTEXITCODE = 0
                 return


### PR DESCRIPTION
## Summary

- add `Invoke-MiseSelfUpgrade` / `mise-self-upgrade` for updating winget-managed mise
- run `winget upgrade --id jdx.mise --source winget --disable-interactivity --force`
- run `mise reshim` only after an actual update
- treat winget's no-applicable-update exit code as a successful no-op
- avoid parsing localized winget output so mojibake does not break detection
- document the workflow in `docs/operations.md`

## Validation

- PowerShell profile syntax check
- `chezmoi execute-template` for `home/PowerShell_profile.ps1.tmpl`
- exercised the no-upgrade path and confirmed it exits successfully
