### PR TITLE
feat: add agent finder skill

### DIFF
--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -38,6 +38,10 @@ npx skills add -g <owner>/<repo>/<path>
 chezmoi re-add ~/.copilot/skills/<skill-name>
 ```
 
+`agentfinder` は GitHub Agent Finder (`https://agentfinder.github.com/api/v1/search`) を使って、MCP サーバー、ツール、スキル、エージェントを検索する手動追加スキル。
+GitHub Docs の Agent Finder 手順に従い、`home/private_dot_copilot/skills/agentfinder/SKILL.md` を `~/.copilot/skills/agentfinder/SKILL.md` として配置する。
+利用時は `/agentfinder <探したい連携や作業>` を実行し、返された候補はユーザーが明示的に選ぶまで自動インストールしない。
+
 ## セキュリティフック
 
 `preToolUse` で以下を検査する。設計は [`architecture.md`](architecture.md#copilot-guard-の設計) を参照。

--- a/home/private_dot_copilot/skills/agentfinder/SKILL.md
+++ b/home/private_dot_copilot/skills/agentfinder/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agentfinder
+description: >-
+  Discover installable MCP servers, tools, skills, and agents through GitHub
+  Agent Finder. Use when the user wants to find a tool, MCP server, skill,
+  agent, connector, or integration for a task or third-party service.
+argument-hint: <what you want to find>
+---
+
+# Agent Finder
+
+Use this skill when the user asks to find an MCP server, tool, skill, agent, connector, or integration for a task.
+Agent Finder implements Agentic Resource Discovery (ARD) and searches GitHub's public Agent Finder catalog.
+
+Do not use this skill for purely local tasks such as editing files, writing code without external integrations, running git, shell work, or math.
+
+## Built-in discovery endpoint
+
+Use GitHub Agent Finder unless the user explicitly names another ARD service.
+
+```text
+https://agentfinder.github.com/api/v1/search
+```
+
+Do not ask the user for this URL.
+No authentication is required for the default endpoint.
+
+If the user explicitly gives another ARD service base URL such as `https://host/api/v1`, derive endpoints from it:
+
+- Search endpoint: append `/search`
+- MCP endpoint: append `/mcp`
+
+## Search workflow
+
+Invoke this skill as `/agentfinder <query>`, where `<query>` is the task or integration the user wants to find.
+
+Send the task as an ARD `query` object:
+
+```bash
+curl -s https://agentfinder.github.com/api/v1/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"text":"<the user task in plain language>"},"pageSize":5}'
+```
+
+Use `query.filter` only when the user asks for a specific resource type.
+
+```json
+{
+  "query": {
+    "text": "find a PostgreSQL MCP server",
+    "filter": {
+      "type": ["application/mcp-server+json"]
+    }
+  },
+  "pageSize": 5
+}
+```
+
+## Presenting results
+
+The response shape is `{ "results": [ ... ] }`.
+For each result, show a numbered list with:
+
+- `displayName`
+- `mediaType`
+- `url`
+- `identifier`
+- `source`
+- `score`
+
+State that `score` is relevance only.
+It is not a trust, security, or safety rating.
+
+## Installation rule
+
+Never install, add, enable, or connect a returned resource automatically.
+Installation requires an explicit user request after the user chooses a result.
+
+When the user chooses a result, explain the next step for that resource type:
+
+| Resource type | Next step |
+|---|---|
+| `application/mcp-server+json` | Add the returned `url` as an MCP server through the client's MCP server configuration flow. |
+| `application/ai-skill` | Install the skill from the returned `url`. |
+| Other media types | Connect to the returned `url` using that resource's protocol or documentation. |
+
+Stop after giving the installation instruction unless the user explicitly asks you to make the change.
+
+## Reference
+
+- GitHub Docs: https://docs.github.com/en/copilot/concepts/mcp-management#agent-finder
+- Catalog browser: https://github.com/agentfinder


### PR DESCRIPTION
## 概要

- Copilot CLI で `/agentfinder` を使えるように `agentfinder` スキルを追加
- GitHub Agent Finder の検索エンドポイントと結果提示ルールをスキル内に記載
- `docs/copilot-cli.md` に手動追加スキルとしての管理メモを追記

## 確認

- `git diff --check`
- GitHub Agent Finder endpoint smoke test