### PR TITLE
fix: harden Windows git pre-commit hook

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,6 +82,17 @@ command -v copilot uv
 [Environment]::GetEnvironmentVariable('Path', 'User') -split ';' | Select-String 'mise\\shims'
 ```
 
+## Git pre-commit が `C:/Users/.../.config/git/hooks/pre-commit: No such file or directory` で失敗する
+
+グローバル hook は chezmoi で `~/.config/git/hooks/pre-commit` に配置し、`core.hooksPath` から参照する。未配置なら次で復旧する。
+
+```bash
+git config --global core.hooksPath   # 期待値: ~/.config/git/hooks
+chezmoi apply ~/.config/git/hooks/pre-commit
+```
+
+Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin/env bash` が WSL の `bash.exe` を拾い、Windows 形式の `C:/...` パスを開けていない可能性がある。この pre-commit hook はその経路を避けるため POSIX `sh` 互換で管理する。mise の Windows shim も extensionless 版は `/bin/bash` スクリプトなので、hook 内では `gitleaks.exe` を優先する。
+
 ## Copilot CLI: preToolUse フックが並列実行時にすり抜ける
 
 症状: 短時間に複数のツール呼び出しが走った際、`copilot-guard.py` / `uv-enforcer.py` の deny が適用されず、ブロックすべき操作が実行される。

--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -1,39 +1,51 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Global pre-commit hook: gitleaks secret detection + local hook delegation
 #
 # Deployed by chezmoi to ~/.config/git/hooks/pre-commit
 # Activated via core.hooksPath in ~/.gitconfig
+# Keep this POSIX sh compatible so Windows Git does not pick up WSL bash
+# through /usr/bin/env bash and pass it an unopenable C:/... hook path.
 
 # --- gitleaks secret scan ---
 
 find_gitleaks() {
+  # Windows (Git Bash): prefer the .exe shim. The extensionless mise shim is a
+  # /bin/bash script and can still route to WSL bash in this environment.
+  if [ -n "${LOCALAPPDATA:-}" ]; then
+    localappdata_unix="$(cygpath -u "${LOCALAPPDATA}" 2>/dev/null || echo "${LOCALAPPDATA}")"
+    if [ -x "${localappdata_unix}/mise/shims/gitleaks.exe" ]; then
+      echo "${localappdata_unix}/mise/shims/gitleaks.exe"
+      return 0
+    fi
+  fi
+  if [ -x "${HOME}/.local/share/mise/shims/gitleaks.exe" ]; then
+    echo "${HOME}/.local/share/mise/shims/gitleaks.exe"
+    return 0
+  fi
+  if command -v gitleaks.exe >/dev/null 2>&1; then
+    command -v gitleaks.exe
+    return 0
+  fi
+
   if command -v gitleaks >/dev/null 2>&1; then
     command -v gitleaks
     return 0
   fi
 
-  # Try mise shim locations when not in PATH (git hooks don't source shell rc)
-  local shim_dirs=(
-    "${HOME}/.local/share/mise/shims"
-  )
-  # Windows (Git Bash): LOCALAPPDATA is set by the OS
-  if [ -n "${LOCALAPPDATA:-}" ]; then
-    shim_dirs+=("$(cygpath -u "${LOCALAPPDATA}" 2>/dev/null || echo "${LOCALAPPDATA}")/mise/shims")
+  # Try mise shim locations when not in PATH (git hooks don't source shell rc).
+  if [ -x "${HOME}/.local/share/mise/shims/gitleaks" ]; then
+    echo "${HOME}/.local/share/mise/shims/gitleaks"
+    return 0
   fi
 
-  for dir in "${shim_dirs[@]}"; do
-    if [ -x "${dir}/gitleaks" ]; then
-      echo "${dir}/gitleaks"
+  if [ -n "${LOCALAPPDATA:-}" ]; then
+    if [ -x "${localappdata_unix}/mise/shims/gitleaks" ]; then
+      echo "${localappdata_unix}/mise/shims/gitleaks"
       return 0
     fi
-    # Windows shim may be .exe
-    if [ -x "${dir}/gitleaks.exe" ]; then
-      echo "${dir}/gitleaks.exe"
-      return 0
-    fi
-  done
+  fi
 
   return 1
 }


### PR DESCRIPTION
Windows の Copilot CLI 環境で global pre-commit hook が WSL の bash 経由に流れると、`C:/Users/.../.config/git/hooks/pre-commit` を開けずに失敗していました。

## Summary

- pre-commit hook を POSIX `sh` 互換にして、`/usr/bin/env bash` の PATH 解決に依存しないようにしました。
- Windows では mise の extensionless shim ではなく `gitleaks.exe` shim を優先し、`/bin/bash` 経由の再発を避けます。
- 同じ症状の復旧手順を troubleshooting に追記しました。

## Validation

- `git hook run pre-commit`
- `git diff --check`