### PR TITLE
fix: use AppContainer sandbox schema on Windows

### DIFF
--- a/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
+++ b/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
@@ -10,7 +10,7 @@ ADR-010 では preToolUse Hook による URL allowlist を採用した。Copilot
 
 ## Decision
 
-Copilot CLI の shell command network control は local sandbox に移行する。`sandbox.enabled=true`、`userPolicy.network.allowOutbound=false`、`allowLocalNetwork=true` を基本とし、必要な例外は `allowedHosts` / `blockedHosts` で表現する。MCP / LSP / filesystem は sandbox 対象外として `sandboxMcpServers=false`、`sandboxLspServers=false`、`addCurrentWorkingDirectory=false`、`userPolicy.filesystem` は empty / preserved arrays、`clearPolicyOnExit=false` を維持する。sandbox disabled 時の Hook fallback は持たない。
+Copilot CLI の shell command network control は local sandbox に移行する。Windows では AppContainer backend を使うため `userPolicy.version=0.4.0-alpha` を指定する。`sandbox.enabled=true`、`userPolicy.network.allowOutbound=false`、`allowLocalNetwork=true` を基本とし、必要な例外は `allowedHosts` / `blockedHosts` で表現する。MCP / LSP / filesystem は sandbox 対象外として `sandboxMcpServers=false`、`sandboxLspServers=false`、`addCurrentWorkingDirectory=false`、`userPolicy.filesystem` は empty / preserved arrays、`clearPolicyOnExit=false` を維持する。sandbox disabled 時の Hook fallback は持たない。
 
 ## Consequences
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -69,7 +69,7 @@ uv run -m unittest tests.test_copilot_guard -v
 設計上の前提と限界:
 
 - local sandbox は Copilot が起動する shell command の実行環境を制御する。MCP、LSP、Copilot CLI のファイル読み書きツールの sandbox 化はこの repo では設定しない。
-- `run_onchange_after_35-configure-copilot-sandbox.*` は `~/.copilot/settings.json` の他のキーを保ったまま `sandbox` セクションを更新する。`allowOutbound = false`、`allowLocalNetwork = true`、`allowedHosts = []` が初期状態である。ホスト許可は後から `/sandbox` または `settings.json` で追加する。
+- `run_onchange_after_35-configure-copilot-sandbox.*` は `~/.copilot/settings.json` の他のキーを保ったまま `sandbox` セクションを更新する。`userPolicy.version = 0.4.0-alpha`、`allowOutbound = false`、`allowLocalNetwork = true`、`allowedHosts = []` が初期状態である。ホスト許可は後から `/sandbox` または `settings.json` で追加する。
 - `--deny-tool 'memory'` はビルトインに該当ツールが存在しないため no-op（v1.0.49 時点の検証）。
 - `/share gist`（`--share-gist`）は **ユーザー直接コマンドのため preToolUse Hook の対象外**。`--allow-all` 下で秘匿情報がエージェントのコンテキストに入った状態で実行すると、secret Gist として外部化され得る。非 EMU 環境では技術的に防ぐ手段が無いため、運用ルール（実行前に `/reset-allowed-tools` で承認状態をクリアする等）で補う。
 - `permissionRequest` / `notification` / `userPromptSubmitted` 等の Hook タイプは現状未使用。`--allow-all` を外して承認を自動化する運用に切り替える場合の拡張余地として記録しておく。

--- a/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
@@ -74,6 +74,7 @@ Set-JsonProperty -Object $network -Name 'blockedHosts' -Value (Get-JsonArrayOrEm
 
 Set-JsonProperty -Object $userPolicy -Name 'filesystem' -Value $filesystem
 Set-JsonProperty -Object $userPolicy -Name 'network' -Value $network
+Set-JsonProperty -Object $userPolicy -Name 'version' -Value '0.4.0-alpha'
 Set-JsonProperty -Object $sandbox -Name 'enabled' -Value $true
 Set-JsonProperty -Object $sandbox -Name 'sandboxMcpServers' -Value $false
 Set-JsonProperty -Object $sandbox -Name 'sandboxLspServers' -Value $false

--- a/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
@@ -35,6 +35,7 @@ jq '
     | .addCurrentWorkingDirectory = false
     | .userPolicy = (
       (.userPolicy // {})
+      | .version = "0.4.0-alpha"
       | .filesystem = (
         (.filesystem // {})
         | .readwritePaths = (.readwritePaths // [])


### PR DESCRIPTION
## Summary
- Set `sandbox.userPolicy.version` to `0.4.0-alpha` so Windows can use the AppContainer fallback
- Document the schema version in ADR-015 and the Copilot CLI guide

## Validation
- `uv run -m unittest discover -s tests -v`
- `git diff --check origin/main...HEAD`
- PowerShell and shell template syntax checks were run before cherry-picking this fix