### PR TITLE
fix: allow mise release-age warnings on PowerShell

### DIFF
--- a/home/PowerShell_profile.ps1.tmpl
+++ b/home/PowerShell_profile.ps1.tmpl
@@ -143,7 +143,14 @@ function Invoke-MiseUpgrade {
             if ($miseExitCode -ne 0) {
                 throw $FailureMessage
             }
-            if ($capturedOutput | Where-Object { "$_" -match 'mise WARN' }) {
+            $minimumReleaseAgePattern = '^mise WARN\s+newer \S+ release \S+(?:\s+\(released [^)]+\))?\s+ignored by minimum_release_age \([^)]+\); latest eligible release is \S+\s*$'
+            $blockingWarnings = $capturedOutput |
+                ForEach-Object { "$_" -replace "`e\[[0-9;]*[A-Za-z]", "" } |
+                Where-Object {
+                    $_ -match 'mise WARN' -and
+                    $_ -notmatch $minimumReleaseAgePattern
+                }
+            if ($blockingWarnings) {
                 throw "$FailureMessage mise の警告を検出したため、commit と push を中止します"
             }
         }

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -266,7 +266,7 @@ _mise_is_allowed_warning() {
   emulate -L zsh
 
   local warning="$1"
-  local minimum_release_age_pattern='^mise WARN[[:space:]]+newer [^[:space:]]+ release [^[:space:]]+ ignored by minimum_release_age \([^)]+\); latest eligible release is [^[:space:]]+$'
+  local minimum_release_age_pattern='^mise WARN[[:space:]]+newer [^[:space:]]+ release [^[:space:]]+([[:space:]]+\(released [^)]+\))?[[:space:]]+ignored by minimum_release_age \([^)]+\); latest eligible release is [^[:space:]]+$'
   [[ "$warning" =~ $minimum_release_age_pattern ]]
 }
 


### PR DESCRIPTION
## Summary
- allow the expected mise minimum_release_age warning in PowerShell
- keep other mise warnings blocking

## Validation
- PowerShell warning handling covered by the follow-up parity test suite