### PR TITLE
fix(mise): disable versions-host to silence kustomize WARN

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,3 +26,4 @@ mise 設定を変更する際は、以下のツールの対応状況を確認し
 
 - **Azure CLI SyntaxWarning**: `dot_zshrc.tmpl` の `az()` ラッパー。[Azure/azure-sdk-for-python#38618](https://github.com/Azure/azure-sdk-for-python/issues/38618) が Close されたら削除する
 - **op-ssh-sign-wsl.exe CRLF (ADR-012)**: `home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl` で stdout/stderr の CR を剥がして `git verify-commit` を成立させている。1Password が WSL バイナリの改行を LF に揃えた、または git 本体が find-principals 結果の `\r` を剥がすようになったら wrapper と `.gitconfig-linux` の `program` 切替を撤去する
+- **mise versions-host kustomize WARN**: `mise/config.toml.tmpl` で `use_versions_host = false` を設定。kustomize のスラッシュ入りタグ（`kustomize/v5.8.1`）を mise の versions-host が `invalid_asset_urls` と誤判定し WARN を出すため。ツール単位設定が無いのでグローバル無効化。mise がスラッシュ入りタグ検証に対応したら撤去する

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -37,6 +37,14 @@ cargo-make = "latest"
 experimental = true
 lockfile = true
 fetch_remote_versions_timeout = "60s"
+# mise の versions-host (mise-versions.jdx.dev) は GitHub リリースのアセット URL を
+# `releases/download/{tag}/{asset}` のセグメント数で検証するが、kustomize はモノレポで
+# タグがスラッシュを含む（例: kustomize/v5.8.1）ため検証に失敗し、毎回 mise-upgrade で
+# `invalid_asset_urls fallback=true` の WARN が出る（フォールバックは正常動作、実害なし）。
+# ツール単位で versions-host を無効化する設定は mise に存在しないため、グローバルで無効化する。
+# upgrade/outdated 時は GitHub へ直接問い合わせる（GITHUB_TOKEN ありなので実質影響なし）。
+# 定期チェック対象: mise がスラッシュ入りタグの検証に対応したら本設定を撤去する。
+use_versions_host = false
 
 {{ if eq .chezmoi.os "windows" -}}
 # Windows 限定: mise が rust install 時に `~/.cargo/bin` へ symlink を張る処理は


### PR DESCRIPTION
## なぜ

`mise-upgrade`（および `mise outdated` など latest 解決を伴う操作）のたびに、次の警告が毎回出ていた:

```
mise WARN  mise-versions endpoint=github_release repo=kubernetes-sigs/kustomize tag=latest outcome=invalid_asset_urls fallback=true
```

## 原因

kustomize はモノレポで、リリースタグがスラッシュを含む（例: `kustomize/v5.8.1`）。mise の versions-host (`mise-versions.jdx.dev`) はアセットの `browser_download_url` を `releases/download/{tag}/{asset}` のパスセグメント数で検証するが、スラッシュ入りタグだとセグメントが 1 つ増えて検証に失敗し、`invalid_asset_urls` を出してフォールバックする。フォールバックは正常に動作しバージョン解決は成功するため、**警告は表示上のもので実害はない**（mise の `versions_host.rs` で確認）。

## 対応

mise には versions-host をツール単位で無効化する設定が存在しないため、`config.toml` の `[settings]` で **グローバルに `use_versions_host = false`** を設定した。

- 全ツールの `latest` 自動更新は維持される。
- 代償は `upgrade`/`outdated` 時に versions-host のキャッシュを使わず GitHub へ直接問い合わせる点のみ。これらの操作では常に `GITHUB_TOKEN` を渡しているため実質的な影響はない。

撤去条件（定期チェック対象として `.github/copilot-instructions.md` に記載）: mise がスラッシュ入りタグの検証に対応したら本設定を撤去する。

## 確認

キャッシュをクリアした上で `mise outdated kustomize` を実行し、警告が出ないことを確認済み。