### PR TITLE
fix: seed git hooks via templateDir

### DIFF
--- a/docs/adr/018-git-hooks-via-init-templatedir.md
+++ b/docs/adr/018-git-hooks-via-init-templatedir.md
@@ -1,0 +1,26 @@
+# ADR-018: 機械全体への Git hook 配布は init.templateDir で行う
+
+## Status
+
+Accepted
+
+## Context
+
+従来は `core.hooksPath = ~/.config/git/hooks` を GLOBAL に設定し、chezmoi で配布した `pre-commit`（gitleaks でステージ差分をスキャンし、repo-local な `.git/hooks/pre-commit` があれば `exec` で委譲）を全リポジトリに適用していた。狙いは gitleaks 未設定のリポジトリも含めた機械全体での保護。
+
+この設計は事故を起こした。同一機械上の無関係なプロジェクトで素の `lefthook install` を実行したところ、lefthook は現在の `core.hooksPath` を尊重するため、生成した hook スタブ（`prepare-commit-msg` 等）が GLOBAL 設定のせいで共有ディレクトリ `~/.config/git/hooks/` に書き込まれた。これは dotfiles リポジトリ自身を含む全リポジトリを汚染し、無関係な commit で `Can't find lefthook in PATH` が出る原因になった。根本問題は、GLOBAL かつ共有かつ書き込み可能な `core.hooksPath` が、lefthook/husky/pre-commit のような「自リポジトリの hooks ディレクトリを専有する」前提の hook 管理ツールと構造的に相容れない点にある。
+
+Python の `pre-commit` フレームワークには `pre-commit init-templatedir` という、まさに「機械全体へ hook を配布する」ための機能があり、`core.hooksPath` ではなく Git 純正の `init.templateDir` を使う。husky・lefthook も `core.hooksPath` の GLOBAL 設定を明示的に非推奨とし、自身の `install` は LOCAL に設定する。Git 自体の `.git/hooks/*.sample` もこのテンプレート機構で配布されており、奇策ではない。
+
+## Decision
+
+`core.hooksPath`（GLOBAL）を廃止し、`[init] templateDir = ~/.config/git/templates`（`home/dot_gitconfig.tmpl`）に切り替える。hook 本体は `home/dot_config/git/templates/hooks/executable_pre-commit` に移し（`~/.config/git/templates/hooks/pre-commit` へ配置）、repo-local hook への delegate/exec ロジックは削除する（テンプレート配布後は各リポジトリの通常の local hook になるため、委譲対象と自分自身が同一になり不要かつ自己ループの原因になる）。旧配置の `pre-commit` ファイルは `home/.chezmoiremove` で削除するが、旧ディレクトリ全体は削除しない。加えて、全 `ghq` リポジトリを走査して local `core.hooksPath` 上書き・hook 欠落・非 gitleaks hook・正常、を報告する読み取り専用の `git-hooks-audit`（zsh 関数 / PowerShell 関数）を追加する。
+
+## Consequences
+
+- `init.templateDir` は `git init`/`git clone` の瞬間に一度だけコピーされ、既存ファイルがあれば上書きしない（Git 本体の `copy_templates()` の挙動）。コピー後は完全に repo-local な通常ファイルになるため、他 hook マネージャの「バックアップ/上書き」判断も正しく働き、他リポジトリへの汚染は構造的に不可能になる。
+- 保証が「常時・全リポジトリで強制」から「新規 init/clone 時にのみ自動配布」へ弱まる。既存リポジトリは `git -C <repo> init`（安全・冪等・既存ファイル非破壊）による一括バックフィルが必要。これは意図的に許容したトレードオフであり、機械全体での継続的強制と、他ツールから透過的な per-repo hook 管理は無調整では両立しないという Git の hook モデル上の制約による（設計時に内部レビュー2回で確認済み）。
+- 他プロジェクトの hook マネージャが特定リポジトリの `.git/hooks/pre-commit` を上書きしても、影響はそのリポジトリ内に閉じる。
+- テンプレートディレクトリは `hooks/pre-commit` のみを持ち、Git 既定の `*.sample` 等は引き継がない（この用途では無害・許容）。
+- 「chezmoi apply のたびに旧共有ディレクトリの不明ファイルを自動削除する」案は、他プロジェクトの正規 hook を無警告で無効化しうる（hook ファイル欠落は git が黙って無視する）ため設計段階で明示的に却下した。可視性を保ちつつ自動破壊的操作を避けるため、読み取り専用の `git-hooks-audit` を採用した。
+- Windows: hook 本体の POSIX `sh` 互換要件（Git for Windows が `/usr/bin/env bash` を WSL の bash.exe に解決し `C:/...` パスを開けない問題への対応）は変わらず適用される。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -30,6 +30,7 @@
 | [015](015-copilot-cli-shell-network-via-local-sandbox.md) | Copilot CLI shell のネットワーク制御は local sandbox で行う | Accepted |
 | [016](016-rust-external-rustup.md) | Rust は全 OS で外部 rustup 管理とする (mise 管理から除外) | Accepted |
 | [017](017-msvc-linker-env-var-override-windows.md) | Windows の MSVC リンカーは CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER で明示指定する | Accepted |
+| [018](018-git-hooks-via-init-templatedir.md) | 機械全体への Git hook 配布は init.templateDir で行う | Accepted |
 
 ## テンプレート
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ home/                           ← chezmoi source
 ├── dot_zshrc.tmpl              ← 対話 zsh
 ├── dot_profile.tmpl            ← POSIX 互換の共通 env（PATH, brew shellenv, mise shims）
 ├── dot_{zprofile,zshenv,bash_profile,bashrc}.tmpl ← 全て ~/.profile を source
-├── dot_config/git/hooks/pre-commit  ← gitleaks + ローカルフック委譲
+├── dot_config/git/templates/hooks/pre-commit  ← gitleaks (init.templateDir 経由)
 ├── dot_config/mise/{config.toml.tmpl,mise.lock}
 ├── PowerShell_profile.ps1.tmpl
 ├── private_dot_copilot/        ← ~/.copilot/ 配下（instructions, hooks, mcp, skills）
@@ -28,7 +28,7 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 - `copilot-guard.py` / `uv-enforcer.py` / `node-global-enforcer.py` でネットワーク以外の危険操作を抑止、`postToolUse` で監査ログ
 - Copilot CLI local sandbox を有効化
 - `copilot-guardrails` で利便性と秘匿環境変数の扱いを固定
-- `gitleaks` 付き pre-commit を配布
+- `gitleaks` 付き pre-commit を `init.templateDir` 経由で配布（ADR-018）
 
 ## Copilot Guard の設計
 
@@ -45,7 +45,9 @@ shell command の外部ネットワーク通信は、`~/.copilot/settings.json` 
 
 ## git pre-commit フック
 
-グローバル `pre-commit` を `~/.config/git/hooks/pre-commit` に配置し `core.hooksPath` で有効化。`gitleaks git --pre-commit --staged --redact` の後、リポジトリローカルの `.git/hooks/pre-commit` があれば追加実行する。
+`~/.config/git/templates/hooks/pre-commit` を配置し、`git config --global init.templateDir` で有効化（ADR-018）。`git init`/`git clone` の瞬間に各リポジトリの `.git/hooks/pre-commit` へコピーされ、以降は通常のローカル hook として扱われる。`core.hooksPath` のようにグローバルに強制するのではなく「新規リポジトリの既定値」として配る方式のため、lefthook/husky 等の repo-local hook manager を導入した他リポジトリを巻き込まない。
+
+トレードオフとして、既存リポジトリには自動適用されない（`git init` を一度再実行して backfill するか、独自 hook manager を使うリポジトリはそのままにする）。`git-hooks-audit`（zsh 関数 / PowerShell `Invoke-GitHooksAudit`）で ghq 管理下の全リポジトリの状態（hook 未配置・local hooksPath 上書き・gitleaks 以外の hook に置き換え済み）を確認できる。
 
 ## プラットフォーム検出
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -118,12 +118,20 @@ sed '/^{{/d' home/run_once_after_10-setup-shell.sh.tmpl | bash -n
 
 ## git pre-commit フック
 
-グローバル pre-commit を `~/.config/git/hooks/pre-commit` に配置し、`gitleaks` で staged 変更を検査する。必要ならリポジトリローカルの `.git/hooks/pre-commit` に委譲する。
+`~/.config/git/templates/hooks/pre-commit` を `gitleaks` の scan スクリプトとして配置し、`init.templateDir` 経由で新規リポジトリ（`git init`/`git clone`）にのみ既定配布する（ADR-018、旧 `core.hooksPath` グローバル方式からの移行）。
 
 ```bash
-git config --global core.hooksPath   # 期待値: ~/.config/git/hooks
-chezmoi edit ~/.config/git/hooks/pre-commit && chezmoi apply
+git config --global init.templateDir   # 期待値: ~/.config/git/templates
+chezmoi edit ~/.config/git/templates/hooks/pre-commit && chezmoi apply
 ```
+
+既存リポジトリへの backfill（`git init` の再実行は既存 hook を上書きしないため安全・冪等）:
+
+```bash
+git -C <repo-path> init
+```
+
+状態の確認は `git-hooks-audit`（zsh）/ `Invoke-GitHooksAudit`（PowerShell）で ghq 管理下の全リポジトリを一括チェックできる。
 
 ## `run_once_*` の再実行
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,14 +98,16 @@ command -v copilot uv
     [Environment]::GetEnvironmentVariable('CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER', 'User')
     ```
 
-## Git pre-commit が `C:/Users/.../.config/git/hooks/pre-commit: No such file or directory` で失敗する
+## 新規リポジトリに gitleaks pre-commit hook が入らない
 
-グローバル hook は chezmoi で `~/.config/git/hooks/pre-commit` に配置し、`core.hooksPath` から参照する。未配置なら次で復旧する。
+新規/backfill 済みリポジトリの hook は、`git init`/`git clone` 時に `~/.config/git/templates/hooks/pre-commit` から `.git/hooks/pre-commit` へコピーされる（ADR-018）。テンプレートが未配置なら次で復旧する。
 
 ```bash
-git config --global core.hooksPath   # 期待値: ~/.config/git/hooks
-chezmoi apply ~/.config/git/hooks/pre-commit
+git config --global init.templateDir   # 期待値: ~/.config/git/templates
+chezmoi apply ~/.config/git/templates/hooks/pre-commit
 ```
+
+`init.templateDir` は `git init`/`git clone` した瞬間にしか `.git/hooks/` へコピーされない。既存リポジトリに hook が無い場合は `git -C <repo> init` を再実行して backfill する（既存ファイルは上書きされないため安全）。`git-hooks-audit` / `Invoke-GitHooksAudit` で ghq 管理下の全リポジトリの hook 有無をまとめて確認できる。
 
 Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin/env bash` が WSL の `bash.exe` を拾い、Windows 形式の `C:/...` パスを開けていない可能性がある。この pre-commit hook はその経路を避けるため POSIX `sh` 互換で管理する。mise の Windows shim も extensionless 版は `/bin/bash` スクリプトなので、hook 内では `gitleaks.exe` を優先する。
 

--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -1,2 +1,4 @@
 # Remove legacy config files superseded by new locations
 .mise.toml
+# Superseded by ~/.config/git/templates/hooks/pre-commit + init.templateDir (ADR-018)
+.config/git/hooks/pre-commit

--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -174,11 +174,71 @@ function Invoke-MiseUpgrade {
     }
 }
 
+# git-hooks-audit: ghq 管理下の全リポジトリを走査し、init.templateDir 経由の
+# pre-commit hook (gitleaks) が効いているか報告する (ADR-018)。
+# init.templateDir は git init/clone 時に一度だけ hook をコピーする方式のため、
+# 既存リポジトリや、独自 hooksPath を持つリポジトリ (lefthook/husky 等) では
+# 自動的には保護されない。ここでは削除・変更は一切行わず、状態を可視化するのみ。
+function Invoke-GitHooksAudit {
+    if (-not (Get-Command ghq -ErrorAction SilentlyContinue)) {
+        Write-Error "❌ ghq が見つかりません"
+        return
+    }
+
+    ghq list -p | ForEach-Object {
+        $repo = $_
+        if (-not (Test-Path $repo -PathType Container)) { return }
+
+        # --local ではなく実効値を見る（global/system/includeIf 由来の override も検知するため）
+        $hooksPathEffective = git -C $repo config --get core.hooksPath 2>$null
+        if ($LASTEXITCODE -eq 0 -and $hooksPathEffective) {
+            if ($hooksPathEffective -eq "$HOME/.config/git/hooks" -or $hooksPathEffective -eq "~/.config/git/hooks") {
+                Write-Host "⚠️  ${repo}: core.hooksPath=$hooksPathEffective (旧グローバル設定。chezmoi apply 後に再確認)"
+            }
+            else {
+                Write-Host "⚠️  ${repo}: core.hooksPath=$hooksPathEffective (init.templateDir hook は使われません)"
+            }
+            return
+        }
+
+        $isBare = git -C $repo rev-parse --is-bare-repository 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $isBare) {
+            Write-Host "❓ ${repo}: git repo として認識できません"
+            return
+        }
+        if ($isBare -eq 'true') {
+            Write-Host "ℹ️  ${repo}: bare repo のため対象外"
+            return
+        }
+
+        # 手動で相対パスを組み立てない（worktree 等で $repo 相対とは限らないため）
+        $hookPath = git -C $repo rev-parse --path-format=absolute --git-path hooks/pre-commit 2>$null
+        $gitOk = $LASTEXITCODE -eq 0
+        if (-not $gitOk -or -not $hookPath) {
+            Write-Host "❓ ${repo}: hook path を解決できません"
+            return
+        }
+
+        if (-not (Test-Path $hookPath -PathType Leaf)) {
+            Write-Host "❌ ${repo}: pre-commit hook が無い（backfill: git -C '$repo' init）"
+            return
+        }
+
+        if (Select-String -Path $hookPath -Pattern 'gitleaks.*git.*--pre-commit.*--staged' -Quiet) {
+            Write-Host "✅ ${repo}: gitleaks hook 有効"
+        }
+        else {
+            Write-Host "ℹ️  ${repo}: pre-commit hook はあるが gitleaks 製ではない（他ツールが管理中と思われる）"
+        }
+    }
+}
+
 # === Aliases ===
 Set-Alias -Name e -Value Open-EditInNewConsole
 Set-Alias -Name k -Value kubectl
 Set-Alias -Name mise-self-upgrade -Value Invoke-MiseSelfUpgrade
 Set-Alias -Name mise-upgrade -Value Invoke-MiseUpgrade
+Set-Alias -Name git-hooks-audit -Value Invoke-GitHooksAudit
 
 # Copilot CLI: local sandbox is enabled. preToolUse hooks still protect
 # sensitive files and shell-level secret reads.

--- a/home/dot_config/git/templates/hooks/executable_pre-commit
+++ b/home/dot_config/git/templates/hooks/executable_pre-commit
@@ -1,14 +1,25 @@
 #!/bin/sh
 set -eu
 
-# Global pre-commit hook: gitleaks secret detection + local hook delegation
+# Default pre-commit hook: gitleaks secret detection.
 #
-# Deployed by chezmoi to ~/.config/git/hooks/pre-commit
-# Activated via core.hooksPath in ~/.gitconfig
+# Deployed by chezmoi to ~/.config/git/templates/hooks/pre-commit and wired up
+# via `git config --global init.templateDir ~/.config/git/templates`. Git
+# copies this file into <repo>/.git/hooks/pre-commit at `git init`/`git clone`
+# time only, and only if that file does not already exist there (git will
+# print "templates not copied: file already exists" and skip it otherwise).
+# From that point on it is an ordinary local hook file for that repository:
+# any repo-local hook manager (lefthook, husky, pre-commit framework, ...)
+# that later installs its own <repo>/.git/hooks/pre-commit will simply replace it
+# using its own normal detect/backup/overwrite logic, with no effect on any
+# other repository. See docs/adr/018-git-hooks-via-init-templatedir.md.
+#
+# Existing repos are not retroactively covered: re-run `git init` inside them
+# once (safe/idempotent, never overwrites an existing hook) to backfill this
+# hook, or run the git-hooks-audit helper to find repos missing it.
+#
 # Keep this POSIX sh compatible so Windows Git does not pick up WSL bash
 # through /usr/bin/env bash and pass it an unopenable C:/... hook path.
-
-# --- gitleaks secret scan ---
 
 find_gitleaks() {
   # Windows (Git Bash): prefer the .exe shim. The extensionless mise shim is a
@@ -59,13 +70,4 @@ GITLEAKS=$(find_gitleaks) || {
 
 if [ -n "${GITLEAKS}" ]; then
   "${GITLEAKS}" git --pre-commit --staged --redact --verbose --no-banner
-fi
-
-# --- Delegate to repository-local pre-commit hook ---
-# core.hooksPath overrides .git/hooks/, so we explicitly run the local hook
-# if it exists to preserve project-specific hooks.
-
-LOCAL_HOOK="$(git rev-parse --git-dir 2>/dev/null)/hooks/pre-commit"
-if [ -x "${LOCAL_HOOK}" ]; then
-  exec "${LOCAL_HOOK}" "$@"
 fi

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -1,7 +1,6 @@
 [core]
 	autocrlf = input
 	fileMode = false
-	hooksPath = ~/.config/git/hooks
 [pull]
 	ff = only
 [rerere]
@@ -12,6 +11,12 @@
 	signoff = true
 [init]
 	defaultBranch = main
+	# Seeds new repos' .git/hooks/ at `git init`/`git clone` time only (see
+	# ADR-018). Unlike core.hooksPath, this never redirects an existing repo's
+	# hook lookup, so repo-local hook managers (lefthook, husky, ...) can't be
+	# clobbered across repositories. Existing repos need a one-time backfill;
+	# run the git-hooks-audit helper to find repos missing the seeded hook.
+	templateDir = ~/.config/git/templates
 [help]
 	autocorrect = 20
 [alias]

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -198,6 +198,57 @@ function ghcd() {
   fi
 }
 
+# git-hooks-audit: ghq 管理下の全リポジトリを走査し、init.templateDir 経由の
+# pre-commit hook (gitleaks) が効いているか報告する (ADR-018)。
+# init.templateDir は git init/clone 時に一度だけ hook をコピーする方式のため、
+# 既存リポジトリや、独自 hooksPath を持つリポジトリ (lefthook/husky 等) では
+# 自動的には保護されない。ここでは削除・変更は一切行わず、状態を可視化するのみ。
+git-hooks-audit() {
+  if ! command -v ghq >/dev/null 2>&1; then
+    echo "❌ ghq が見つかりません" >&2
+    return 1
+  fi
+
+  local repo hooks_path_effective hook_path is_bare
+  ghq list -p | while IFS= read -r repo; do
+    [ -d "$repo" ] || continue
+    # --local ではなく実効値を見る（global/system/includeIf 由来の override も検知するため）
+    hooks_path_effective=$(git -C "$repo" config --get core.hooksPath 2>/dev/null || true)
+    if [ -n "${hooks_path_effective}" ]; then
+      if [ "${hooks_path_effective}" = "${HOME}/.config/git/hooks" ] || [ "${hooks_path_effective}" = "~/.config/git/hooks" ]; then
+        echo "⚠️  ${repo}: core.hooksPath=${hooks_path_effective} (旧グローバル設定。chezmoi apply 後に再確認)"
+      else
+        echo "⚠️  ${repo}: core.hooksPath=${hooks_path_effective} (init.templateDir hook は使われません)"
+      fi
+      continue
+    fi
+    is_bare=$(git -C "$repo" rev-parse --is-bare-repository 2>/dev/null || true)
+    if [ -z "${is_bare}" ]; then
+      echo "❓ ${repo}: git repo として認識できません"
+      continue
+    fi
+    if [ "${is_bare}" = "true" ]; then
+      echo "ℹ️  ${repo}: bare repo のため対象外"
+      continue
+    fi
+    # 手動で相対パスを組み立てない（worktree 等で $repo 相対とは限らないため）
+    hook_path=$(git -C "$repo" rev-parse --path-format=absolute --git-path hooks/pre-commit 2>/dev/null || true)
+    if [ -z "${hook_path}" ]; then
+      echo "❓ ${repo}: hook path を解決できません"
+      continue
+    fi
+    if [ ! -f "${hook_path}" ]; then
+      echo "❌ ${repo}: pre-commit hook が無い（backfill: git -C '${repo}' init）"
+      continue
+    fi
+    if grep -q "gitleaks.*git.*--pre-commit.*--staged" "${hook_path}" 2>/dev/null; then
+      echo "✅ ${repo}: gitleaks hook 有効"
+    else
+      echo "ℹ️  ${repo}: pre-commit hook はあるが gitleaks 製ではない（他ツールが管理中と思われる）"
+    fi
+  done
+}
+
 # Azure CLI の SyntaxWarning を抑制（azure-sdk-for-python#38618 の回避策）
 az() {
   PYTHONWARNINGS="ignore::SyntaxWarning" command az "$@"


### PR DESCRIPTION
## Summary
- replace global `core.hooksPath` with `init.templateDir` for gitleaks hook seeding
- move the managed pre-commit hook into the Git template directory
- add read-only audit helpers and ADR/docs for the migration trade-off

## Validation
- `git diff --cached --check`
- `sh -n home/dot_config/git/templates/hooks/executable_pre-commit`
- `shellcheck -s sh home/dot_config/git/templates/hooks/executable_pre-commit`
- `sh -n` on the zsh `git-hooks-audit` function snippet
- PowerShell AST parse of the `Invoke-GitHooksAudit` logic
- temp-repo checks for `init.templateDir` copy and non-overwrite behavior
- chezmoi dry-run check that only the old managed pre-commit hook is removed
