### PR TITLE
fix: authenticate mise lockfile sync

### DIFF
--- a/docs/adr/013-mise-lockfile-sync-hook.md
+++ b/docs/adr/013-mise-lockfile-sync-hook.md
@@ -16,7 +16,8 @@ Accepted
 
 - 番号 15 は `run_onchange_after_21-link-mise-shims.sh.tmpl`（macOS の shim symlink, ADR-002）より前で `run_once_after_20-mise-install.sh.tmpl` の後に走らせるための位置取り。
 - mise が PATH に無い環境（CI 等）は skip して exit 0、apply 全体を止めない。
-- 失敗しても exit 0 で警告のみ。次回 apply で hash 再評価により再試行される。
+- mise 用の GitHub token が未設定で `gh` が認証済みの場合は、`gh auth token` から取得した token を `MISE_GITHUB_TOKEN` としてフックのプロセス内だけで `mise install` へ渡す。`gh` が未認証の環境では従来の動作を変更しない。
+- `mise install` / `mise reshim` が失敗しても exit 0 で警告のみ。次回 apply で hash 再評価により再試行される。
 
 ## Consequences
 

--- a/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
@@ -31,6 +31,22 @@ if (-not $miseExe -or -not (Test-Path -LiteralPath $miseExe)) {
   exit 0
 }
 
+if (-not $env:MISE_GITHUB_TOKEN -and -not $env:GITHUB_API_TOKEN -and -not $env:GITHUB_TOKEN) {
+  if ($env:GH_TOKEN) {
+      $env:MISE_GITHUB_TOKEN = $env:GH_TOKEN
+  }
+  else {
+      $ghCommand = Get-Command -CommandType Application -Name 'gh.exe' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+      if ($ghCommand) {
+          $token = & $ghCommand.Source auth token 2>$null
+          if ($LASTEXITCODE -eq 0 -and $token) {
+              $env:MISE_GITHUB_TOKEN = $token
+          }
+      }
+  }
+}
+
 Write-Host "Syncing mise tools with lockfile via $miseExe ..."
 & $miseExe install
 $installExit = $LASTEXITCODE

--- a/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
@@ -23,6 +23,15 @@ if ! command -v mise >/dev/null 2>&1; then
   exit 0
 fi
 
+if [ -z "${MISE_GITHUB_TOKEN:-}" ] && [ -z "${GITHUB_API_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+  if [ -n "${GH_TOKEN:-}" ]; then
+    MISE_GITHUB_TOKEN="$GH_TOKEN"
+    export MISE_GITHUB_TOKEN
+  elif command -v gh >/dev/null 2>&1; then
+    MISE_GITHUB_TOKEN="$(gh auth token 2>/dev/null)" && export MISE_GITHUB_TOKEN
+  fi
+fi
+
 echo 'Syncing mise tools with lockfile...'
 mise install
 install_exit=$?


### PR DESCRIPTION
## Summary

- Pass an existing mise GitHub token through unchanged.
- Use `GH_TOKEN` or `gh auth token` as a process-scoped `MISE_GITHUB_TOKEN` when mise has no configured token.
- Apply the same behavior to the Unix and Windows lockfile synchronization hooks.

## Background

A mise lockfile update causes chezmoi's `run_onchange` hook to run `mise install`. The hook previously invoked mise without using the credentials already managed by GitHub CLI, so its GitHub API requests could use the unauthenticated rate limit.

This change does not alter behavior when GitHub authentication is unavailable. It only supplies authentication when an existing token or an authenticated `gh` installation is available.

## Verification

- Rendered Unix hook passes `bash -n` and ShellCheck.
- Rendered PowerShell hook parses successfully.
- Rendered Unix hook completes `mise install` successfully with the current lockfile.
