### PR TITLE
feat(git): resolve multi-account HTTPS auth per owner

### DIFF
--- a/docs/adr/014-github-multi-account-https-auth-per-owner.md
+++ b/docs/adr/014-github-multi-account-https-auth-per-owner.md
@@ -1,0 +1,34 @@
+# ADR-014: GitHub 多アカウント HTTPS 認証は credential の URL パス方式 + gh auth token --user で解決する
+
+## Status
+
+Accepted
+
+## Context
+
+`~/.gitconfig` は `helper = !gh auth git-credential` を使う。`gh auth git-credential` は**ホスト単位でアクティブな 1 アカウントのトークンしか返さない**（stdin の `username=` は無視。gh 2.93.0 で実機確認）。
+
+このため EMU（Enterprise Managed Users）リポジトリ（所有者が個人と異なる、例: `<corpUser>/*`）に個人トークンが送られ、権限の無いプライベートリポジトリが **404 Not Found** になる。Copilot CLI や `gh` はプロジェクトごとに `GH_TOKEN` を注入してアカウントを上書きするため動くが、**VS Code の Git にはその注入が無い**ため破綻していた。
+
+## Decision
+
+`home/dot_gitconfig.tmpl` の credential セクションを認証のみ変更（11 行追加）:
+
+- `[credential "https://github.com"]` に `useHttpPath = true` を追加し、git が credential ブロックを所有者パスでマッチできるようにする。デフォルトヘルパーは従来どおり `helper = !gh auth git-credential`（GH_TOKEN / アクティブアカウントを尊重、アプリと個人の挙動は不変）。
+- corp 所有者専用ブロックを `{{ if .corpUser }}` ガードで追加。`[credential "https://github.com/<corpUser>"]` で空 `helper =` リセット後、`helper = "!f() { test \"$1\" = get && echo username=<corpUser> && echo password=$(gh auth token --user <corpUser>); }; f"`。
+
+`gh auth token --user <account>` は **GH_TOKEN 注入下でも対象アカウントのトークンを返す**ことを実機確認済み（VS Code・アプリ端末の双方で機能）。
+
+検討した代替案:
+
+1. **gitdir `includeIf` で認証を出し分ける** — 却下。所有者別ディレクトリ運用の規律が必要（過去に放置）、`ghq.root` のチキンエッグ、submodule/worktree がパス判定から外れ EMU で 404 という事故を招く（当リポジトリは worktree 運用でリスク大）。
+2. **認証 + identity を両方分離（gitdir 併用）** — 見送り。identity は URL/リモート単位で出し分け不可で `includeIf gitdir:` 依存となり上記の規律・副作用が戻る。署名鍵分離は `allowed_signers` の両鍵登録が必要で ADR-012 の op-ssh-sign wrapper とも干渉しうる。EMU が別 identity を要求したら再検討する。
+
+## Consequences
+
+- クローン場所に依存せず所有者で認証が振り分く。VS Code・アプリ端末・CLI すべてで EMU リポジトリにアクセス可能（`git ls-remote` で実認証確認済み）。
+- 前提: corp アカウントは単一（`corpUser`）。将来 EMU を複数アカウントで使うなら所有者ブロックを増やす拡張が必要。
+- `useHttpPath = true` の副作用は credential キャッシュキーに path が入る程度。利用ヘルパーは stateless な gh のみなので実害なし。
+- **EMU リポジトリへのコミットは個人の identity（name/email/署名鍵）のまま**。これは意図的なスコープ外。
+- 既存の `~/workspace_corp` / `gitconfig-corp`（gitdir includeIf）機構は本問題には未使用（リポジトリをそこに置いていないため発火しない）。identity 分離など別目的として据え置く。
+- 撤回条件: 本決定は `gh auth git-credential` がアカウント指定を受け付けない現挙動への対処。将来 stdin の username を尊重して per-account トークンを返すようになったら、owner ブロックと `useHttpPath` を撤去して単一ヘルパーに戻せる。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -26,6 +26,7 @@
 | [011](011-edit-windows-via-winget-dsc.md) | Microsoft Edit は Windows のみ winget/DSC で管理する | Accepted |
 | [012](012-wsl-op-ssh-sign-crlf-wrapper.md) | WSL では op-ssh-sign-wsl.exe を CR 除去ラッパー経由で呼ぶ | Accepted |
 | [013](013-mise-lockfile-sync-hook.md) | mise lockfile 変更時に install / reshim を自動同期する | Accepted |
+| [014](014-github-multi-account-https-auth-per-owner.md) | GitHub 多アカウント HTTPS 認証は credential の URL パス方式 + gh auth token --user で解決する | Accepted |
 
 ## テンプレート
 

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -21,12 +21,23 @@
 [oh-my-zsh]
 	hide-status = 1
 	hide-dirty = 1
+# gh auth git-credential returns only the active account's token per host, so EMU
+# repositories under a different owner get the personal token and 404. useHttpPath
+# lets git match credential blocks by owner path; the owner-scoped block below pins
+# that owner's token via `gh auth token --user`, which is honored even when GH_TOKEN
+# is injected. Identity (name/email/signingkey) is intentionally left unsplit here.
 [credential "https://github.com"]
+	useHttpPath = true
 	helper =
 	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
 	helper =
 	helper = !gh auth git-credential
+{{- if .corpUser }}
+[credential "https://github.com/{{ .corpUser }}"]
+	helper =
+	helper = "!f() { test \"$1\" = get && echo username={{ .corpUser }} && echo password=$(gh auth token --user {{ .corpUser }}); }; f"
+{{- end }}
 [ghq]
 	root = ~/workspace
 	user = torumakabe


### PR DESCRIPTION
## なぜ

github.com の同一ホストで個人アカウントと EMU アカウントを併用していると、`helper = !gh auth git-credential` が**ホスト単位でアクティブな 1 アカウントのトークンしか返さない**ため、所有者の異なる EMU プライベートリポジトリに個人トークンが送られて **404 Not Found** になっていた。Copilot CLI / `gh` はプロジェクトごとに `GH_TOKEN` を注入して回避できるが、VS Code の Git にはその注入が無く破綻していた。

## 何をしたか（認証のみ・identity は据え置き）

`home/dot_gitconfig.tmpl` の credential セクションを所有者ベースの振り分けに変更:

- `[credential "https://github.com"]` に `useHttpPath = true` を追加し、git が credential ブロックを**所有者パスでマッチ**できるようにした。デフォルトのヘルパーは従来どおり `!gh auth git-credential` のままなので、個人リポジトリと `GH_TOKEN` 注入下のアプリ挙動は不変。
- corp 所有者専用ブロックを `{{ if .corpUser }}` ガード付きで追加。空 `helper =` でリセット後、`gh auth token --user <corpUser>` で当該アカウントのトークンを返す。このコマンドは **`GH_TOKEN` 注入下でも対象アカウントのトークンを返す**ことを実機確認済み。

## 設計判断

- **gitdir `includeIf` 方式は採用しなかった**。所有者別ディレクトリ運用の規律が必要なうえ、submodule / worktree がパス判定から外れて認証が個人トークンに化け EMU で 404 になる事故を招く（当リポジトリは worktree 運用のためリスク大）。本方式はクローン場所に依存しない。
- **identity（name/email/署名鍵）は意図的に分離していない**。EMU リポジトリへのコミットは個人 identity のまま。必要になったら別途 ADR で検討する。
- 経緯と代替案は `docs/adr/014` に記録。

## レビュー時の注意

- 実アカウント名はリポジトリに直書きせず `.corpUser`（`home/.chezmoi.toml.tmpl` の `promptStringOnce` で入力、ローカル config に永続化）でテンプレート化している。
- 前提は corp アカウント単一。将来 EMU を複数アカウントで使う場合は所有者ブロックの追加が必要。

## 検証

- `chezmoi diff` / `chezmoi apply` で実 `~/.gitconfig` に反映し、`git credential fill` で個人=個人トークン・EMU=corp トークンに振り分くことを確認。
- `GH_TOKEN` 無しで EMU プライベートリポジトリへ `git ls-remote` が成功（404 解消を実認証で確認）。
- `corpUser` 空のレンダリングで所有者ブロックが出力されないことを確認。