### PR TITLE
fix(windows): resolve MSVC linker conflict with Coreutils link.exe

### DIFF
--- a/docs/adr/017-msvc-linker-env-var-override-windows.md
+++ b/docs/adr/017-msvc-linker-env-var-override-windows.md
@@ -1,0 +1,33 @@
+# ADR-017: Windows の MSVC リンカーは CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER で明示指定する
+
+## Status
+
+Accepted
+
+## Context
+
+Windows で `cargo build`（`windows-msvc` ターゲット）は `link.exe`（MSVC リンカー）を必要とする。一方、winget で導入している Coreutils for Windows (`Microsoft.Coreutils`, `reference/windows/configuration.dsc.yaml`) は GNU coreutils 版の `link`（ハードリンク作成用）を提供し、これが `C:\Program Files\coreutils\bin\link.exe` として Machine PATH（MSI が登録、現ユーザーには書き込み権限なし）に存在する。
+
+rustc/cc クレートの MSVC ツールチェイン解決は「PATH 上に `link.exe` が見つかればそれを無条件使用し、無い場合のみ vswhere.exe で自動検出する」仕様のため、coreutils 版が存在するだけで vswhere による正しい自動検出が丸ごとスキップされ、誤った `link.exe` が呼ばれてリンクエラーになる。
+
+Windows のプロセス初期 PATH は Machine PATH → User PATH の順で連結されるため、User PATH で新ディレクトリを prepend しても Machine PATH 上の coreutils を追い越せない（実機確認: 現ユーザーでの当該ファイルへの書き込み・リネームは Access Denied）。
+
+本リポジトリの既存 Windows 自動化スクリプトはすべて非昇格のユーザースコープ操作のみであり、この方針を崩したくない。また Copilot CLI のシェルセッションでは `$PROFILE` が読み込まれないため、プロファイルで `$env:Path` を書き換える方式は効かない。ユーザー環境変数（レジストリ永続化）ならこの制約を回避できる。`.cargo/config.toml` への絶対パスのハードコードは、MSVC ツールセットのバージョンフォルダが Build Tools 更新で変わりうるため陳腐化リスクがある。
+
+この衝突は上流 `microsoft/coreutils` でも既知の不具合として認識されている（Issue #123「`link` can conflict with MSVC linker」、Issue #31 の重複としてクローズ）。メンテナは `coreutils-manager disable <utility>` による個別無効化を用意しているが、README の「Shell conflicts」一覧（CMD/PowerShell 組み込みコマンドとの衝突が対象）に `link` は載っておらず、Coreutils 自体が preview 段階で無効化にも管理者権限が必要と見られる（未検証）ため、上流対応より本 ADR の方式のほうが現時点で堅牢と判断した。
+
+## Decision
+
+coreutils の `link.exe` 自体は変更・削除・リネームしない。代わりに Cargo 公式の `CARGO_TARGET_<triple>_LINKER` 仕組みを使い、`CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER` をユーザースコープ環境変数として設定する。PATH の並び順にも `$PROFILE` にも依存しない。
+
+値（MSVC `link.exe` の絶対パス）は `vswhere.exe` で毎回動的に解決し、ハードコードは持たない。実装は `home/run_onchange_after_20-resolve-msvc-linker.ps1.tmpl`（Windows 限定）。安定した変更検知元が無いため `{{ now }}` を埋め込み `chezmoi apply` の度に強制再実行させ、解決結果が現在値と同じ場合は書き込みを行わない（冪等）。VS Build Tools/vswhere が未導入でもエラーにせず fail-soft で継続する。
+
+併せて `reference/windows/configuration.dsc.yaml` に VS 2022 Build Tools 本体と C++ ワークロード（`Microsoft.VisualStudio.DSC/VSComponents`, `Microsoft.VisualStudio.Workload.VCTools`）を追加した。`WinGetPackage` リソースにはインストーラー追加引数を渡すプロパティが無いため。
+
+## Consequences
+
+- coreutils の `link` コマンドは PATH 上に存在し続ける。Cargo のビルドだけが環境変数経由で正しい MSVC リンカーを使う
+- `chezmoi apply` の実行時間がわずかに伸びる（vswhere 実行分）
+- 新規マシンでは `winget configure -f reference/windows/configuration.dsc.yaml` を管理者権限で手動実行するまで解決が効かない
+- 他プロジェクトが独自の `CARGO_TARGET_*_LINKER` を `.cargo/config.toml` で設定している場合、環境変数側が優先され意図しない上書きになりうる（現状未確認）
+- amd64 Windows のみ対応。環境変数名 (`CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER`) と vswhere 検索パターン (`Hostx64\x64`) がターゲットトリプル/ホスト固定のため、ARM64 Windows（Coreutils ARM64 版でも同種の衝突が起こりうる）は未対応。将来的に `.chezmoi.arch` での分岐が必要

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -29,6 +29,7 @@
 | [014](014-github-multi-account-https-auth-per-owner.md) | GitHub 多アカウント HTTPS 認証は credential の URL パス方式 + gh auth token --user で解決する | Accepted |
 | [015](015-copilot-cli-shell-network-via-local-sandbox.md) | Copilot CLI shell のネットワーク制御は local sandbox で行う | Accepted |
 | [016](016-rust-external-rustup.md) | Rust は全 OS で外部 rustup 管理とする (mise 管理から除外) | Accepted |
+| [017](017-msvc-linker-env-var-override-windows.md) | Windows の MSVC リンカーは CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER で明示指定する | Accepted |
 
 ## テンプレート
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,14 @@ Dock / Spotlight / GitHub Desktop から起動された子プロセスは launch
 
 mise は shims と `mise activate` を併用する。対話 zsh では `mise activate zsh` が shims を除去して自前挿入し、`[env]` / hooks が効く。非対話シェルでは shims のみで解決する。shims では `[env]` / `hooks` / `_.file` が動かないが、本 repo の `config.toml` は `[tools]` / `[settings]` のみ使用するため影響なし（必要時は `mise exec -- <cmd>`）。詳細: <https://mise.jdx.dev/dev-tools/shims.html>
 
+## MSVC リンカー解決 (Windows)
+
+Windows で cargo が `windows-msvc` ターゲットをビルドするには MSVC の `link.exe` が必要（[ADR-017](adr/017-msvc-linker-env-var-override-windows.md)）。winget で導入する Coreutils for Windows の `link.exe`（ハードリンク作成コマンド）と名前が衝突し、Machine PATH 側が優先されるため PATH の並び替えでは解決できない。
+
+- `reference/windows/configuration.dsc.yaml` で Visual Studio 2022 Build Tools + C++ ワークロード (`Microsoft.VisualStudio.Workload.VCTools`) を導入
+- `run_onchange_after_20-resolve-msvc-linker.ps1` が `vswhere.exe` で現在の `link.exe` を解決し、ユーザー環境変数 `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER` に設定する。PATH に依存しないため $PROFILE を読まないシェル（Copilot CLI 等）でも有効
+- `{{ now }}` を script hash に埋め込み `chezmoi apply` の度に再評価するため、VS Build Tools の更新でツールセットのバージョンフォルダが変わっても追従する
+
 ## `run_once_*` スクリプトの実行順
 
 chezmoi は `run_once_before_*` → 通常ファイル適用 → `run_once_after_*` の順に処理し、同フェーズ内は数字順で実行する。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,6 +82,22 @@ command -v copilot uv
 [Environment]::GetEnvironmentVariable('Path', 'User') -split ';' | Select-String 'mise\\shims'
 ```
 
+## Windows で `cargo build` / `cargo check` がリンクエラーになる (`link.exe` が見つからない/引数エラー)
+
+症状: `error: linking with \`link.exe\` failed` や、coreutils の `link` コマンドのヘルプ/エラーメッセージがそのまま出力される。
+
+原因: winget で導入した Coreutils for Windows の `link.exe`（ハードリンク作成コマンド）が Machine PATH に登録されており、MSVC の `link.exe` と名前が衝突する。詳細は [`docs/architecture.md`](architecture.md#msvc-リンカー解決-windows) と [ADR-017](adr/017-msvc-linker-env-var-override-windows.md)。
+
+復旧:
+
+1. Visual Studio 2022 Build Tools（C++ によるデスクトップ開発ワークロード）が未導入なら、管理者権限の PowerShell で `winget configure -f reference\windows\configuration.dsc.yaml` を実行する
+2. `chezmoi apply` を実行する（`run_onchange_after_20-resolve-msvc-linker.ps1` は毎回再評価されるため、追加の手動操作は不要）
+3. 環境変数が設定されているか確認する（新しいシェルで反映される）
+
+    ```powershell
+    [Environment]::GetEnvironmentVariable('CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER', 'User')
+    ```
+
 ## Git pre-commit が `C:/Users/.../.config/git/hooks/pre-commit: No such file or directory` で失敗する
 
 グローバル hook は chezmoi で `~/.config/git/hooks/pre-commit` に配置し、`core.hooksPath` から参照する。未配置なら次で復旧する。

--- a/home/run_onchange_after_20-resolve-msvc-linker.ps1.tmpl
+++ b/home/run_onchange_after_20-resolve-msvc-linker.ps1.tmpl
@@ -1,0 +1,57 @@
+{{ if eq .chezmoi.os "windows" -}}
+# MSVC リンカー (link.exe) を CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER で明示指定する。
+#
+# 背景:
+#   winget で導入した Coreutils for Windows (Microsoft.Coreutils) は GNU coreutils 版の
+#   link.exe (ハードリンク作成コマンド) を提供し、Machine PATH に登録される
+#   (MSI インストーラーによる登録のため、管理者権限なしでは書き換え/削除不可)。
+#   rustc は windows-msvc ターゲットのリンク時、PATH 上に link.exe が見つかると
+#   vswhere によるツールチェイン自動検出を丸ごとスキップしてそれをそのまま呼び出すため、
+#   coreutils 版が誤って使われてリンクエラーになる。
+#   Machine PATH は User PATH より先に解決されるため、PATH の並び替え (User PATH 側の
+#   prepend) では解決できない。
+#
+# 対応:
+#   PATH の並び順に依存しない CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER 環境変数
+#   (ユーザースコープ) で MSVC の link.exe を直接指定する。vswhere で毎回解決し直す
+#   ため、Visual Studio Build Tools の更新でツールセットのバージョンフォルダが
+#   変わっても追従する (ハードコードされた絶対パスを chezmoi ソースに持たない)。
+#
+# 関連: docs/adr/017-msvc-linker-env-var-override-windows.md
+#
+# 実行契機:
+#   VS Build Tools の更新を検知できる安定したハッシュ元がないため、{{ "{{ now }}" }} を
+#   埋め込み `chezmoi apply` の度に再評価する。vswhere 実行のみで数十 ms 程度であり、
+#   解決結果が変わらない限り環境変数への書き込みは行わない。
+#
+# generated: {{ now.Format "2006-01-02T15:04:05Z07:00" }}
+
+$ErrorActionPreference = 'Continue'
+
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path -LiteralPath $vswhere)) {
+    Write-Host 'vswhere.exe not found; skipping MSVC linker resolution (Visual Studio Build Tools not installed yet?).'
+    exit 0
+}
+
+$linkerPaths = & $vswhere -latest -prerelease -products * `
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    -find 'VC\Tools\MSVC\**\bin\Hostx64\x64\link.exe' 2>$null
+
+if (-not $linkerPaths) {
+    Write-Host 'MSVC link.exe not found via vswhere; skipping (Desktop development with C++ ワークロードを導入してください).'
+    exit 0
+}
+
+$linkerPath = $linkerPaths | Sort-Object | Select-Object -Last 1
+$varName = 'CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER'
+$current = [Environment]::GetEnvironmentVariable($varName, 'User')
+
+if ($current -eq $linkerPath) {
+    Write-Host "MSVC linker already up to date: $linkerPath"
+} else {
+    Write-Host "Setting $varName = $linkerPath"
+    [Environment]::SetEnvironmentVariable($varName, $linkerPath, 'User')
+    Set-Item -Path "Env:$varName" -Value $linkerPath
+}
+{{ end -}}

--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -88,6 +88,30 @@ properties:
         id: Rustlang.Rustup
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: VisualStudioBuildTools
+      directives:
+        # cargo/rustc の windows-msvc ターゲットビルドに必要な MSVC リンカー (link.exe) を導入する。
+        # C++ ワークロードはインストーラー引数が必要なため WinGetPackage 単体では指定できず、
+        # 下の VSComponents リソースで別途追加する。
+        # link.exe が Coreutils for Windows 版と名前衝突する問題への対応は docs/adr/017-msvc-linker-env-var-override-windows.md
+        description: "Install Visual Studio 2022 Build Tools"
+        allowPrerelease: false
+        securityContext: elevated
+      settings:
+        id: Microsoft.VisualStudio.2022.BuildTools
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - VisualStudioBuildTools
+      directives:
+        description: "Install C++ build tools workload (Desktop development with C++) + Windows SDK"
+        securityContext: elevated
+      settings:
+        productId: Microsoft.VisualStudio.Product.BuildTools
+        channelId: VisualStudio.17.Release
+        components: Microsoft.VisualStudio.Workload.VCTools
+        includeRecommended: true
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: "Install Microsoft Edit"
         allowPrerelease: false
@@ -96,6 +120,8 @@ properties:
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
+        # 同梱の link.exe (ハードリンク作成コマンド) が MSVC リンカーと名前衝突する。
+        # 対応: docs/adr/017-msvc-linker-env-var-override-windows.md
         description: "Install Coreutils for Windows"
         allowPrerelease: false
       settings:


### PR DESCRIPTION
## Why

`cargo check`/`cargo build` for `windows-msvc` targets was failing on Windows because Coreutils for Windows (`Microsoft.Coreutils`) registers its own `link.exe` (a hard-link utility) on Machine PATH. rustc/cc-rs only fall back to `vswhere.exe`-based MSVC toolchain auto-detection when no `link.exe` is resolvable via PATH at all, so the coreutils version gets picked up unconditionally and the build fails with a linker error.

Machine PATH is concatenated before User PATH on Windows, so reordering User PATH (even via a PowerShell profile) cannot fix this in non-interactive/non-profile shells. The current user also has no write access to `C:\Program Files\coreutils\bin`, ruling out renaming/deleting the offending `link.exe` as a non-elevated, automatable fix.

## Approach

- **`reference/windows/configuration.dsc.yaml`**: add Visual Studio 2022 Build Tools plus the "Desktop development with C++" workload (`Microsoft.VisualStudio.DSC/VSComponents`, `Microsoft.VisualStudio.Workload.VCTools`), since `Microsoft.WinGet.DSC/WinGetPackage` has no property for passing installer arguments needed to select a workload.
- **`home/run_onchange_after_20-resolve-msvc-linker.ps1.tmpl`** (new, Windows-only): resolves the current MSVC `link.exe` path via `vswhere.exe` and persists it as the user-scope `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER` environment variable (Cargo's official per-target linker override). This sidesteps PATH entirely and works even in shells that don't source `$PROFILE`. The path is never hardcoded, so it keeps working across VS Build Tools toolset updates. Since there's no stable hash source reflecting the installed VS version, the script embeds `{{ now }}` so chezmoi's `run_onchange` re-evaluates it on every `chezmoi apply`; the actual env var write is skipped when the resolved value hasn't changed (idempotent), and the script fails soft (exit 0) if VS Build Tools/vswhere aren't installed yet.
- Documented the mechanism in `docs/architecture.md`, added a troubleshooting entry in `docs/troubleshooting.md`, and recorded the decision in `docs/adr/017-msvc-linker-env-var-override-windows.md` (including references to the known upstream issue in `microsoft/coreutils`, i.e. issue #123 deduped into #31).

## Non-obvious points for reviewers

- `reference/windows/configuration.dsc.yaml` is not applied automatically by `chezmoi apply` (it lives outside `.chezmoiroot`); VS Build Tools only gets installed once someone runs `winget configure -f reference\windows\configuration.dsc.yaml` in an elevated PowerShell.
- Known limitation (documented in ADR-017's Consequences): this only supports amd64 Windows. The env var name and the vswhere `Hostx64\x64` search pattern are hardcoded to the x64 host/target; ARM64 Windows would need `CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER` and a different vswhere pattern, and isn't addressed here.
- Coreutils' `link.exe` itself is left untouched; only cargo's linker resolution is redirected via the env var.

## Verification

Tested end-to-end on a real Windows machine (amd64) that had the conflict:
1. Ran the DSC file (elevated) to install VS 2022 Build Tools + C++ workload; confirmed `vswhere.exe` resolves `link.exe`.
2. Applied the new script and confirmed `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER` gets set correctly, and re-running it is idempotent (no-op when unchanged).
3. Ran `cargo check` in `github/github-app` (a real MSVC-target Rust project) in a fresh shell: build succeeded without linker errors, including linking an actual `x86_64-pc-windows-msvc` binary.