### PR TITLE
feat(dsc): add Coreutils for Windows to DSC config

### DIFF
--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -86,6 +86,13 @@ properties:
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
+        description: "Install Coreutils for Windows"
+        allowPrerelease: false
+      settings:
+        id: Microsoft.Coreutils
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
         description: "Install Azure CLI"
         allowPrerelease: false
       settings:


### PR DESCRIPTION
## Why

Windows と Linux/macOS/WSL を行き来する際に、同じコマンド・フラグ・パイプラインをそのまま使えるようにしたい。[microsoft/coreutils](https://github.com/microsoft/coreutils) は uutils/coreutils・findutils・GNU 互換 grep を単一バイナリにまとめた Microsoft 製ビルドで、winget で配布されている。

## What

`reference/windows/configuration.dsc.yaml` に `Microsoft.Coreutils` の `WinGetPackage` リソースを 1 件追加。Microsoft Edit の直後、CLI ツール群の並びに配置した。これで `winget configure -f configuration.dsc.yaml` 実行時に他の GUI/CLI アプリと同じ経路でインストール・更新される。

## Notes

- winget ID は公式 README の `winget install Microsoft.Coreutils` に準拠。
- `allowPrerelease` は他の Microsoft CLI ツールに揃えて `false`。プロジェクトは preview 表記だが winget マニフェストは安定版として公開されているため通常はこれで取得できる。取得できない場合は `true` に切り替える想定。
- 利用上の注意（本 PR では未対応、必要に応じ別途検討）: PowerShell 7.4+ が必須、`whoami`/`kill` 等は非搭載、PowerShell では `cat`/`ls`/`rm` 等が組み込みと衝突するため PATH/エイリアス調整が要る場合がある。