### PR TITLE
feat: enable core.longpaths for Windows gitconfig

### DIFF
--- a/home/dot_gitconfig-windows.tmpl
+++ b/home/dot_gitconfig-windows.tmpl
@@ -1,5 +1,6 @@
 [core]
   sshCommand = C:/Windows/System32/OpenSSH/ssh.exe
+  longpaths = true
 
 [gpg "ssh"]
   program = C:/Users/{{ .windowsUser }}/AppData/Local/Microsoft/WindowsApps/op-ssh-sign.exe


### PR DESCRIPTION
Windows の MAX_PATH 制限 (260 文字) を超えるパスでも git が正常に動作するよう、Windows 用 gitconfig に `core.longpaths = true` を追加する。

深くネストされたディレクトリ構造を持つリポジトリや、node_modules などの長いパスが発生しやすい環境でのクローン・チェックアウト失敗を防ぐための設定。

**注意**: OS 側でも長いパスのサポートを有効にする必要がある。未設定の場合は管理者権限で以下を実行すること:

```powershell
New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name LongPathsEnabled -Value 1 -PropertyType DWORD -Force
```