### PR TITLE
fix: Windowsのghq rootをDドライブへ変更

### DIFF
--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -44,7 +44,11 @@
 	helper = "!f() { test \"$1\" = get && echo username={{ .corpUser }} && echo password=$(gh auth token --user {{ .corpUser }}); }; f"
 {{- end }}
 [ghq]
+{{- if .isWindows }}
+	root = D:/workspace
+{{- else }}
 	root = ~/workspace
+{{- end }}
 	user = torumakabe
 [user]
 	name = Toru Makabe
@@ -66,7 +70,7 @@
 # gitdir matches the repository path prefix, so keep shared defaults here and load
 # platform-specific overrides from separate files without duplicating the base config.
 # Windows uses explicit drive letters because Git has no drive-agnostic gitdir pattern;
-# this setup assumes local clones live on C:/ or D:/ and needs another rule otherwise.
+# ghq stores local clones under D:/workspace, while C:/ remains supported separately.
 [includeIf "gitdir:~/workspace_corp/"]
 	path = ~/.gitconfig-corp
 [includeIf "gitdir:/home/"]


### PR DESCRIPTION
## 背景

Windowsでは `~/workspace` から Dev Drive 上の `D:/workspace` へシンボリックリンクしていたため、パスの正規化やアクセス許可を扱うツールがC:側のパスを参照する可能性がありました。

## 変更内容

Windowsではghqが `D:/workspace` を直接参照するようにchezmoiテンプレートを分岐します。macOS、Linux、WSLでは従来どおり `~/workspace` を使用し、C:とD:のGit `includeIf` は両方維持します。

## 確認

- Windowsで生成される `ghq.root` が `D:/workspace` であること
- ghq管理下の19リポジトリとworktreeがD:の実パスで利用できること
- 適用後のchezmoi差分がないこと