### PR TITLE
fix(mise): manage Rust via external rustup on all platforms

### DIFF
--- a/docs/adr/009-mise-rust-windows-isolate-home.md
+++ b/docs/adr/009-mise-rust-windows-isolate-home.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-016
 
 ## Context
 
@@ -23,3 +23,5 @@ PATH 追加は行わない。Windows では `run_once_after_05-setup-mise-shims-
 - Windows で mise install の symlink 衝突が消え、pre-commit / `uv run` の安定化につながる
 - Windows 上で「mise が管理する rust」と「外部 rustup が管理する rust」が別 toolchain になる。`cargo install` の成果物も別パスになるため、直接 `%USERPROFILE%\.cargo\bin` を叩いていた利用者は移行が必要
 - Linux/macOS は変更なし。全 OS 一律の分離方針を取らないのは、shim exclude (ADR-003) のレイヤでは救えない Windows 固有問題であり、他 OS の既存 UX を壊す必要がないため
+
+本 ADR は ADR-016 により置換された。rust を全 OS で mise 管理から除外し外部 rustup に一本化したため、本 ADR が対処していた mise/rustup home 分離は不要になった。

--- a/docs/adr/016-rust-external-rustup.md
+++ b/docs/adr/016-rust-external-rustup.md
@@ -1,0 +1,26 @@
+# ADR-016: Rust は全 OS で外部 rustup 管理とする (mise 管理から除外)
+
+## Status
+
+Accepted
+
+## Context
+
+mise の rust shim は呼び出し時に `RUSTUP_TOOLCHAIN` 環境変数を強制注入する。rustup のトゥールチェイン優先順位は「環境変数 > rust-toolchain.toml > default」のため、mise 経由の cargo/rustc はプロジェクトの `rust-toolchain.toml` を常に無視して上書きしてしまう（実機確認: `rustup show` が `active because: overridden by environment variable RUSTUP_TOOLCHAIN` と明言）。
+
+これは特定プロジェクト固有ではなく、`rust-toolchain.toml` を使う全プロジェクトに共通する構造的問題であり、mise で `rust = "latest"` を管理する限り解消できない。
+
+ADR-009 は Windows 限定で「外部 rustup が既に存在する」ことを前提にした設計（mise の rust home を分離）を採用しており、この非対称性を既に部分的に前提としていた。
+
+## Decision
+
+全 OS (macOS/Linux/Windows) で `home/dot_config/mise/config.toml.tmpl` の `[tools]` から `rust` を除外する。rust toolchain の解決は公式 rustup + `rust-toolchain.toml` のネイティブ解決に一本化する。
+
+導入は macOS/Linux では公式インストールスクリプト (`https://sh.rustup.rs`, `command -v rustup` が無い場合のみ) で、Windows では winget (`Rustlang.Rustup`) で行う。
+
+## Consequences
+
+- `rust-toolchain.toml` を持つプロジェクトのバージョン固定が正しく機能するようになる
+- mise lockfile が rust バージョンを追跡しなくなる。更新は `rustup update` / `rustup default` で個別管理する
+- ADR-009 が対処していた Windows 固有の mise/rustup home 分離の複雑さが不要になる（ADR-009 は本 ADR により Superseded）
+- 新規マシンでは rustup のインストールタイミングが `run_once_before_10` (mise install より前) になる

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -21,13 +21,14 @@
 | [006](006-pretooluse-hook-no-allow.md) | Copilot CLI preToolUse フックは allow を出力しない | Accepted |
 | [007](007-python-with-uv-and-pep723.md) | Python スクリプトは uv run + PEP 723 で実行する | Accepted |
 | [008](008-zshenv-sources-profile.md) | ~/.zshenv は ~/.profile を source する | Accepted |
-| [009](009-mise-rust-windows-isolate-home.md) | Windows では mise の rust home を外部 rustup から分離する | Accepted |
+| [009](009-mise-rust-windows-isolate-home.md) | Windows では mise の rust home を外部 rustup から分離する | Superseded by ADR-016 |
 | [010](010-url-allowlist-via-pretooluse-hook.md) | Copilot CLI の URL 包括制御は preToolUse Hook で行う | Superseded by ADR-015 |
 | [011](011-edit-windows-via-winget-dsc.md) | Microsoft Edit は Windows のみ winget/DSC で管理する | Accepted |
 | [012](012-wsl-op-ssh-sign-crlf-wrapper.md) | WSL では op-ssh-sign-wsl.exe を CR 除去ラッパー経由で呼ぶ | Accepted |
 | [013](013-mise-lockfile-sync-hook.md) | mise lockfile 変更時に install / reshim を自動同期する | Accepted |
 | [014](014-github-multi-account-https-auth-per-owner.md) | GitHub 多アカウント HTTPS 認証は credential の URL パス方式 + gh auth token --user で解決する | Accepted |
 | [015](015-copilot-cli-shell-network-via-local-sandbox.md) | Copilot CLI shell のネットワーク制御は local sandbox で行う | Accepted |
+| [016](016-rust-external-rustup.md) | Rust は全 OS で外部 rustup 管理とする (mise 管理から除外) | Accepted |
 
 ## テンプレート
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,7 +27,7 @@ mise install
 
 ## shell 起動時に `mise WARN missing:` が出る
 
-`mise upgrade` 等で `private_mise.lock` が更新された後、対応する `mise install` / `mise reshim` が走っていないと shim と install marker が古いまま残り、`mise hook-env` で `WARN missing:` が出る。Windows では rustup の `info: syncing channel updates ...` も併発する。
+`mise upgrade` 等で `private_mise.lock` が更新された後、対応する `mise install` / `mise reshim` が走っていないと shim と install marker が古いまま残り、`mise hook-env` で `WARN missing:` が出る。
 
 通常は `chezmoi apply` で `run_onchange_after_15-mise-sync-tools` フック（[ADR-013](adr/013-mise-lockfile-sync-hook.md)）が自動で同期する。手動で `mise uninstall` した等のケースで残った場合は次を実行する。
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -24,7 +24,6 @@ bat = "latest"
 shellcheck = "latest"
 gitleaks = "latest"
 jq = "latest"
-rust = "latest"
 bun = "latest"
 "npm:typescript" = "latest"
 "npm:typescript-language-server" = "latest"
@@ -47,13 +46,3 @@ fetch_remote_versions_timeout = "60s"
 # 定期チェック対象: mise がスラッシュ入りタグの検証に対応したら本設定を撤去する。
 use_versions_host = false
 
-{{ if eq .chezmoi.os "windows" -}}
-# Windows 限定: mise が rust install 時に `~/.cargo/bin` へ symlink を張る処理は
-# 既存ディレクトリ（外部 rustup が管理する実体）と衝突し os error 183 で失敗する。
-# mise 専用の cargo/rustup home を `%LOCALAPPDATA%\mise\rust\` 配下に分離し、
-# 外部 rustup と共存させる。PATH は shims 経由のままで良いので追加調整は不要。
-# 詳細: docs/adr/009-mise-rust-windows-isolate-home.md
-[settings.rust]
-cargo_home = '{{ .chezmoi.homeDir }}/AppData/Local/mise/rust/cargo'
-rustup_home = '{{ .chezmoi.homeDir }}/AppData/Local/mise/rust/rustup'
-{{ end -}}

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -94,4 +94,11 @@ brew install \
 brew install --cask libreoffice
 
 {{ end -}}
+
+# Rust — rust-toolchain.toml を持つプロジェクトでの version pinning を機能させるため、
+# mise ではなく公式インストーラー (rustup) で管理する。詳細: docs/adr/016-rust-external-rustup.md
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "Installing Rust via rustup (official installer)..."
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+fi
 {{ end -}}

--- a/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
@@ -5,16 +5,13 @@
 #   `mise upgrade` 等で `~/.config/mise/private_mise.lock` が更新されても、
 #   ローカルの `mise install` / `mise reshim` は自動で走らない。結果として shim と
 #   install marker が古いまま残り、PowerShell 起動時の `_mise_hook` (`mise hook-env`)
-#   で `mise WARN missing:` が発生する。Windows ではさらに `installs\rust\<ver>` が
-#   `cargo\bin` への junction として作られているため、shim が一度欠落すると `MISE_AUTO_INSTALL`
-#   による自動 install が走り、rustup の `info: syncing channel updates ...` が起動の度に表示される。
+#   で `mise WARN missing:` が発生する。
 #
 # 対応:
 #   lockfile の hash 変化を chezmoi の run_onchange でフックし、`mise install` と
 #   `mise reshim` を流して install marker と shim を lockfile と同期させる。
 #
 # 関連:
-#   - docs/adr/009-mise-rust-windows-isolate-home.md (cargo_home/rustup_home の分離)
 #   - docs/adr/013-mise-lockfile-sync-hook.md (本フックの設計判断)
 #
 # mise lockfile hash: {{ include "dot_config/mise/private_mise.lock" | sha256sum }}
@@ -43,6 +40,16 @@ $reshimExit = $LASTEXITCODE
 if ($installExit -ne 0 -or $reshimExit -ne 0) {
   Write-Warning ("mise sync finished with non-zero exit codes (install={0}, reshim={1}). " +
     "次回 chezmoi apply 時に再試行されるため、原因を確認してください。" -f $installExit, $reshimExit)
+}
+
+# corepack (pnpm/yarn 提供) を有効化する。mise 管理 node に同梱されており、
+# 未実行だと `pnpm` コマンドが解決できない。冪等なため無条件に実行してよい。
+$corepackCmd = Get-Command -Name 'corepack' -ErrorAction SilentlyContinue
+if ($corepackCmd) {
+  & $corepackCmd.Source enable
+  if ($LASTEXITCODE -ne 0) {
+    Write-Warning 'corepack enable failed.'
+  }
 }
 
 exit 0

--- a/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
@@ -34,5 +34,11 @@ if [ "$install_exit" -ne 0 ] || [ "$reshim_exit" -ne 0 ]; then
   echo '     次回 chezmoi apply 時に再試行されます。原因を確認してください。' >&2
 fi
 
+# corepack (pnpm/yarn 提供) を有効化する。mise 管理 node に同梱されており、
+# 未実行だと `pnpm` コマンドが解決できない。冪等なため無条件に実行してよい。
+if command -v corepack >/dev/null 2>&1; then
+  corepack enable || echo 'WARN: corepack enable failed.' >&2
+fi
+
 exit 0
 {{- end -}}

--- a/home/run_onchange_after_21-link-mise-shims.sh.tmpl
+++ b/home/run_onchange_after_21-link-mise-shims.sh.tmpl
@@ -38,15 +38,14 @@ STATE_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/chezmoi-dotfiles/mise-shim-lin
 
 # 言語ランタイム本体。VS Code 等が ~/.local/bin を優先して拾うと予期せぬバージョンで
 # 起動する恐れがあるため、Copilot 経由での利用価値より副作用リスクを優先して除外。
+# rust は mise 管理外 (docs/adr/016-rust-external-rustup.md) のため shim 自体が存在せず対象外。
 EXCLUDE_EXACT=(
   node npm npx corepack
   dotnet dnx
-  cargo rustc rustup rustfmt rustdoc clippy-driver rls
 )
 
-# glob パターン。cargo-*/rust-* は cargo/rustc 本体とセットで無効化。
-# *.bat/*.ps1/*.sh/*.zst/*.txt/*-darwin-* は shim ではない付随ファイル。
-EXCLUDE_PATTERN=('cargo-*' 'rust-*' '*.bat' '*.ps1' '*.sh' '*.zst' '*.txt' '*-darwin-*')
+# glob パターン。*.bat/*.ps1/*.sh/*.zst/*.txt/*-darwin-* は shim ではない付随ファイル。
+EXCLUDE_PATTERN=('*.bat' '*.ps1' '*.sh' '*.zst' '*.txt' '*-darwin-*')
 
 is_excluded() {
   local name="$1" e p

--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -79,6 +79,16 @@ properties:
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
+        # rust-toolchain.toml を持つプロジェクトでの version pinning を機能させるため、
+        # mise ではなく公式インストーラー (rustup) で管理する。
+        # 詳細: docs/adr/016-rust-external-rustup.md
+        description: "Install Rust (rustup)"
+        allowPrerelease: false
+      settings:
+        id: Rustlang.Rustup
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
         description: "Install Microsoft Edit"
         allowPrerelease: false
       settings:


### PR DESCRIPTION
## Why

While reviewing copilot-agent-runtime's dev environment requirements (Rust 1.95.0 pinned via `rust-toolchain.toml`), I found that mise's `rust` shim forcibly injects `RUSTUP_TOOLCHAIN` on every invocation. Since rustup resolves toolchains as env var > `rust-toolchain.toml` > default, this silently overrides *any* project's `rust-toolchain.toml` (confirmed on the live machine: `rustup show` reported `active because: overridden by environment variable RUSTUP_TOOLCHAIN`). This isn't specific to that project - it breaks version pinning for every rust-toolchain.toml-based project as long as mise manages `rust = "latest"`.

Windows (ADR-009) already assumed an external rustup existed and isolated mise's rust home to avoid symlink collisions. This PR extends that same model to all OSes instead of keeping the asymmetry, and retires ADR-009 in favor of a new ADR-016.

## What changed

- Removed `rust` from mise's `[tools]` and the Windows-only `cargo_home`/`rustup_home` isolation block in `mise/config.toml.tmpl`.
- macOS/Linux: `run_once_before_10-install-packages.sh.tmpl` now installs rustup via the official installer, only if not already present.
- Windows: added `Rustlang.Rustup` to the winget/DSC configuration.
- Cleaned up now-dead rust entries in the shim-link exclude lists (`run_onchange_after_21-link-mise-shims.sh.tmpl`) and stale rustup-related comments in the mise-sync-tools scripts and `troubleshooting.md`.
- Added ADR-016 documenting the decision; ADR-009 marked as Superseded by ADR-016.

## Also included: pnpm/corepack

While investigating, I found `pnpm` was resolving through a stray `/opt/homebrew/bin/pnpm` symlink left over from a Homebrew Node install that had since been removed - dotfiles never actually set up `corepack enable` anywhere. Added `corepack enable` to the mise-sync-tools hooks (`run_onchange_after_15-mise-sync-tools.{sh,ps1}.tmpl`) so pnpm/yarn resolve consistently from the mise-managed Node install on every OS, and cleaned up the stray symlink on this machine.

## Verification

- Rendered templates with `chezmoi execute-template` and validated TOML/YAML syntax.
- Ran the full test suite (`uv run -m unittest discover -s tests`): 230 tests passing.
- Verified locally: removed the stray pnpm symlink, ran `corepack enable`, confirmed `pnpm` now resolves from the mise Node install and `pnpm --version` works.

## Trade-offs

- mise's lockfile no longer tracks a rust version; updates are now via `rustup update`/`rustup default` instead of `mise upgrade`.
- New machines will install rustup earlier in the bootstrap sequence (`run_once_before_10`, ahead of mise install) rather than through mise.