### PR TITLE
fix: keep copilot sandbox non-blocking

### DIFF
--- a/docs/adr/010-url-allowlist-via-pretooluse-hook.md
+++ b/docs/adr/010-url-allowlist-via-pretooluse-hook.md
@@ -4,9 +4,11 @@
 
 Superseded by ADR-015
 
+ADR-015 により、本 ADR の URL allowlist Hook とネットワーク系 `--deny-tool` 補助列挙は撤去した。これらは Hook の fail-open、Hook が発火しない経路、コマンド名や URL 文字列検査の抜け道により、shell network control の境界として維持しない。
+
 ## Context
 
-Copilot CLI v1.0.35-4 / v1.0.49 時点の実機検証で、CLI 単体では「listed 以外 deny」型の URL ホワイトリスト制御が実現できないことを確認した。`--deny-url='*'` や `--deny-url='https://*'` の wildcard 単独指定はヒットせず、機能するのは個別 domain（例 `example.com`）または prefix（`https://example.com/*`）のみ。さらに `--allow-all`（`--allow-all-urls` を含む）下では `--deny-url` / `--allow-url` 自体が無効化される。`~/.copilot/config.json` の `deniedUrls` も同様で、加えて単独ワイルドカード `"*"` は設定ファイル側で非対応、リポジトリレベル設定（`.github/copilot/settings.json`）では `deniedUrls` / `allowedUrls` キー自体がサポートされない。`copilot --autopilot` のような Autopilot 運用や `--allow-all` 系オプションを伴う運用では、包括的ホワイトリスト方式は Hook でしか実現できない（`--deny-tool 'url(...)'` は `--allow-all` 下でも優先されるが、個別列挙のため包括制御には向かない）。
+Copilot CLI v1.0.35-4 / v1.0.49 時点の実機検証で、CLI 単体では「listed 以外 deny」型の URL ホワイトリスト制御が実現できないことを確認した。`--deny-url='*'` や `--deny-url='https://*'` の wildcard 単独指定はヒットせず、機能するのは個別 domain（例 `example.com`）または prefix（`https://example.com/*`）のみ。さらに `--allow-all`（`--allow-all-urls` を含む）下では `--deny-url` / `--allow-url` 自体が無効化される。`~/.copilot/config.json` の `deniedUrls` も同様で、加えて単独ワイルドカード `"*"` は設定ファイル側で非対応、リポジトリレベル設定（`.github/copilot/settings.json`）では `deniedUrls` / `allowedUrls` キー自体がサポートされない。当時は Hook で包括的ホワイトリスト方式を実装したが、ADR-015 でこの方式を撤去した。
 
 ## Decision
 
@@ -14,8 +16,8 @@ URL の包括的ホワイトリスト制御は preToolUse Hook の `check_url_al
 
 ## Consequences
 
-- Hook は fail-open（exit 1 / 不正 JSON / timeout / 空出力で通過）なため、allowlist は「うっかり外部アクセス防止」レベルの保険で完全隔離ではない
-- サブエージェント経路は Hook 未発火。危険 URL は CLI `--deny-url` で個別列挙が必須
-- 判断の前提は CLI v1.0.35-4 の挙動。アップグレード時に再検証、CLI が wildcard `--deny-url='*'` をサポートしたら allowlist 簡素化／撤去を検討する（`review-repo` の定期チェック対象）
-- 現時点では `allowed-urls.txt` は空（全行コメントアウト）で URL 制御は適用していない。本 ADR は将来ブロック対象が発生した際の実装先を定めるもの
+- Hook は fail-open（exit 1 / 不正 JSON / timeout / 空出力で通過）なため、allowlist は shell network control の境界にならない
+- Hook が発火しない経路やコマンド名検査の抜け道が残るため、URL allowlist Hook とネットワーク系 `--deny-tool` 補助列挙は復活させない
+- 判断の前提は CLI v1.0.35-4 の挙動。アップグレード時に再検証し、shell network control の見直しは ADR-015 の sandbox policy 側で扱う
+- 現時点では `allowed-urls.txt` は削除済みで URL 制御は適用していない。将来ブロック対象が発生した場合も、URL 文字列検査ではなく ADR-015 の sandbox policy で扱う
 - 検証ログ: セッション 978f18e4-1610-4819-98be-6620c6d68271（A1/A15）

--- a/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
+++ b/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
@@ -6,16 +6,21 @@ Accepted
 
 ## Context
 
-ADR-010 では preToolUse Hook による URL allowlist を採用した。Copilot CLI の設定 schema で local sandbox が確認でき、shell command の外向きネットワーク制御を CLI 側に移せる。対象は shell command の network control のみで、MCP / LSP / filesystem sandboxing は別判断とする。
+ADR-010 では preToolUse Hook による URL allowlist を採用した。しかし、Hook の fail-open、Hook が発火しない経路、コマンド名や URL 文字列検査の抜け道により、shell network control の境界としては維持しない。Copilot CLI の設定 schema で local sandbox が確認でき、shell command の外向きネットワーク制御を CLI 側に移せる見込みがある。対象は shell command の network control のみで、MCP / LSP / filesystem sandboxing は別判断とする。
 
 ## Decision
 
-Copilot CLI の shell command network control は local sandbox に移行する。Windows では AppContainer backend を使うため `userPolicy.version=0.4.0-alpha` を指定する。`sandbox.enabled=true`、`userPolicy.network.allowOutbound=false`、`allowLocalNetwork=true` を基本とし、必要な例外は `allowedHosts` / `blockedHosts` で表現する。MCP / LSP / filesystem は sandbox 対象外として `sandboxMcpServers=false`、`sandboxLspServers=false`、`addCurrentWorkingDirectory=false`、`userPolicy.filesystem` は empty / preserved arrays、`clearPolicyOnExit=false` を維持する。sandbox disabled 時の Hook fallback は持たない。
+Copilot CLI の shell command network control は local sandbox に移行する。ただし、現時点では sandbox を有効化するだけにとどめ、外向き通信の遮断や host rule は設定しない。`sandbox.enabled=true`、`userPolicy.network.allowOutbound=true`、`allowLocalNetwork=true`、`allowedHosts=[]`、`blockedHosts=[]` を基本とし、local sandbox が成熟した段階で遮断対象を増やす。MCP / LSP / filesystem は sandbox 対象外として `sandboxMcpServers=false`、`sandboxLspServers=false`、`addCurrentWorkingDirectory=false`、`userPolicy.filesystem` は empty / preserved arrays、`clearPolicyOnExit=false` を維持する。sandbox disabled 時の Hook fallback は持たない。
+
+## Tracking
+
+- GitHub Copilot CLI の local sandbox の現状と改善状況は [github/copilot-cli#3861](https://github.com/github/copilot-cli/issues/3861) で追跡する。
 
 ## Consequences
 
 - ADR-010 の URL allowlist Hook 方針を置き換える
-- ネットワーク遮断は URL 文字列検査ではなく sandbox policy に委ねる
+- ネットワーク遮断は URL 文字列検査ではなく sandbox policy に委ねるが、現時点では遮断設定を投入しない
+- URL allowlist Hook とネットワーク系 `--deny-tool` 補助列挙は、抜け道により形骸化しやすいため復活させない
 - MCP / LSP / filesystem の隔離は本 ADR では保証しない
-- `allowLocalNetwork=true` のため localhost / link-local は許可する。必要なら metadata endpoint 等を `blockedHosts` に追加する
-- sandbox を無効化した運用では shell network 制御も無効になる
+- 旧設定の残留で外向き通信が遮断されないよう、管理対象の host rule は空にする
+- shell network control は sandbox policy に集約するため、Hook や `--deny-tool` による fallback は持たない

--- a/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
+++ b/docs/adr/015-copilot-cli-shell-network-via-local-sandbox.md
@@ -10,7 +10,7 @@ ADR-010 では preToolUse Hook による URL allowlist を採用した。Copilot
 
 ## Decision
 
-Copilot CLI の shell command network control は local sandbox に移行する。`sandbox.enabled=true`、`userPolicy.network.allowOutbound=false`、`allowLocalNetwork=true` を基本とし、必要な例外は `allowedHosts` / `blockedHosts` で表現する。MCP / LSP / filesystem は sandbox 対象外として `sandboxMcpServers=false`、`sandboxLspServers=false`、`addCurrentWorkingDirectory=false`、`userPolicy.filesystem` は empty / preserved arrays、`clearPolicyOnExit=false` を維持する。sandbox disabled 時の Hook fallback は持たない。
+Copilot CLI の shell command network control は local sandbox に移行する。Windows では AppContainer backend を使うため `userPolicy.version=0.4.0-alpha` を指定する。`sandbox.enabled=true`、`userPolicy.network.allowOutbound=false`、`allowLocalNetwork=true` を基本とし、必要な例外は `allowedHosts` / `blockedHosts` で表現する。MCP / LSP / filesystem は sandbox 対象外として `sandboxMcpServers=false`、`sandboxLspServers=false`、`addCurrentWorkingDirectory=false`、`userPolicy.filesystem` は empty / preserved arrays、`clearPolicyOnExit=false` を維持する。sandbox disabled 時の Hook fallback は持たない。
 
 ## Consequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 - 設定配布 `chezmoi` / ツール版管理 `mise` / Python 実行 `uv`
 - Git の環境差分は `includeIf`、コミット署名は 1Password SSH エージェント（コンテナ系は自動無効化）
 - `copilot-guard.py` / `uv-enforcer.py` / `node-global-enforcer.py` でネットワーク以外の危険操作を抑止、`postToolUse` で監査ログ
-- Copilot CLI local sandbox で shell command の外部ネットワーク通信を制御
+- Copilot CLI local sandbox を有効化
 - `copilot-guardrails` で利便性と秘匿環境変数の扱いを固定
 - `gitleaks` 付き pre-commit を配布
 
@@ -41,7 +41,7 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 
 パス比較前に `\` を `/` へ正規化する。パターンファイルは `/` 前提で書く。
 
-shell command の外部ネットワーク通信は `~/.copilot/settings.json` の `sandbox.userPolicy.network` で制御する。初期状態では `allowOutbound = false` とし、必要なホストは後から `allowedHosts` に追加する。
+shell command の外部ネットワーク通信は、`~/.copilot/settings.json` の `sandbox.userPolicy.network` で設定する。初期状態では sandbox を有効化するだけにとどめ、外向き通信の遮断や host rule は設定しない。
 
 ## git pre-commit フック
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -69,7 +69,7 @@ uv run -m unittest tests.test_copilot_guard -v
 設計上の前提と限界:
 
 - local sandbox は Copilot が起動する shell command の実行環境を制御する。MCP、LSP、Copilot CLI のファイル読み書きツールの sandbox 化はこの repo では設定しない。
-- `run_onchange_after_35-configure-copilot-sandbox.*` は `~/.copilot/settings.json` の他のキーを保ったまま `sandbox` セクションを更新する。`allowOutbound = false`、`allowLocalNetwork = true`、`allowedHosts = []` が初期状態である。ホスト許可は後から `/sandbox` または `settings.json` で追加する。
+- `run_onchange_after_35-configure-copilot-sandbox.*` は `~/.copilot/settings.json` の他のキーを保ったまま `sandbox` セクションを更新する。`userPolicy.version = 0.4.0-alpha`、`allowOutbound = false`、`allowLocalNetwork = true`、`allowedHosts = []` が初期状態である。ホスト許可は後から `/sandbox` または `settings.json` で追加する。
 - `--deny-tool 'memory'` はビルトインに該当ツールが存在しないため no-op（v1.0.49 時点の検証）。
 - `/share gist`（`--share-gist`）は **ユーザー直接コマンドのため preToolUse Hook の対象外**。`--allow-all` 下で秘匿情報がエージェントのコンテキストに入った状態で実行すると、secret Gist として外部化され得る。非 EMU 環境では技術的に防ぐ手段が無いため、運用ルール（実行前に `/reset-allowed-tools` で承認状態をクリアする等）で補う。
 - `permissionRequest` / `notification` / `userPromptSubmitted` 等の Hook タイプは現状未使用。`--allow-all` を外して承認を自動化する運用に切り替える場合の拡張余地として記録しておく。

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -53,7 +53,7 @@ GitHub Docs の Agent Finder 手順に従い、`home/private_dot_copilot/skills/
 
 パターンファイルは 1 行 1 パターン、`#` でコメント。パス比較は `\` → `/` に正規化、`deny > ask > allow`。
 
-`copilot-guard.py` の `blocked-files.txt` チェックは `view` / `edit` 系ツールだけでなく **`bash`/`powershell` ツール内の `cat` / `Get-Content` 等のシェル経由参照にも適用される**。これは CLI 本体のパス検出が shell コマンド内に埋め込まれたパスを十分に追えない（公式ドキュメントの "Path detection for shell commands has limitations" 記載）穴を Hook で塞ぐ意図的な設計である。shell command のネットワーク制御は ADR-015 に従い local sandbox で扱う。
+`copilot-guard.py` の `blocked-files.txt` チェックは `view` / `edit` 系ツールだけでなく **`bash`/`powershell` ツール内の `cat` / `Get-Content` 等のシェル経由参照にも適用される**。これは CLI 本体のパス検出が shell コマンド内に埋め込まれたパスを十分に追えない（公式ドキュメントの "Path detection for shell commands has limitations" 記載）穴を Hook で塞ぐ意図的な設計である。
 
 動作確認:
 
@@ -64,12 +64,12 @@ uv run -m unittest tests.test_copilot_guard -v
 
 ## `copilot-guardrails`
 
-`.zshrc` / `PowerShell_profile.ps1` の `copilot-guardrails` は、Copilot CLI の利便性（`--allow-all`）と `--secret-env-vars` による環境変数隠蔽を固定する起動ラッパー。shell command の外部ネットワーク通信は local sandbox の `sandbox.userPolicy.network` で制御する。起動モード（interactive / plan / autopilot）は固定しない。
+`.zshrc` / `PowerShell_profile.ps1` の `copilot-guardrails` は、Copilot CLI の利便性（`--allow-all`）と `--secret-env-vars` による環境変数隠蔽を固定する起動ラッパー。起動モード（interactive / plan / autopilot）は固定しない。
 
 設計上の前提と限界:
 
 - local sandbox は Copilot が起動する shell command の実行環境を制御する。MCP、LSP、Copilot CLI のファイル読み書きツールの sandbox 化はこの repo では設定しない。
-- `run_onchange_after_35-configure-copilot-sandbox.*` は `~/.copilot/settings.json` の他のキーを保ったまま `sandbox` セクションを更新する。`userPolicy.version = 0.4.0-alpha`、`allowOutbound = false`、`allowLocalNetwork = true`、`allowedHosts = []` が初期状態である。ホスト許可は後から `/sandbox` または `settings.json` で追加する。
+- `run_onchange_after_35-configure-copilot-sandbox.*` は `~/.copilot/settings.json` の他のキーを保ったまま `sandbox` セクションを更新する。初期状態では sandbox を有効化するだけにとどめ、`allowOutbound = true`、`allowLocalNetwork = true`、`allowedHosts = []`、`blockedHosts = []` に正規化する。
 - `--deny-tool 'memory'` はビルトインに該当ツールが存在しないため no-op（v1.0.49 時点の検証）。
 - `/share gist`（`--share-gist`）は **ユーザー直接コマンドのため preToolUse Hook の対象外**。`--allow-all` 下で秘匿情報がエージェントのコンテキストに入った状態で実行すると、secret Gist として外部化され得る。非 EMU 環境では技術的に防ぐ手段が無いため、運用ルール（実行前に `/reset-allowed-tools` で承認状態をクリアする等）で補う。
 - `permissionRequest` / `notification` / `userPromptSubmitted` 等の Hook タイプは現状未使用。`--allow-all` を外して承認を自動化する運用に切り替える場合の拡張余地として記録しておく。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,7 +105,6 @@ Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin
 対策 (本リポジトリで適用済み):
 
 - `home/private_dot_copilot/hooks/hooks.json` の `timeoutSec` を preToolUse 30 秒 / postToolUse 15 秒に設定し、キューが長くなっても fail-open に落ちにくくする
-- shell command の外部ネットワーク通信は Hook ではなく Copilot CLI local sandbox で制御する
 - 上流の挙動変更を追跡する (`github/copilot-cli` の issue)
 
 暫定回避:

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -180,8 +180,8 @@ Set-Alias -Name k -Value kubectl
 Set-Alias -Name mise-self-upgrade -Value Invoke-MiseSelfUpgrade
 Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
 
-# Copilot CLI: local sandbox handles shell network access. preToolUse hooks
-# still protect sensitive files and shell-level secret reads.
+# Copilot CLI: local sandbox is enabled. preToolUse hooks still protect
+# sensitive files and shell-level secret reads.
 function Invoke-CopilotGuardrails {
     copilot `
       --allow-all `

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -100,8 +100,8 @@ command -v mise >/dev/null && source <(mise activate zsh)
 alias k=kubectl
 alias ll='ls -ahl'
 
-# Copilot CLI: local sandbox handles shell network access. preToolUse hooks
-# still protect sensitive files and shell-level secret reads.
+# Copilot CLI: local sandbox is enabled. preToolUse hooks still protect
+# sensitive files and shell-level secret reads.
 alias copilot-guardrails='copilot \
   --allow-all \
   --secret-env-vars "AZURE_CLIENT_SECRET,ARM_CLIENT_SECRET,ARM_ACCESS_KEY,AZURE_STORAGE_CONNECTION_STRING"'

--- a/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
@@ -74,6 +74,7 @@ Set-JsonProperty -Object $network -Name 'blockedHosts' -Value (Get-JsonArrayOrEm
 
 Set-JsonProperty -Object $userPolicy -Name 'filesystem' -Value $filesystem
 Set-JsonProperty -Object $userPolicy -Name 'network' -Value $network
+Set-JsonProperty -Object $userPolicy -Name 'version' -Value '0.4.0-alpha'
 Set-JsonProperty -Object $sandbox -Name 'enabled' -Value $true
 Set-JsonProperty -Object $sandbox -Name 'sandboxMcpServers' -Value $false
 Set-JsonProperty -Object $sandbox -Name 'sandboxLspServers' -Value $false

--- a/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.ps1.tmpl
@@ -1,7 +1,7 @@
 {{- if eq .chezmoi.os "windows" -}}
 # Copilot CLI local sandbox 設定 (Windows)
 #
-# Copilot sandbox policy version: 1
+# Copilot sandbox policy version: 2
 
 $ErrorActionPreference = 'Stop'
 
@@ -52,6 +52,17 @@ function Get-JsonProperty {
   return $prop.Value
 }
 
+function Remove-JsonProperty {
+  param(
+    $Object,
+    [Parameter(Mandatory = $true)] [string] $Name
+  )
+
+  if ($null -ne $Object -and $Object.PSObject.Properties[$Name]) {
+    $Object.PSObject.Properties.Remove($Name)
+  }
+}
+
 $existingSandbox = Get-JsonProperty -Object $settings -Name 'sandbox'
 $existingPolicy = Get-JsonProperty -Object $existingSandbox -Name 'userPolicy'
 $existingFilesystem = Get-JsonProperty -Object $existingPolicy -Name 'filesystem'
@@ -67,14 +78,14 @@ Set-JsonProperty -Object $filesystem -Name 'readonlyPaths' -Value (Get-JsonArray
 Set-JsonProperty -Object $filesystem -Name 'deniedPaths' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingFilesystem -Name 'deniedPaths'))
 Set-JsonProperty -Object $filesystem -Name 'clearPolicyOnExit' -Value $false
 
-Set-JsonProperty -Object $network -Name 'allowOutbound' -Value $false
+Set-JsonProperty -Object $network -Name 'allowOutbound' -Value $true
 Set-JsonProperty -Object $network -Name 'allowLocalNetwork' -Value $true
-Set-JsonProperty -Object $network -Name 'allowedHosts' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingNetwork -Name 'allowedHosts'))
-Set-JsonProperty -Object $network -Name 'blockedHosts' -Value (Get-JsonArrayOrEmpty (Get-JsonProperty -Object $existingNetwork -Name 'blockedHosts'))
+Set-JsonProperty -Object $network -Name 'allowedHosts' -Value @()
+Set-JsonProperty -Object $network -Name 'blockedHosts' -Value @()
 
 Set-JsonProperty -Object $userPolicy -Name 'filesystem' -Value $filesystem
 Set-JsonProperty -Object $userPolicy -Name 'network' -Value $network
-Set-JsonProperty -Object $userPolicy -Name 'version' -Value '0.4.0-alpha'
+Remove-JsonProperty -Object $userPolicy -Name 'version'
 Set-JsonProperty -Object $sandbox -Name 'enabled' -Value $true
 Set-JsonProperty -Object $sandbox -Name 'sandboxMcpServers' -Value $false
 Set-JsonProperty -Object $sandbox -Name 'sandboxLspServers' -Value $false

--- a/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
@@ -35,6 +35,7 @@ jq '
     | .addCurrentWorkingDirectory = false
     | .userPolicy = (
       (.userPolicy // {})
+      | .version = "0.4.0-alpha"
       | .filesystem = (
         (.filesystem // {})
         | .readwritePaths = (.readwritePaths // [])

--- a/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
+++ b/home/run_onchange_after_35-configure-copilot-sandbox.sh.tmpl
@@ -2,7 +2,7 @@
 #!/usr/bin/env bash
 # Copilot CLI local sandbox 設定 (Linux/macOS)
 #
-# Copilot sandbox policy version: 1
+# Copilot sandbox policy version: 2
 
 set -euo pipefail
 
@@ -35,7 +35,7 @@ jq '
     | .addCurrentWorkingDirectory = false
     | .userPolicy = (
       (.userPolicy // {})
-      | .version = "0.4.0-alpha"
+      | del(.version)
       | .filesystem = (
         (.filesystem // {})
         | .readwritePaths = (.readwritePaths // [])
@@ -45,10 +45,10 @@ jq '
       )
       | .network = (
         (.network // {})
-        | .allowOutbound = false
+        | .allowOutbound = true
         | .allowLocalNetwork = true
-        | .allowedHosts = (.allowedHosts // [])
-        | .blockedHosts = (.blockedHosts // [])
+        | .allowedHosts = []
+        | .blockedHosts = []
       )
     )
   )


### PR DESCRIPTION
## Summary
- keep Copilot CLI local sandbox enabled while leaving outbound network unblocked
- remove the AppContainer schema workaround and clear managed host rules
- keep the rationale for removed network deny-tool and URL allowlist controls in ADRs only

## Validation
- `uv run -m unittest discover -s tests -v`
- `bash -n` on the sandbox shell template body
- PowerShell parser check on the sandbox PowerShell template body