### PR TITLE
fix: install Copilot CLI even when the base image ships one

### DIFF
--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -25,6 +25,8 @@
 
 更新は全 OS で `copilot update`。macOS では Copilot Desktop から参照できるよう、`.zshrc` で `COPILOT_CLI_PATH` を公開する。
 
+Codespaces / Dev Container のベースイメージには `/usr/local/bin/copilot` が同梱されていることがあり、`copilot update` の対象外のまま古くなる。このため導入判定は `command -v copilot` ではなく `~/.local/bin/copilot` の実体で行う（[`docs/troubleshooting.md`](troubleshooting.md#codespaces--dev-container-で-copilot-のバージョンが古い)）。
+
 ## LSP サーバー
 
 `~/.copilot/lsp-config.json` (chezmoi 管理) で設定する。Python 向け `ty` (Astral) は mise バックエンドがないため `uv tool install ty`（`run_once` で自動化）、TypeScript 等の npm パッケージは mise の `npm:` バックエンドで管理する。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,6 +111,25 @@ chezmoi apply ~/.config/git/templates/hooks/pre-commit
 
 Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin/env bash` が WSL の `bash.exe` を拾い、Windows 形式の `C:/...` パスを開けていない可能性がある。この pre-commit hook はその経路を避けるため POSIX `sh` 互換で管理する。mise の Windows shim も extensionless 版は `/bin/bash` スクリプトなので、hook 内では `gitleaks.exe` を優先する。
 
+## Codespaces / Dev Container で `copilot` のバージョンが古い
+
+症状: `copilot --version` が極端に古い（例: 1.0.3）。
+
+原因: ベースイメージ（Codespaces universal 等）に `/usr/local/bin/copilot` が同梱されており、`run_once_before_10-install-packages.sh` の導入判定が `command -v copilot` だと、これを検出して公式スクリプトによる導入をスキップしていた。同梱バイナリはイメージのビルド時点で固定されるため、`copilot update` の対象にもならない。
+
+対策は導入済み。判定は `~/.local/bin/copilot` の実体で行う。既存のコンテナでは次で復旧する。
+
+```bash
+curl -fsSL https://gh.io/copilot-install | bash   # ~/.local/bin/copilot へ導入
+exec zsh -l
+type -a copilot                                   # 先頭が ~/.local/bin/copilot であること
+~/.local/bin/copilot --version
+```
+
+同梱バイナリは削除しない。`~/.local/bin` が PATH で `/usr/local/bin` より前にあれば shadow されるため、特権操作なしで解決する（Codespaces universal イメージではこの順序を確認済み。逆順のイメージでは PATH 側の調整が必要）。`copilot update` が更新するのは実行された側の実体だけで、同梱バイナリは対象外である。
+
+VS Code 拡張 (`github.copilot-chat`) が PATH へ注入する `.../globalStorage/github.copilot-chat/copilotCli/copilot` は shim であり、自分のディレクトリを除いた PATH から実体を探して委譲するだけなので、バージョン固定の原因にはならない。ただし `command -v copilot` はこの shim を返すため、確認には `type -a copilot` を使う。
+
 ## Copilot CLI: preToolUse フックが並列実行時にすり抜ける
 
 症状: 短時間に複数のツール呼び出しが走った際、`copilot-guard.py` / `uv-enforcer.py` の deny が適用されず、ブロックすべき操作が実行される。

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -30,9 +30,18 @@ sudo apt-get install -y -qq \
 
 # Copilot CLI — mise の github: バックエンドでは更新が遅れるため、
 # 公式インストールスクリプトで導入し、更新は copilot update で行う
-if ! command -v copilot >/dev/null 2>&1; then
+# 判定に command -v を使わない: Codespaces / Dev Container のベースイメージには
+# /usr/local/bin/copilot が同梱されていることがあり、これを検出すると自前の導入が
+# スキップされ、copilot update の対象外の古いバイナリが使われ続ける。
+# 公式スクリプトは非 root で ~/.local/bin へ入れるため、その実体で判定する。
+if [ ! -x "${HOME}/.local/bin/copilot" ]; then
   echo "Installing GitHub Copilot CLI via official script..."
-  curl -fsSL https://gh.io/copilot-install | bash
+  # GITHUB_TOKEN を外して実行する: Codespaces が注入するトークンでは、public repo の
+  # release asset でも SAML SSO により 403 になることがある (mise 側の回避と同じ理由)。
+  # 導入失敗で chezmoi apply 全体を止めないよう、警告に留める。
+  if ! (unset GITHUB_TOKEN GH_TOKEN; curl -fsSL https://gh.io/copilot-install | bash); then
+    echo "Warning: Copilot CLI installation failed. Run 'curl -fsSL https://gh.io/copilot-install | bash' manually." >&2
+  fi
 fi
 
 {{ if not .codespaces -}}

--- a/tests/test_copilot_cli_install.py
+++ b/tests/test_copilot_cli_install.py
@@ -1,0 +1,45 @@
+"""Guard the Copilot CLI install predicate in the Linux package bootstrap.
+
+Codespaces / Dev Container base images ship /usr/local/bin/copilot, which is
+never refreshed by `copilot update`. Gating the official installer on
+`command -v copilot` therefore pins an old CLI, so the gate must test the
+repo-managed binary at ~/.local/bin/copilot instead.
+"""
+import pathlib
+import re
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+BOOTSTRAP_PATH = REPO_ROOT / "home/run_once_before_10-install-packages.sh.tmpl"
+INSTALL_COMMAND = "curl -fsSL https://gh.io/copilot-install | bash"
+
+
+class CopilotCliInstallTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.bootstrap = BOOTSTRAP_PATH.read_text(encoding="utf-8")
+
+    def test_gate_uses_repo_managed_binary(self) -> None:
+        self.assertIn('if [ ! -x "${HOME}/.local/bin/copilot" ]; then', self.bootstrap)
+
+    def test_gate_does_not_regress_to_command_lookup(self) -> None:
+        self.assertNotRegex(self.bootstrap, r"command -v copilot")
+
+    def test_installer_runs_without_github_credentials(self) -> None:
+        # The token Codespaces injects can turn a public release asset into a
+        # SAML SSO 403, so the download must drop credentials.
+        pattern = re.compile(
+            r"\(unset GITHUB_TOKEN GH_TOKEN; " + re.escape(INSTALL_COMMAND) + r"\)"
+        )
+        self.assertRegex(self.bootstrap, pattern)
+
+    def test_install_failure_does_not_abort_apply(self) -> None:
+        # The script runs under `set -euo pipefail`; an unguarded install would
+        # stop every later chezmoi script.
+        self.assertIn("if ! (unset GITHUB_TOKEN GH_TOKEN;", self.bootstrap)
+        self.assertIn("Warning: Copilot CLI installation failed.", self.bootstrap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

Codespaces で `copilot --version` が 1.0.3 と極端に古いままだった。実機調査の結果、原因はベースイメージ同梱の `/usr/local/bin/copilot`（139MB, 3/9 ビルド）で、`run_once_before_10-install-packages.sh` の導入判定 `command -v copilot` がこれを検出し、公式インストールスクリプトによる導入を丸ごとスキップしていた。同梱バイナリはイメージのビルド時点で固定され、本リポジトリが前提とする `copilot update`（ADR-004）の対象にもならない。

同じベースイメージ系を使う Dev Container でも同一の事象になる（この導入ブロックは Codespaces / Dev Container を除外していない）。

## 変更内容

- 導入判定をリポジトリ管理下の実体 `~/.local/bin/copilot` に変更。同梱バイナリを検出しても自前の導入が走る
- 公式インストールスクリプトを `unset GITHUB_TOKEN GH_TOKEN` したサブシェルで実行し、失敗時は警告に留める
- `docs/troubleshooting.md` に原因と既存コンテナの復旧手順、`docs/copilot-cli.md` に判定方針を追記
- `tests/test_copilot_cli_install.py` を追加（判定式、`command -v copilot` への逆戻り禁止、認証情報除去、非致命化）

## 注意点・判断

- 認証情報を外すのは、Codespaces が注入するトークンだと public repo の release asset でも SAML SSO で 403 になり得るため。既存の mise 側回避（`run_once_after_20-mise-install.sh.tmpl`）と同じ理由。失敗を非致命にしたのは、このスクリプトが `set -euo pipefail` で動き、以降の chezmoi スクリプトを巻き添えにするのを避けるため
- 同梱バイナリは削除しない。`~/.local/bin` が PATH で `/usr/local/bin` より前にあれば shadow されるので、特権操作が不要。PATH 順序は Codespaces universal イメージで確認済み
- VS Code 拡張が PATH に注入する `.../github.copilot-chat/copilotCli/copilot` は shim（自分のディレクトリを除いた PATH から実体を探して委譲）であり、今回の原因ではない。ただし `command -v copilot` はこの shim を返すため、確認手順は `type -a copilot` にしている
- 検討して見送り: PATH 先頭移動などの `~/.profile` 側の硬化（今回の原因ではないため差分最小を優先）、Linux/WSL での環境別判定（ADR-004 の Linux 導入先は `~/.local/bin` であり、二重コピーは shadow されて更新も新しい側に効く）

## 検証

- `uv run -m unittest discover -s tests` : 258 件 OK
- `sh -n` でテンプレート本体の構文確認
- `if ! (unset ...; false | cat)` 構造を `set -euo pipefail` 下の sh で実行し、警告表示・処理継続・外側の環境変数保持を確認