### PR TITLE
chore(brew): trust azure/azd formula before install on macOS

### DIFF
--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -74,6 +74,12 @@ fi
 {{ else if eq .chezmoi.os "darwin" -}}
 echo "Installing system packages via brew..."
 brew update --quiet
+# サードパーティ tap (azure/azd) の formula は HOMEBREW_REQUIRE_TAP_TRUST 強制後に
+# 未信頼だと黙ってスキップされるため、install 前に formula 単位で信頼しておく。
+# 強制は Homebrew 5.2.0 / 6.0.0 のいずれか早い方でデフォルト化予定。
+# brew trust は冪等。古い brew に未実装でも全体を止めないよう失敗は警告に留める。
+brew trust --formula azure/azd/azd \
+  || echo "Warning: 'brew trust' unavailable or failed; azd install may be skipped under tap-trust enforcement." >&2
 # gh: mise install 前にトークン取得手段を確保する（mise 版 gh が shim で shadow する）
 # azure-cli / azd / copilot-cli: GUI アプリや github: バックエンド都合を避けるため
 # macOS では brew で管理


### PR DESCRIPTION
## 概要

Homebrew の tap 信頼強制（`HOMEBREW_REQUIRE_TAP_TRUST`）に備え、macOS のパッケージ導入スクリプトで `azure/azd/azd` を install 前に formula 単位で信頼するようにする。

## 背景

`brew upgrade` 時に未信頼 tap の警告が出るようになった。Homebrew はサプライチェーン対策として tap 信頼を強制する方針で、**5.2.0 か 6.0.0（先に来た方）でデフォルト化**される。強制後は未信頼のサードパーティ tap の formula/cask/command は**エラーではなく黙って無視**される。

`home/run_once_before_10-install-packages.sh.tmpl` の darwin 分岐は非対話で `brew install azure/azd/azd` を実行しているため、強制化後は新規セットアップで azd が黙ってスキップされ、環境が壊れる。

実環境調査では、警告に出た5 tap のうち実際に formula を導入していたのは `azure/azd/azd` のみ。残り4 tap（`hashicorp/tap` `k1low/tap` `microsoft/dev-proxy` `oven-sh/bun`）は formula 未導入の残骸で、terraform は mise(aqua)、dev-proxy は mise(github) に移行済み。これらは手元で `brew untap` 済み。

## 変更内容

- `brew update` 後・`brew install` 前に `brew trust --formula azure/azd/azd` を追加
- `brew trust` は冪等。古い brew に未実装でも全体を止めないよう、失敗は `|| echo ... >&2` で警告に留める

## 検証

- `chezmoi execute-template` で darwin 出力が意図通り展開されることを確認
- 展開後スクリプトを `shellcheck` 通過（exit 0）
- 手元で `brew trust --formula azure/azd/azd` 実行・未使用4 tap を untap 済み（残 tap は `azure/azd` のみ）
