### PR TITLE
feat: migrate Copilot shell network control to sandbox

### DIFF
--- a/docs/adr/010-url-allowlist-via-pretooluse-hook.md
+++ b/docs/adr/010-url-allowlist-via-pretooluse-hook.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-015
 
 ## Context
 

--- a/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
+++ b/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
@@ -1,0 +1,21 @@
+# ADR-015: Copilot CLI shell のネットワーク制御は local sandbox で行う
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-010 では preToolUse Hook による URL allowlist を採用した。Copilot CLI の設定 schema で local sandbox が確認でき、shell command の外向きネットワーク制御を CLI 側に移せる。対象は shell command の network control のみで、MCP / LSP / filesystem sandboxing は別判断とする。
+
+## Decision
+
+Copilot CLI の shell command network control は local sandbox に移行する。`sandbox.enabled=true`、`userPolicy.network.allowOutbound=false`、`allowLocalNetwork=true` を基本とし、必要な例外は `allowedHosts` / `blockedHosts` で表現する。MCP / LSP / filesystem は sandbox 対象外として `sandboxMcpServers=false`、`sandboxLspServers=false`、`addCurrentWorkingDirectory=false`、`userPolicy.filesystem` は empty / preserved arrays、`clearPolicyOnExit=false` を維持する。sandbox disabled 時の Hook fallback は持たない。
+
+## Consequences
+
+- ADR-010 の URL allowlist Hook 方針を置き換える
+- ネットワーク遮断は URL 文字列検査ではなく sandbox policy に委ねる
+- MCP / LSP / filesystem の隔離は本 ADR では保証しない
+- `allowLocalNetwork=true` のため localhost / link-local は許可する。必要なら metadata endpoint 等を `blockedHosts` に追加する
+- sandbox を無効化した運用では shell network 制御も無効になる

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -22,11 +22,12 @@
 | [007](007-python-with-uv-and-pep723.md) | Python スクリプトは uv run + PEP 723 で実行する | Accepted |
 | [008](008-zshenv-sources-profile.md) | ~/.zshenv は ~/.profile を source する | Accepted |
 | [009](009-mise-rust-windows-isolate-home.md) | Windows では mise の rust home を外部 rustup から分離する | Accepted |
-| [010](010-url-allowlist-via-pretooluse-hook.md) | Copilot CLI の URL 包括制御は preToolUse Hook で行う | Accepted |
+| [010](010-url-allowlist-via-pretooluse-hook.md) | Copilot CLI の URL 包括制御は preToolUse Hook で行う | Superseded by ADR-015 |
 | [011](011-edit-windows-via-winget-dsc.md) | Microsoft Edit は Windows のみ winget/DSC で管理する | Accepted |
 | [012](012-wsl-op-ssh-sign-crlf-wrapper.md) | WSL では op-ssh-sign-wsl.exe を CR 除去ラッパー経由で呼ぶ | Accepted |
 | [013](013-mise-lockfile-sync-hook.md) | mise lockfile 変更時に install / reshim を自動同期する | Accepted |
 | [014](014-github-multi-account-https-auth-per-owner.md) | GitHub 多アカウント HTTPS 認証は credential の URL パス方式 + gh auth token --user で解決する | Accepted |
+| [015](015-copilot-cli-shell-network-via-local-sandbox.md) | Copilot CLI shell のネットワーク制御は local sandbox で行う | Accepted |
 
 ## テンプレート
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,8 +25,9 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 
 - 設定配布 `chezmoi` / ツール版管理 `mise` / Python 実行 `uv`
 - Git の環境差分は `includeIf`、コミット署名は 1Password SSH エージェント（コンテナ系は自動無効化）
-- `copilot-guard.py` / `uv-enforcer.py` / `node-global-enforcer.py` で危険操作を抑止、`postToolUse` で監査ログ
-- `copilot-guardrails` で利便性とセキュリティのバランスを取った既定値を固定
+- `copilot-guard.py` / `uv-enforcer.py` / `node-global-enforcer.py` でネットワーク以外の危険操作を抑止、`postToolUse` で監査ログ
+- Copilot CLI local sandbox で shell command の外部ネットワーク通信を制御
+- `copilot-guardrails` で利便性と秘匿環境変数の扱いを固定
 - `gitleaks` 付き pre-commit を配布
 
 ## Copilot Guard の設計
@@ -36,9 +37,11 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 1. 秘匿ファイル拒否 (`blocked-files.txt`)
 2. 確認付きアクセス (`ask-files.txt`)
 3. 機微な環境変数の読み取り拒否 (`printenv`, `$TOKEN`, `os.environ` 等)。通常使う変数は許可リストで除外
-4. 許可外 URL 拒否 (`allowed-urls.txt`)
+4. `git commit` の明示承認
 
 パス比較前に `\` を `/` へ正規化する。パターンファイルは `/` 前提で書く。
+
+shell command の外部ネットワーク通信は `~/.copilot/settings.json` の `sandbox.userPolicy.network` で制御する。初期状態では `allowOutbound = false` とし、必要なホストは後から `allowedHosts` に追加する。
 
 ## git pre-commit フック
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -8,8 +8,9 @@
 
 - `copilot-instructions.md` — ユーザーレベルのカスタム指示
 - `mcp-config.json` — 手動 MCP サーバー設定（`/mcp add` 後は `chezmoi re-add`）
+- `settings.json` の `sandbox` セクション — `run_onchange_after_35-configure-copilot-sandbox.*` で既存設定へマージ
 - `hooks/hooks.json` / `hooks/scripts/*.py` — `preToolUse` / `postToolUse` / `postToolUseFailure` フック（`copilot-guard.py`, `uv-enforcer.py`, `node-global-enforcer.py`, `audit-log.py`, `audit-failure.py`）
-- `hooks/{blocked-files,ask-files,allowed-urls}.txt` — アクセス制御リスト
+- `hooks/{blocked-files,ask-files}.txt` — ファイルアクセス制御リスト
 - `skills/` — 手動追加分のみ（プラグイン由来は対象外）
 
 管理外: `installed-plugins/`（Copilot CLI 側で管理）。
@@ -46,13 +47,13 @@ GitHub Docs の Agent Finder 手順に従い、`home/private_dot_copilot/skills/
 
 `preToolUse` で以下を検査する。設計は [`architecture.md`](architecture.md#copilot-guard-の設計) を参照。
 
-- `copilot-guard.py`: 秘匿ファイル (`blocked-files.txt`) / 確認付き (`ask-files.txt`) / URL 許可 (`allowed-urls.txt`) / 機微な環境変数の読み取り
+- `copilot-guard.py`: 秘匿ファイル (`blocked-files.txt`) / 確認付き (`ask-files.txt`) / 機微な環境変数の読み取り / `git commit` の明示承認
 - `uv-enforcer.py`: `python` / `pip` の直接実行を抑止
 - `node-global-enforcer.py`: `npm` / `yarn` / `pnpm` のグローバルインストールを抑止
 
-パターンファイルは 1 行 1 パターン、`#` でコメント。パス比較は `\` → `/` に正規化、`deny > ask > allow`。`allowed-urls.txt` は全行コメントアウトで無効化できる。
+パターンファイルは 1 行 1 パターン、`#` でコメント。パス比較は `\` → `/` に正規化、`deny > ask > allow`。
 
-`copilot-guard.py` の `blocked-files.txt` チェックは `view` / `edit` 系ツールだけでなく **`bash`/`powershell` ツール内の `cat` / `Get-Content` 等のシェル経由参照にも適用される**。これは CLI 本体のパス検出が shell コマンド内に埋め込まれたパスを十分に追えない（公式ドキュメントの "Path detection for shell commands has limitations" 記載）穴を Hook で塞ぐ意図的な設計である（ADR-006 / ADR-010 と整合）。
+`copilot-guard.py` の `blocked-files.txt` チェックは `view` / `edit` 系ツールだけでなく **`bash`/`powershell` ツール内の `cat` / `Get-Content` 等のシェル経由参照にも適用される**。これは CLI 本体のパス検出が shell コマンド内に埋め込まれたパスを十分に追えない（公式ドキュメントの "Path detection for shell commands has limitations" 記載）穴を Hook で塞ぐ意図的な設計である。shell command のネットワーク制御は ADR-015 に従い local sandbox で扱う。
 
 動作確認:
 
@@ -63,12 +64,12 @@ uv run -m unittest tests.test_copilot_guard -v
 
 ## `copilot-guardrails`
 
-`.zshrc` / `PowerShell_profile.ps1` の `copilot-guardrails` は、Copilot CLI の利便性（`--allow-all`）とセキュリティ（`--deny-tool` での外部送信系制限、`--secret-env-vars` での環境変数隠蔽）のバランスを取った起動ラッパー。起動モード（interactive / plan / autopilot）は固定しない。記法は `copilot help permissions` と公式ドキュメント参照。
+`.zshrc` / `PowerShell_profile.ps1` の `copilot-guardrails` は、Copilot CLI の利便性（`--allow-all`）と `--secret-env-vars` による環境変数隠蔽を固定する起動ラッパー。shell command の外部ネットワーク通信は local sandbox の `sandbox.userPolicy.network` で制御する。起動モード（interactive / plan / autopilot）は固定しない。
 
 設計上の前提と限界:
 
-- `--allow-all` は `--allow-all-tools` + `--allow-all-paths` + `--allow-all-urls` を含意し、**`--deny-url` / `--allow-url` および `~/.copilot/config.json` の `deniedUrls` を無効化する**。URL ブロックは `--deny-tool 'url(...)'`（`--allow-all` 下でも優先される）で行うこと。
-- `--deny-tool 'shell(cmd:*)'` はシェルコマンドラインの**先頭トークン**に対するプレフィックス一致であり、`bash` ツール自体や内部で実行される一般コマンドは止めない。ツール実装ごと止めたい場合は `--excluded-tools <tool>` を使う。
+- local sandbox は Copilot が起動する shell command の実行環境を制御する。MCP、LSP、Copilot CLI のファイル読み書きツールの sandbox 化はこの repo では設定しない。
+- `run_onchange_after_35-configure-copilot-sandbox.*` は `~/.copilot/settings.json` の他のキーを保ったまま `sandbox` セクションを更新する。`allowOutbound = false`、`allowLocalNetwork = true`、`allowedHosts = []` が初期状態である。ホスト許可は後から `/sandbox` または `settings.json` で追加する。
 - `--deny-tool 'memory'` はビルトインに該当ツールが存在しないため no-op（v1.0.49 時点の検証）。
 - `/share gist`（`--share-gist`）は **ユーザー直接コマンドのため preToolUse Hook の対象外**。`--allow-all` 下で秘匿情報がエージェントのコンテキストに入った状態で実行すると、secret Gist として外部化され得る。非 EMU 環境では技術的に防ぐ手段が無いため、運用ルール（実行前に `/reset-allowed-tools` で承認状態をクリアする等）で補う。
 - `permissionRequest` / `notification` / `userPromptSubmitted` 等の Hook タイプは現状未使用。`--allow-all` を外して承認を自動化する運用に切り替える場合の拡張余地として記録しておく。
@@ -80,7 +81,7 @@ uv run -m unittest tests.test_copilot_guard -v
 | ファイル | 記録内容 | 書込元 |
 |---|---|---|
 | `~/.copilot/audit.jsonl` | ツール実行成功履歴 | `postToolUse` → `audit-log.py` |
-| `~/.copilot/audit-denies.jsonl` | `copilot-guard.py` が deny 判定した呼び出し（URL/env/blocked-files/secrets 等）| `preToolUse` → `copilot-guard.py` |
+| `~/.copilot/audit-denies.jsonl` | `copilot-guard.py` が deny 判定した呼び出し（env/blocked-files/secrets 等）| `preToolUse` → `copilot-guard.py` |
 | `~/.copilot/audit-failures.jsonl` | ツールハンドラーが返したエラー（例: `view` の path 不在） | `postToolUseFailure` → `audit-failure.py` |
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,6 +105,7 @@ Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin
 対策 (本リポジトリで適用済み):
 
 - `home/private_dot_copilot/hooks/hooks.json` の `timeoutSec` を preToolUse 30 秒 / postToolUse 15 秒に設定し、キューが長くなっても fail-open に落ちにくくする
+- shell command の外部ネットワーク通信は Hook ではなく Copilot CLI local sandbox で制御する
 - 上流の挙動変更を追跡する (`github/copilot-cli` の issue)
 
 暫定回避:

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -180,59 +180,11 @@ Set-Alias -Name k -Value kubectl
 Set-Alias -Name mise-self-upgrade -Value Invoke-MiseSelfUpgrade
 Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 
-# Copilot CLI: multi-layer defense (based on security report recommendations)
-# --deny-tool overrides --allow-all and has no fail-open risk.
-# File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
-# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), read[(path)] (undocumented), <MCP>(tool)
-# NOTE: shell(cmd:*) is a prefix match against the *first token* of the shell command line
-#       (e.g. shell(curl:*) blocks `curl ...` but does NOT block `echo` inside the `bash` tool).
-#       To disable a whole tool implementation, use --excluded-tools instead.
-#       On Windows, .exe suffix and PowerShell aliases are distinct first tokens and must be
-#       listed separately.
-# NOTE: --allow-all implies --allow-all-urls, which disables --deny-url / --allow-url and
-#       ~/.copilot/config.json deniedUrls. URL blocking must therefore use --deny-tool 'url(...)',
-#       which is honored even under --allow-all (covers web_fetch and bash curl/wget).
+# Copilot CLI: local sandbox handles shell network access. preToolUse hooks
+# still protect sensitive files and shell-level secret reads.
 function Invoke-CopilotGuardrails {
     copilot `
       --allow-all `
-      --deny-tool 'shell(curl:*)' `
-      --deny-tool 'shell(curl.exe:*)' `
-      --deny-tool 'shell(wget:*)' `
-      --deny-tool 'shell(wget.exe:*)' `
-      --deny-tool 'shell(Invoke-WebRequest:*)' `
-      --deny-tool 'shell(iwr:*)' `
-      --deny-tool 'shell(Invoke-RestMethod:*)' `
-      --deny-tool 'shell(irm:*)' `
-      --deny-tool 'shell(Start-BitsTransfer:*)' `
-      --deny-tool 'shell(nslookup:*)' `
-      --deny-tool 'shell(nslookup.exe:*)' `
-      --deny-tool 'shell(dig:*)' `
-      --deny-tool 'shell(dig.exe:*)' `
-      --deny-tool 'shell(host:*)' `
-      --deny-tool 'shell(host.exe:*)' `
-      --deny-tool 'shell(Resolve-DnsName:*)' `
-      --deny-tool 'shell(nc:*)' `
-      --deny-tool 'shell(nc.exe:*)' `
-      --deny-tool 'shell(netcat:*)' `
-      --deny-tool 'shell(netcat.exe:*)' `
-      --deny-tool 'shell(ncat:*)' `
-      --deny-tool 'shell(ncat.exe:*)' `
-      --deny-tool 'shell(socat:*)' `
-      --deny-tool 'shell(socat.exe:*)' `
-      --deny-tool 'shell(telnet:*)' `
-      --deny-tool 'shell(telnet.exe:*)' `
-      --deny-tool 'shell(Test-NetConnection:*)' `
-      --deny-tool 'shell(tnc:*)' `
-      --deny-tool 'shell(ssh:*)' `
-      --deny-tool 'shell(ssh.exe:*)' `
-      --deny-tool 'shell(scp:*)' `
-      --deny-tool 'shell(scp.exe:*)' `
-      --deny-tool 'shell(sftp:*)' `
-      --deny-tool 'shell(sftp.exe:*)' `
-      --deny-tool 'shell(ftp:*)' `
-      --deny-tool 'shell(ftp.exe:*)' `
-      --deny-tool 'shell(bitsadmin:*)' `
-      --deny-tool 'shell(bitsadmin.exe:*)' `
       --secret-env-vars 'AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING' `
       @args
 }

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -100,33 +100,10 @@ command -v mise >/dev/null && source <(mise activate zsh)
 alias k=kubectl
 alias ll='ls -ahl'
 
-# Copilot CLI: multi-layer defense alias (based on security report recommendations)
-# --deny-tool overrides --allow-all and has no fail-open risk.
-# File read/write protection is handled by preToolUse hooks (copilot-guard.py), not --deny-tool.
-# Supported --deny-tool kinds: shell(cmd:*), write, url(domain), read[(path)] (undocumented), <MCP>(tool)
-# NOTE: shell(cmd:*) is a prefix match against the *first token* of the shell command line
-#       (e.g. `shell(curl:*)` blocks `curl ...` but does NOT block `echo` inside the `bash` tool).
-#       To disable a whole tool implementation, use --excluded-tools instead.
-#       Aliases and .exe suffixes are distinct first tokens and must be listed separately.
-# NOTE: --allow-all implies --allow-all-urls, which disables --deny-url / --allow-url and
-#       ~/.copilot/config.json deniedUrls. URL blocking must therefore use --deny-tool 'url(...)',
-#       which is honored even under --allow-all (covers web_fetch and bash curl/wget).
+# Copilot CLI: local sandbox handles shell network access. preToolUse hooks
+# still protect sensitive files and shell-level secret reads.
 alias copilot-guardrails='copilot \
   --allow-all \
-  --deny-tool "shell(curl:*)" \
-  --deny-tool "shell(wget:*)" \
-  --deny-tool "shell(nslookup:*)" \
-  --deny-tool "shell(dig:*)" \
-  --deny-tool "shell(host:*)" \
-  --deny-tool "shell(nc:*)" \
-  --deny-tool "shell(netcat:*)" \
-  --deny-tool "shell(ncat:*)" \
-  --deny-tool "shell(socat:*)" \
-  --deny-tool "shell(telnet:*)" \
-  --deny-tool "shell(ssh:*)" \
-  --deny-tool "shell(scp:*)" \
-  --deny-tool "shell(sftp:*)" \
-  --deny-tool "shell(ftp:*)" \
   --secret-env-vars "AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING"'
 
 # FPATH for completions (must be before compinit)

--- a/home/private_dot_copilot/hooks/allowed-urls.txt
+++ b/home/private_dot_copilot/hooks/allowed-urls.txt
@@ -1,8 +1,0 @@
-# Allowed domains for URL allowlist filtering (one domain per line)
-# Uncomment and customize to enable URL filtering in hook scripts.
-#
-# github.com
-# npmjs.com
-# registry.npmjs.org
-# login.microsoftonline.com
-# management.azure.com

--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -3,9 +3,8 @@
 # ///
 """Copilot Guard — cross-platform preToolUse hook (bash / powershell).
 
-Reads a JSON tool-call from stdin, checks against blocked-files.txt,
-ask-files.txt, and allowed-urls.txt, and emits a JSON permission decision
-on stdout.
+Reads a JSON tool-call from stdin, checks against blocked-files.txt and
+ask-files.txt, and emits a JSON permission decision on stdout.
 
 Architecture:
     Each security check is implemented as a *checker function* with the
@@ -124,7 +123,6 @@ class CheckContext(NamedTuple):
     command: str
     blocked_patterns: list[str]
     ask_patterns: list[str]
-    allowed_domains: list[str]
 
 
 # Checker function contract: (CheckContext) -> CheckResult or None.
@@ -569,47 +567,6 @@ def check_git_commit(ctx: CheckContext) -> CheckResult | None:
 
 
 # ---------------------------------------------------------------------------
-# Checker: URL allowlist
-# ---------------------------------------------------------------------------
-
-def extract_urls(text: str) -> list[str]:
-    return re.findall(r"https?://[^\s\"']+", text)
-
-
-def extract_url_host(url: str) -> str:
-    """Extract the hostname from a URL without external dependencies."""
-    host = re.sub(r"^https?://", "", url)
-    host = host.split("/")[0].split(":")[0]
-    return host
-
-
-def is_url_allowed(url: str, allowed_domains: list[str]) -> bool:
-    host = extract_url_host(url)
-    for domain in allowed_domains:
-        if host == domain or host.endswith("." + domain):
-            return True
-    return False
-
-
-def check_url_allowlist(ctx: CheckContext) -> CheckResult | None:
-    """Check URLs in commands and web_fetch args against the domain allowlist."""
-    if not ctx.allowed_domains:
-        return None
-
-    if ctx.command:
-        for url in extract_urls(ctx.command):
-            if not is_url_allowed(url, ctx.allowed_domains):
-                return CheckResult("deny", f"URL not in allowlist: {url}")
-
-    if ctx.tool_name == "web_fetch":
-        url = ctx.tool_args.get("url", "")
-        if url and not is_url_allowed(url, ctx.allowed_domains):
-            return CheckResult("deny", f"URL not in allowlist: {url}")
-
-    return None
-
-
-# ---------------------------------------------------------------------------
 # Checker registry
 # ---------------------------------------------------------------------------
 
@@ -617,7 +574,6 @@ CHECKERS: list[Checker] = [
     check_blocked_files,
     check_env,
     check_git_commit,
-    check_url_allowlist,
 ]
 
 
@@ -640,7 +596,6 @@ def build_context() -> CheckContext:
     hooks_dir = script_dir.parent
     blocked_file = hooks_dir / "blocked-files.txt"
     ask_file = hooks_dir / "ask-files.txt"
-    allowed_urls_file = hooks_dir / "allowed-urls.txt"
 
     if not blocked_file.is_file():
         deny("blocked-files.txt not found - fail-safe deny")
@@ -651,7 +606,6 @@ def build_context() -> CheckContext:
         command=command,
         blocked_patterns=load_config_lines(blocked_file),
         ask_patterns=load_config_lines(ask_file),
-        allowed_domains=load_config_lines(allowed_urls_file),
     )
 
 

--- a/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
@@ -1,0 +1,86 @@
+{{- if eq .chezmoi.os "windows" -}}
+# Copilot CLI local sandbox 設定 (Windows)
+#
+# Copilot sandbox policy version: 1
+
+$ErrorActionPreference = 'Stop'
+
+$settingsPath = Join-Path $HOME '.copilot\settings.json'
+$settingsDir = Split-Path -Parent $settingsPath
+New-Item -ItemType Directory -Path $settingsDir -Force | Out-Null
+
+if (Test-Path -LiteralPath $settingsPath) {
+  try {
+    $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+  } catch {
+    Write-Error "Failed to parse $settingsPath as JSON. Configure Copilot sandbox manually or remove JSONC comments before chezmoi apply."
+    exit 1
+  }
+} else {
+  $settings = [pscustomobject]@{}
+}
+
+function Set-JsonProperty {
+  param(
+    [Parameter(Mandatory = $true)] [object] $Object,
+    [Parameter(Mandatory = $true)] [string] $Name,
+    [Parameter(Mandatory = $true)] $Value
+  )
+
+  if ($Object.PSObject.Properties[$Name]) {
+    $Object.$Name = $Value
+  } else {
+    Add-Member -InputObject $Object -NotePropertyName $Name -NotePropertyValue $Value
+  }
+}
+
+function Get-JsonArrayOrEmpty {
+  param($Value)
+  if ($null -eq $Value) { return ,@() }
+  return ,@($Value)
+}
+
+function Get-JsonProperty {
+  param(
+    $Object,
+    [Parameter(Mandatory = $true)] [string] $Name
+  )
+
+  if ($null -eq $Object) { return $null }
+  $prop = $Object.PSObject.Properties[$Name]
+  if ($null -eq $prop) { return $null }
+  return $prop.Value
+}
+
+$existingSandbox = Get-JsonProperty -Object $settings -Name 'sandbox'
+$existingPolicy = Get-JsonProperty -Object $existingSandbox -Name 'userPolicy'
+$existingFilesystem = Get-JsonProperty -Object $existingPolicy -Name 'filesystem'
+$existingNetwork = Get-JsonProperty -Object $existingPolicy -Name 'network'
+
+$sandbox = if ($null -ne $existingSandbox) { $existingSandbox } else { [pscustomobject]@{} }
+$userPolicy = if ($null -ne $existingPolicy) { $existingPolicy } else { [pscustomobject]@{} }
+$filesystem = if ($null -ne $existingFilesystem) { $existingFilesystem } else { [pscustomobject]@{} }
+$network = if ($null -ne $existingNetwork) { $existingNetwork } else { [pscustomobject]@{} }
+
+Set-JsonProperty -Object $filesystem -Name 'readwritePaths' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingFilesystem -Name 'readwritePaths'))
+Set-JsonProperty -Object $filesystem -Name 'readonlyPaths' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingFilesystem -Name 'readonlyPaths'))
+Set-JsonProperty -Object $filesystem -Name 'deniedPaths' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingFilesystem -Name 'deniedPaths'))
+Set-JsonProperty -Object $filesystem -Name 'clearPolicyOnExit' -Value $false
+
+Set-JsonProperty -Object $network -Name 'allowOutbound' -Value $false
+Set-JsonProperty -Object $network -Name 'allowLocalNetwork' -Value $true
+Set-JsonProperty -Object $network -Name 'allowedHosts' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingNetwork -Name 'allowedHosts'))
+Set-JsonProperty -Object $network -Name 'blockedHosts' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingNetwork -Name 'blockedHosts'))
+
+Set-JsonProperty -Object $userPolicy -Name 'filesystem' -Value $filesystem
+Set-JsonProperty -Object $userPolicy -Name 'network' -Value $network
+Set-JsonProperty -Object $sandbox -Name 'enabled' -Value $true
+Set-JsonProperty -Object $sandbox -Name 'sandboxMcpServers' -Value $false
+Set-JsonProperty -Object $sandbox -Name 'sandboxLspServers' -Value $false
+Set-JsonProperty -Object $sandbox -Name 'addCurrentWorkingDirectory' -Value $false
+Set-JsonProperty -Object $sandbox -Name 'userPolicy' -Value $userPolicy
+
+Set-JsonProperty -Object $settings -Name 'sandbox' -Value $sandbox
+$settings | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+Write-Host "Configured Copilot CLI local sandbox in $settingsPath"
+{{- end -}}

--- a/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
@@ -1,0 +1,58 @@
+{{- if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+# Copilot CLI local sandbox 設定 (Linux/macOS)
+#
+# Copilot sandbox policy version: 1
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo 'jq not found on PATH; cannot configure Copilot sandbox settings.' >&2
+  exit 1
+fi
+
+settings_path="${HOME}/.copilot/settings.json"
+settings_dir="$(dirname "${settings_path}")"
+mkdir -p "${settings_dir}"
+
+tmp="$(mktemp)"
+empty_input="${tmp}.empty"
+trap 'rm -f "${tmp}" "${empty_input}"' EXIT
+
+if [ -f "${settings_path}" ]; then
+  input_path="${settings_path}"
+else
+  input_path="${empty_input}"
+  printf '{}\n' >"${input_path}"
+fi
+
+jq '
+  .sandbox = (
+    (.sandbox // {})
+    | .enabled = true
+    | .sandboxMcpServers = false
+    | .sandboxLspServers = false
+    | .addCurrentWorkingDirectory = false
+    | .userPolicy = (
+      (.userPolicy // {})
+      | .filesystem = (
+        (.filesystem // {})
+        | .readwritePaths = (.readwritePaths // [])
+        | .readonlyPaths = (.readonlyPaths // [])
+        | .deniedPaths = (.deniedPaths // [])
+        | .clearPolicyOnExit = false
+      )
+      | .network = (
+        (.network // {})
+        | .allowOutbound = false
+        | .allowLocalNetwork = true
+        | .allowedHosts = (.allowedHosts // [])
+        | .blockedHosts = (.blockedHosts // [])
+      )
+    )
+  )
+' "${input_path}" >"${tmp}"
+
+mv "${tmp}" "${settings_path}"
+echo "Configured Copilot CLI local sandbox in ${settings_path}"
+{{- end -}}

--- a/tests/test_copilot_guard.py
+++ b/tests/test_copilot_guard.py
@@ -29,7 +29,6 @@ def make_ctx(
     command: str = "",
     blocked_patterns: list[str] | None = None,
     ask_patterns: list[str] | None = None,
-    allowed_domains: list[str] | None = None,
 ) -> "copilot_guard.CheckContext":
     return copilot_guard.CheckContext(
         tool_name=tool_name,
@@ -37,7 +36,6 @@ def make_ctx(
         command=command,
         blocked_patterns=blocked_patterns or [],
         ask_patterns=ask_patterns or [],
-        allowed_domains=allowed_domains or [],
     )
 
 
@@ -628,18 +626,6 @@ class CopilotGuardCheckerReturnTypeTests(unittest.TestCase):
         result = copilot_guard.check_env(ctx)
         self.assertIsNone(result)
 
-    def test_check_url_returns_check_result(self) -> None:
-        ctx = make_ctx(
-            tool_name="web_fetch",
-            tool_args={"url": "https://evil.example.com"},
-            allowed_domains=["github.com"],
-        )
-        result = copilot_guard.check_url_allowlist(ctx)
-        self.assertIsNotNone(result)
-        self.assertIsInstance(result, copilot_guard.CheckResult)
-        self.assertEqual(result.decision, "deny")
-
-
 class GitCommitCheckerTests(unittest.TestCase):
     """Tests for the git commit approval checker."""
 
@@ -838,12 +824,12 @@ class LogDenyTests(unittest.TestCase):
         self.assertEqual(entry["path"], "C:\\Users\\me\\.azure\\config")
         self.assertNotIn("command", entry)
 
-    def test_logs_url_for_fetch_tool(self) -> None:
+    def test_logs_url_field_for_fetch_tool(self) -> None:
         ctx = make_ctx(
             tool_name="web_fetch",
             tool_args={"url": "https://pastebin.com/abc"},
         )
-        copilot_guard._log_deny(ctx, "URL not in allowlist")
+        copilot_guard._log_deny(ctx, "test deny")
         entry = self._read_entry()
         self.assertEqual(entry["url"], "https://pastebin.com/abc")
 


### PR DESCRIPTION
## Summary
- Configure Copilot CLI local sandbox network policy via chezmoi run_onchange scripts
- Remove network command and URL allowlist enforcement from guardrails/hooks
- Add ADR-015 and update docs for the sandbox-based scope

## Validation
- `uv run -m unittest discover -s tests -v`
- `git diff --check`
- PowerShell and shell template syntax checks