### PR TITLE
fix(mise): surface lockfile sync failures

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,7 @@
 
 - `mise lock` はデフォルトでプロジェクトレベルの設定のみ対象にするため、グローバル設定には **`--global`** が必須。また引数なしだと既定の 8 プラットフォーム（musl 含む）を対象にするため、**`--platform` も常に指定する**
 - 同じツールとバージョンを維持したまま backend を変更すると、mise は既存の install path をインストール済みと判定し、新しい backend で再インストールしない場合がある。backend を変更した端末では、`mise install --force <tool>` または `mise uninstall <tool>@<version>` と `mise install <tool>` を一度実行する。バージョンも同時に変更し、新しい install path へ通常の `mise install` が実行される場合、この操作は不要
+- backend 移行はコマンドの終了だけで完了と判断しない。`mise ls <tool>` が `missing` を表示しないこと、`mise which <tool>` が新 backend の実体を返すこと、`<tool> --version` 等の実行確認が成功することを確認する。force install が失敗した場合は `reshim` や auto-install の無効化で回避せず、backend 固有の install path と検証コマンドを調査する
 
 ## プラットフォーム制約（定期チェック対象）
 

--- a/.github/workflows/test-copilot-hooks.yml
+++ b/.github/workflows/test-copilot-hooks.yml
@@ -3,12 +3,18 @@ on:
   pull_request:
     paths:
       - 'home/private_dot_copilot/hooks/**'
+      - 'home/dot_config/mise/config.toml.tmpl'
+      - 'home/dot_config/mise/private_mise.lock'
+      - '.github/copilot-instructions.md'
       - 'tests/**'
       - '.github/workflows/test-copilot-hooks.yml'
   push:
     branches: [main]
     paths:
       - 'home/private_dot_copilot/hooks/**'
+      - 'home/dot_config/mise/config.toml.tmpl'
+      - 'home/dot_config/mise/private_mise.lock'
+      - '.github/copilot-instructions.md'
       - 'tests/**'
       - '.github/workflows/test-copilot-hooks.yml'
   schedule:

--- a/docs/adr/013-mise-lockfile-sync-hook.md
+++ b/docs/adr/013-mise-lockfile-sync-hook.md
@@ -17,11 +17,12 @@ Accepted
 - 番号 15 は `run_onchange_after_21-link-mise-shims.sh.tmpl`（macOS の shim symlink, ADR-002）より前で `run_once_after_20-mise-install.sh.tmpl` の後に走らせるための位置取り。
 - mise が PATH に無い環境（CI 等）は skip して exit 0、apply 全体を止めない。
 - mise 用の GitHub token が未設定で `gh` が認証済みの場合は、`gh auth token` から取得した token を `MISE_GITHUB_TOKEN` としてフックのプロセス内だけで `mise install` へ渡す。`gh` が未認証の環境では従来の動作を変更しない。
-- `mise install` / `mise reshim` が失敗しても exit 0 で警告のみ。次回 apply で hash 再評価により再試行される。
+- `mise install` / `mise reshim` は一括処理し、いずれかが失敗した場合は原因と `chezmoi apply` による再実行方法を表示して非ゼロ終了する。失敗した `run_onchange` の状態は成功として保存されないため、原因解消後の apply で再実行される。
 
 ## Consequences
 
 - 起動時の `mise WARN missing:` と rustup の `info: syncing channel updates ...` が解消する。
 - lockfile が変わった `chezmoi apply` の所要時間が数秒〜数十秒延びる（unchanged 時の install は短時間で完了）。
+- install / reshim の失敗時は apply が失敗し、lockfile と実体の不整合が残ったことを利用者が認識して明示的に再実行できる。
 - lockfile 以外の理由（手動 `mise uninstall` 等）で shim が欠落したケースは本フックでは復元されないため、その場合は手動で `mise install && mise reshim` を実行する（`docs/troubleshooting.md` 参照）。
 - ADR-009（Windows での mise rust home 分離）の症状（junction marker と install 判定の揺れ）を直接修正するわけではないが、結果として顕在化を抑止する。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,6 +36,40 @@ mise install
 mise reshim
 ```
 
+## Windows で `core:dotnet` が毎回 install される
+
+症状: `mise ls dotnet` が `missing` を表示し、mise shim を通るコマンドの実行時に .NET SDK の install が繰り返される。Copilot CLI の command Hook が mise shim の影響を受ける環境では、無関係なツール呼び出しも `hook errored` で拒否される場合がある。
+
+まず、system dotnet と mise 管理 dotnet を分けて確認する。
+
+```powershell
+mise ls dotnet
+mise which dotnet
+dotnet --list-sdks
+
+$miseDotnetRoot = Join-Path $env:LOCALAPPDATA 'mise\dotnet-root'
+& (Join-Path $miseDotnetRoot 'dotnet.exe') --list-sdks
+```
+
+mise 管理側に対象 SDK が存在する一方、通常の `dotnet --list-sdks` に対象 SDK が出ない場合、`core:dotnet` のインストール後検証が system dotnet を起動している可能性がある。通常の `mise install --force dotnet` が同じ検証エラーで失敗する場合は、新しい一時 PowerShell で mise 管理 dotnet を検証対象にして再実行する。
+
+```powershell
+$miseDotnetRoot = Join-Path $env:LOCALAPPDATA 'mise\dotnet-root'
+$env:DOTNET_ROOT = $miseDotnetRoot
+$env:PATH = "$miseDotnetRoot;$env:PATH"
+mise install --force dotnet
+```
+
+一時 PowerShell を終了し、新しいシェルで復旧を確認する。
+
+```powershell
+mise ls dotnet       # missing を表示しない
+mise which dotnet    # mise\dotnet-root\dotnet.exe
+dotnet --version
+```
+
+この手順は、jdx/mise の [PR #10691](https://github.com/jdx/mise/pull/10691) で `dotnet --list-sdks` を使う方式へ変更された .NET SDK 検証が、Windows で system dotnet を起動する場合の暫定回避である。mise が管理対象の `dotnet.exe` を直接検証し、一時的な `DOTNET_ROOT` と PATH 設定なしで force install が成功するようになったら削除する。
+
 ## `run_once_*` スクリプトの warning / error
 
 実行順と役割は [`docs/architecture.md`](architecture.md#run_once_-スクリプトの実行順) を参照。
@@ -129,3 +163,22 @@ Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin
 
 - 高並列が予想される作業（一括コマンド送信など）では、1 応答内のツール呼び出し数を抑える
 - deny すべき操作が通ってしまった場合は `~/.copilot/audit.jsonl`（成功ログ）/ `audit-denies.jsonl`（preToolUse deny）/ `audit-failures.jsonl`（tool handler error）で事後検出し、手動で巻き戻す
+
+## Copilot CLI: `hook errored` の詳細を確認する
+
+`preToolUse` command Hook が非ゼロで終了すると、Copilot CLI はツール呼び出しを拒否する。ツール結果には `hook errored` だけが表示される場合でも、セッションの `events.jsonl` に Hook の標準エラーが記録されている。
+
+```powershell
+Get-Content "$HOME\.copilot\session-state\<session-id>\events.jsonl" |
+  ForEach-Object { $_ | ConvertFrom-Json } |
+  Where-Object {
+    $_.type -eq 'hook.end' -and
+    $_.data.hookType -eq 'preToolUse' -and
+    $_.data.success -eq $false
+  } |
+  ForEach-Object { $_.data.error.message }
+```
+
+`hook errored` だけから Hook 本体の障害と判断しない。標準エラー、Hook の起動コマンド、起動時に解決された runtime を確認する。
+
+上のフィルターで何も表示されない場合は、CLI の更新でイベント形式が変わった可能性がある。`Where-Object { $_.type -eq 'hook.end' }` まで条件を緩め、直近イベントの `data` 全体を確認する。

--- a/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
@@ -54,8 +54,12 @@ $installExit = $LASTEXITCODE
 $reshimExit = $LASTEXITCODE
 
 if ($installExit -ne 0 -or $reshimExit -ne 0) {
-  Write-Warning ("mise sync finished with non-zero exit codes (install={0}, reshim={1}). " +
-    "次回 chezmoi apply 時に再試行されるため、原因を確認してください。" -f $installExit, $reshimExit)
+  Write-Error ("mise sync failed (install={0}, reshim={1}). " +
+    "原因を解消してから ``chezmoi apply`` を実行してください。" -f $installExit, $reshimExit)
+  $syncExit = if ($installExit -ne 0) { $installExit } else { $reshimExit }
+}
+else {
+  $syncExit = 0
 }
 
 # corepack (pnpm/yarn 提供) を有効化する。mise 管理 node に同梱されており、
@@ -68,5 +72,5 @@ if ($corepackCmd) {
   }
 }
 
-exit 0
+exit $syncExit
 {{- end -}}

--- a/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
@@ -39,8 +39,14 @@ mise reshim
 reshim_exit=$?
 
 if [ "$install_exit" -ne 0 ] || [ "$reshim_exit" -ne 0 ]; then
-  echo "WARN: mise sync finished with non-zero exit codes (install=${install_exit}, reshim=${reshim_exit})." >&2
-  echo '     次回 chezmoi apply 時に再試行されます。原因を確認してください。' >&2
+  echo "ERROR: mise sync failed (install=${install_exit}, reshim=${reshim_exit})." >&2
+  echo '       原因を解消してから `chezmoi apply` を実行してください。' >&2
+  sync_exit="$install_exit"
+  if [ "$sync_exit" -eq 0 ]; then
+    sync_exit="$reshim_exit"
+  fi
+else
+  sync_exit=0
 fi
 
 # corepack (pnpm/yarn 提供) を有効化する。mise 管理 node に同梱されており、
@@ -49,5 +55,5 @@ if command -v corepack >/dev/null 2>&1; then
   corepack enable || echo 'WARN: corepack enable failed.' >&2
 fi
 
-exit 0
+exit "$sync_exit"
 {{- end -}}

--- a/tests/test_mise_config.py
+++ b/tests/test_mise_config.py
@@ -1,0 +1,58 @@
+"""Verify mise backend configuration and migration instructions stay aligned."""
+
+import pathlib
+import re
+import tomllib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / "home/dot_config/mise/config.toml.tmpl"
+LOCK_PATH = REPO_ROOT / "home/dot_config/mise/private_mise.lock"
+INSTRUCTIONS_PATH = REPO_ROOT / ".github/copilot-instructions.md"
+SYNC_SH_PATH = REPO_ROOT / "home/run_onchange_after_15-mise-sync-tools.sh.tmpl"
+SYNC_PS1_PATH = REPO_ROOT / "home/run_onchange_after_15-mise-sync-tools.ps1.tmpl"
+
+
+def _tool_alias(config: str, tool: str) -> str:
+    match = re.search(
+        rf"(?ms)^\[tool_alias\]\s*$.*?^{re.escape(tool)}\s*=\s*\"([^\"]+)\"\s*$",
+        config,
+    )
+    if match is None:
+        raise AssertionError(f"Missing [tool_alias] entry for {tool}")
+    return match.group(1)
+
+
+class MiseConfigTests(unittest.TestCase):
+    def test_dotnet_alias_matches_lock_backend(self) -> None:
+        config = CONFIG_PATH.read_text(encoding="utf-8")
+        lock = tomllib.loads(LOCK_PATH.read_text(encoding="utf-8"))
+
+        dotnet_entries = lock["tools"]["dotnet"]
+        self.assertEqual(len(dotnet_entries), 1)
+        self.assertEqual(_tool_alias(config, "dotnet"), dotnet_entries[0]["backend"])
+
+    def test_backend_migration_requires_postconditions(self) -> None:
+        instructions = INSTRUCTIONS_PATH.read_text(encoding="utf-8")
+
+        for command in ("mise ls <tool>", "mise which <tool>", "<tool> --version"):
+            with self.subTest(command=command):
+                self.assertIn(command, instructions)
+        self.assertIn("`missing` を表示しない", instructions)
+        self.assertIn("backend 固有の install path", instructions)
+
+    def test_lock_sync_propagates_mise_failure(self) -> None:
+        shell_script = SYNC_SH_PATH.read_text(encoding="utf-8")
+        powershell_script = SYNC_PS1_PATH.read_text(encoding="utf-8")
+
+        self.assertIn('exit "$sync_exit"', shell_script)
+        self.assertIn("exit $syncExit", powershell_script)
+        for script in (shell_script, powershell_script):
+            self.assertIn("chezmoi apply", script)
+            self.assertNotIn("chezmoi apply --force", script)
+            self.assertNotIn("次回 chezmoi apply 時に再試行", script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- mise backend 移行時の設定不整合を回帰テストで検出
- lockfile 同期時の `mise install` / `mise reshim` 失敗を成功扱いせず、chezmoi へ終了コードを伝播
- Windows `core:dotnet` と Copilot CLI Hook の診断手順を追加

## Changes

- backend 変更後の完了条件を Copilot instructions に追加
- shell / PowerShell の lockfile 同期 Hook を fail-closed に変更
- config、lockfile、instructions の変更時にも関連テストを実行
- ADR-013 を実際の再実行挙動に更新

## Verification

- `uv run -m unittest discover -s tests -v`
- rendered shell / PowerShell templates の構文確認
- shell hook の成功時と install 失敗時の終了コード確認
