### PR TITLE
docs(review-repo): add runtime mise drift check for orphaned shims

### DIFF
--- a/.github/agents/review-repo.agent.md
+++ b/.github/agents/review-repo.agent.md
@@ -60,9 +60,21 @@ git ls-files --cached | grep -E '\.(whl|pyc|pyo)$|__pycache__|\.ruff_cache|\.DS_
 
 ### 4. mise 設定と install-packages の整合
 
+#### 4a. ソース照合（静的）
+
 - `home/dot_config/mise/config.toml.tmpl` に列挙されているツールと、`home/run_once_before_10-install-packages.sh.tmpl` で OS 別に入れているツールに重複や欠落がないか
 - ADR-004 対象（`azd`, `copilot-cli`）は **mise 外** で定義されていることを確認
 - `mise lock` 実行時は `--global --platform` が指定される運用になっているか（`dot_zshrc.tmpl` / `PowerShell_profile.ps1.tmpl` の関数）
+
+#### 4b. 実機 mise ドリフト検査（ランタイム／任意）
+
+ソース照合ではなく、**このコマンドを実行した実機**の mise 状態を点検する。
+結果は環境依存で、修正は実機のみを変更し git diff は出ない点に留意する。
+
+- `mise ls` を実行し、**Source 列が空**のエントリ（どの config にも紐づかない）を洗い出す:
+  - **孤児ツール**（config.toml に存在しないツール）→ ADR-004 対象（`copilot`/`azd` 等）が mise 経由で残っていないか特に注意。`mise uninstall --all <tool>` を提案
+  - **宣言ツールの余剰バージョン**（現行版以外）→ `mise prune --tools` を提案
+- 修正提案は他項目と同じくユーザー承認後に実施する
 
 ### 5. Python スクリプトの uv 統一（ADR-007）
 


### PR DESCRIPTION
## なぜ

VS Code 統合ターミナルで `copilot` が hang する事象を調査したところ、原因は mise 管理下に残っていた**孤児 shim**（`mise x -- copilot` の入れ子が conpty 下で TTY を破壊）でした。`copilot` は本来 ADR-004 で mise 外（Windows は DSC/winget）管理のはずが、過去に `mise use` で入れた実体が config から外れた後も `installs`/`shims` に残存していたものです。

実機を掃除して解決しましたが、この種のドリフトは**ソースを読むだけでは検出できない**（実機の `mise ls` を見ないとわからない）ため、`review-repo` エージェントに検査ステップを追加します。

## 変更内容

`.github/agents/review-repo.agent.md` の項目 4 を 2 つに分割:

- **4a. ソース照合（静的）**: 既存の config.toml と install-packages の整合チェックをそのまま維持
- **4b. 実機 mise ドリフト検査（ランタイム／任意）**: `mise ls` の **Source 列が空**のエントリを信号に、孤児ツール（`mise uninstall --all`）と宣言ツールの余剰バージョン（`mise prune --tools`）を検出。ADR-004 対象（`copilot`/`azd`）が mise 経由で残っていないか特に注意する

## 補足

- 4b は静的検査と性質が異なる点を本文に明記しています。結果は**実行環境依存**で、修正は実機のみを変更し **git diff が出ない**ため、レビュー時に「整頓したのにコミット対象なし」と混乱しないよう注意書きを入れています。
- 宣言ツール一覧を手で二重管理せず `mise ls` の Source 列を信号にすることで、config.toml の変更に自動追従します。
- 今回の PR には実機掃除（孤児ツールの撤去）は含まれません。ドキュメント追記のみです。