### PR TITLE
fix: use core dotnet backend

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -46,3 +46,5 @@ fetch_remote_versions_timeout = "60s"
 # 定期チェック対象: mise がスラッシュ入りタグの検証に対応したら本設定を撤去する。
 use_versions_host = false
 
+[tool_alias]
+dotnet = "core:dotnet"

--- a/home/dot_config/mise/private_mise.lock
+++ b/home/dot_config/mise/private_mise.lock
@@ -232,22 +232,7 @@ url_api = "https://api.github.com/repos/cue-lang/cue/releases/assets/461081557"
 
 [[tools.dotnet]]
 version = "10.0.302"
-backend = "vfox:dotnet"
-
-[tools.dotnet."platforms.linux-arm64"]
-url = "https://dot.net/v1/dotnet-install.sh"
-
-[tools.dotnet."platforms.linux-x64"]
-url = "https://dot.net/v1/dotnet-install.sh"
-
-[tools.dotnet."platforms.macos-arm64"]
-url = "https://dot.net/v1/dotnet-install.sh"
-
-[tools.dotnet."platforms.windows-arm64"]
-url = "https://dot.net/v1/dotnet-install.ps1"
-
-[tools.dotnet."platforms.windows-x64"]
-url = "https://dot.net/v1/dotnet-install.ps1"
+backend = "core:dotnet"
 
 [[tools.fzf]]
 version = "0.74.0"


### PR DESCRIPTION
## Summary

- `dotnet` の backend alias を `core:dotnet` に固定
- lockfile を .NET SDK 10.0.302 と core backend で更新
- Windows PowerShell で失敗する旧 vfox プラグインのインストール経路を回避

## Verification

- `mise upgrade dotnet`
- `mise install --locked dotnet`
- `dotnet --version` (`10.0.302`)
