### PR TITLE
fix: pin lockfile platforms via mise lockfile_platforms

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,8 @@
 
 ## mise 操作のトラップ
 
-- `mise lock` はデフォルトでプロジェクトレベルの設定のみ対象にするため、グローバル設定には **`--global`** が必須。また引数なしだと既定の 8 プラットフォーム（musl 含む）を対象にするため、**`--platform` も常に指定する**
+- `mise lock` はデフォルトでプロジェクトレベルの設定のみ対象にするため、グローバル設定には **`--global`** が必須。また `--platform` を省略すると mise の既定集合（musl を含む 7 種）が対象になるため、**`--platform` も常に指定する**
+- lockfile を書き戻すのは `mise lock` だけではない。`lockfile = true` のもとで `mise install` が実インストールを行うと、対象ツールのエントリを auto-lock が書き直す。基準集合は `[settings] lockfile_platforms`（`home/dot_config/mise/config.toml.tmpl`）が正本であり、プラットフォームを増減するときはここを変更する。ただし実行中のプラットフォームは設定に関わらず常に加わり、既存エントリは削除されない
 - 同じツールとバージョンを維持したまま backend を変更すると、mise は既存の install path をインストール済みと判定し、新しい backend で再インストールしない場合がある。backend を変更した端末では、`mise install --force <tool>` または `mise uninstall <tool>@<version>` と `mise install <tool>` を一度実行する。バージョンも同時に変更し、新しい install path へ通常の `mise install` が実行される場合、この操作は不要
 - backend 移行はコマンドの終了だけで完了と判断しない。`mise ls <tool>` が `missing` を表示しないこと、`mise which <tool>` が新 backend の実体を返すこと、`<tool> --version` 等の実行確認が成功することを確認する。force install が失敗した場合は `reshim` や auto-install の無効化で回避せず、backend 固有の install path と検証コマンドを調査する
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Linux / macOS / WSL / Windows / Codespaces / Dev Container で、できるだけ
 
 | 環境 | セットアップ | 補足 |
 |------|------------|------|
-| Linux / macOS / WSL | [Linux / macOS / WSL](#linux--macos--wsl) | WSL は初回 `windowsUser` 入力が必要 |
+| Linux / macOS / WSL | [Linux / macOS / WSL](#linux--macos--wsl) | macOS は Apple Silicon のみ。WSL は初回 `windowsUser` 入力が必要 |
 | GitHub Codespaces | [GitHub Codespaces](#github-codespaces) | 非対話セットアップのため一部設定を省略 |
 | Dev Container (ローカル) | [Dev Container](#dev-container-ローカル) | `mise install --yes` は起動後に手動実行 |
 | Windows | [Windows](#windows) | `copilot` は DSC + winget で導入 |

--- a/docs/adr/021-mise-lockfile-platforms.md
+++ b/docs/adr/021-mise-lockfile-platforms.md
@@ -1,0 +1,44 @@
+# ADR-021: lockfile の対象プラットフォームは lockfile_platforms で固定する
+
+## Status
+
+Accepted
+
+## Context
+
+Codespace で `chezmoi status` が `MM .config/mise/mise.lock` を示し、`chezmoi apply` が「has changed since chezmoi last wrote it?」と問い合わせて TTY の無い環境で停止した。差分の方向を確認すると、source（`home/dot_config/mise/private_mise.lock`）は git クリーンで、デプロイ済みの `~/.config/mise/mise.lock` に 129 行のプラットフォームエントリ（`linux-arm64-musl`、`linux-x64-baseline`、`linux-x64-musl`、`linux-x64-musl-baseline`、`windows-x64-baseline`）が追加されていた。バージョンと既存 URL は変わらず、source は deployed の厳密な部分集合だった。
+
+原因は `[settings] lockfile = true` のもとでの auto-lock である。`mise install` が実インストールを行うと、mise は対象ツールのエントリを musl と baseline を含む既定のプラットフォーム集合で書き直す（mise [PR #8277](https://github.com/jdx/mise/pull/8277)）。リポジトリは同種の混入を `mise lock --global --platform ...` という CLI フラグで防いでいたが、`mise install` 経由の書き戻しはこのフラグでは塞げない。
+
+## Decision
+
+`home/dot_config/mise/config.toml.tmpl` の `[settings]` に mise 標準設定 `lockfile_platforms` を追加し、auto-lock と `--platform` を省略した `mise lock` が使う基準集合を固定する。
+
+```toml
+lockfile_platforms = ["linux-x64", "linux-arm64", "macos-arm64", "windows-x64", "windows-arm64"]
+```
+
+この設定は mise [PR #8966](https://github.com/jdx/mise/pull/8966) で追加された公式機能であり、`2026.4.8` 以降に含まれる。環境変数を各スクリプトへ配る独自の仕組みを作るより、mise の標準設定に委ねる方を選んだ。
+
+集合は mise の既定（`linux-arm64`、`linux-arm64-musl`、`linux-x64`、`linux-x64-musl`、`macos-arm64`、`macos-x64`、`windows-x64` の 7 種）とは一致させない。musl 系はこの dotfiles の対象外であり、`macos-x64` は macOS を Apple Silicon に限定するため除く。代わりに既定に無い `windows-arm64` を加える。
+
+`mise-upgrade`（zsh の関数と PowerShell の `Invoke-MiseUpgrade`）が持つ明示的な `mise lock --global --platform ...` は残す。この処理は既存 lockfile を削除してから再生成する破壊的操作であり、設定が読まれない状況（`2026.4.8` 未満の mise、設定ファイルの欠落）でも意図した集合になることを保証する必要があるため。プラットフォーム集合の正本は config.toml とし、`tests/test_mise_config.py` が config.toml を TOML として解析した値から CLI の CSV を導出して、zsh / PowerShell / 文書との一致を検査する。
+
+## Consequences
+
+以下は mise 2026.7.12 linux-x64 で実測した結果である。
+
+- **発火条件は実インストール。** `mise install` が実際にツールを導入したときだけ lockfile を書き戻す。`all tools are installed` で終わる場合は変更しない。クリーンな lockfile から `mise uninstall yq && mise install yq` を実行すると、設定が無い場合は musl / baseline 5 種が付き、設定がある場合はドリフトしなかった。
+- **現在のプラットフォームは設定値に関わらず加わる。** 設定を `macos-arm64,windows-x64` に絞って yq のエントリを再生成すると、実行環境の `linux-x64` を含む 3 種になった。設定は厳密な許可リストではなく、集合に無い環境（musl 系など）で作業すればその分エントリが増える。
+- **既存エントリは削除されない**（mise PR #9621）。不要なエントリを消すには lockfile を削除して再生成する。
+- **グローバル設定なので他リポジトリの lockfile 操作にも及ぶ。** auto-lock が影響を受けるのは、そのリポジトリが `lockfile = true` を有効にしている場合に限る（`lockfile = true` 自体はグローバルからリポジトリへ波及せず、opt-in していないリポジトリでは `mise.lock` が生成されなかった）。一方 `mise lock` を明示実行した場合は、`lockfile = true` の有無に関わらずこの基準集合が使われる。別の集合が必要なときは `--platform` の明示で上書きできる（明示値が設定より優先されることを確認済み）。
+- **`2026.4.8` 未満の mise では設定が警告なく無視される。** `run_once_before_20-install-mise.sh` は既存の mise があるとバージョンを問わず何もしないため、古い mise を持つ既存端末では従来どおりドリフトする。ただしドリフトは `chezmoi apply` が検知するため、沈黙したまま進むことはない。復旧手順は `docs/troubleshooting.md` に記す。
+- **musl / baseline の全面禁止は検査できない。** bun は musl / baseline をリリース成果物として持つため、source lockfile にも正当なエントリが数件ある。
+
+## 関連
+
+- ADR-013（mise lockfile 同期フック）は置き換えない。同 ADR の sync hook が実行する `mise install` が lockfile を書き戻し得る、という前提を補う。
+
+## 引き継ぐ検証
+
+- `2026.4.8` 未満の mise で設定が無視されることは、公式のリリース内容から判断した。古い mise を用意しての実測は行っていない。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -32,6 +32,7 @@
 | [017](017-msvc-linker-env-var-override-windows.md) | Windows の MSVC リンカーは CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER で明示指定する | Accepted |
 | [018](018-git-hooks-via-init-templatedir.md) | 機械全体への Git hook 配布は init.templateDir で行う | Accepted |
 | [019](019-cross-platform-parity-contract.md) | クロスプラットフォーム機能等価性はプラットフォーム契約と静的検査で担保する | Accepted |
+| [021](021-mise-lockfile-platforms.md) | lockfile の対象プラットフォームは lockfile_platforms で固定する | Accepted |
 
 ## テンプレート
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,10 +61,26 @@ zsh の `mise-upgrade` と PowerShell の `Invoke-MiseUpgrade` は、処理を�
 mise-upgrade
 ```
 
+### 対象プラットフォームの定義元
+
+対象プラットフォームは `~/.config/mise/config.toml` の `[settings] lockfile_platforms` が正本である。この設定は、auto-lock（`mise install` が実インストール後に走らせる書き戻し）と `--platform` を省略した `mise lock` が使う基準集合を決める。
+
+```toml
+[settings]
+lockfile_platforms = ["linux-x64", "linux-arm64", "macos-arm64", "windows-x64", "windows-arm64"]
+```
+
+この設定には、運用上で把握しておくべき性質が四つある。
+
+- **厳密な許可リストではない。実行中のプラットフォームは設定値に無くても必ず加わる。** 上記に無い環境（musl 系の `linux-x64-musl` など）で `mise install` を実行すると、その環境の分だけエントリが増える。この dotfiles は macOS を Apple Silicon に限定しているため、`macos-x64` は集合に含めていない。
+- **明示した `--platform` が設定より優先される。** 別の集合を書きたいときは CLI で指定する。
+- **既存エントリは削除されない。** 設定を絞っても、すでに lockfile にあるプラットフォームはそのまま残る。不要なエントリを消すには lockfile を削除して再生成する。
+- **グローバル設定なので、他のリポジトリでの lockfile 操作にも及ぶ。** auto-lock が影響を受けるのは、そのリポジトリ自身が `lockfile = true` を有効にしている場合に限る（`lockfile = true` はグローバルからリポジトリへ波及しない）。一方、そのリポジトリで `mise lock` を明示実行した場合は、`lockfile = true` の有無に関わらずこの基準集合が使われる。
+
 ### 手動操作の重要ルール
 
 - `mise lock` は **`--global` が必須**（省略するとプロジェクト設定のみ対象になる）
-- lockfile 再生成時は **`--platform` を常に指定**
+- lockfile 再生成時は **`--platform` を常に指定**する。`lockfile_platforms` があっても省略しない。lockfile を削除してから再生成する破壊的操作であり、設定が読まれない状況（古い mise、設定ファイルの欠落）でも意図した集合になることを保証するため
 - `mise upgrade` 後は lockfile を一度削除してから再生成する（既存エントリが残り新版が反映されないため）
 - 両シェルとも、`minimum_release_age` の正規形に一致するリリース保留警告だけを許可し、警告内容を表示して処理を継続する
 - 両シェルとも、正規形以外の `mise WARN` が出力された場合は、終了コードが `0` でも lockfile を復元し、commit と push を行わない

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,40 @@ GITHUB_TOKEN=$(gh auth token) mise lock --global --platform linux-x64,linux-arm6
 mise install
 ```
 
+## `mise.lock has changed since chezmoi last wrote it?` と聞かれる
+
+`chezmoi status` が `MM .config/mise/mise.lock` を示し、`chezmoi apply` が上のプロンプトを出す。Codespaces のような TTY の無い環境では `could not open a new TTY` で停止する。
+
+デプロイ済みの lockfile に、意図しないプラットフォームのエントリが加わった状態である。`chezmoi diff ~/.config/mise/mise.lock` で追加された行を確認する。`linux-x64-musl` や `windows-x64-baseline` のようなエントリが増えていれば、`lockfile_platforms` が効かないまま auto-lock が走ったことを意味する（[ADR-021](adr/021-mise-lockfile-platforms.md)）。
+
+原因は二つある。まず mise のバージョンを確認する。
+
+```bash
+mise --version
+```
+
+`lockfile_platforms` は mise `2026.4.8` 以降が必要である。これより古い場合、設定は警告なく無視される。既存の mise がある端末では `run_once_before_20-install-mise.sh` がバージョンを問わず何もしないため、自分で更新する。
+
+```bash
+mise self-update        # macOS/Homebrew は brew upgrade mise、Windows は mise-self-upgrade
+```
+
+mise が要件を満たしていれば、原因は設定が届いていないことである。次で確認して配り直す。
+
+```bash
+mise settings get lockfile_platforms
+chezmoi apply --force ~/.config/mise/config.toml
+```
+
+どちらの場合も、最後にデプロイ済み lockfile を source の内容へ戻す。`--force` を付けるのは、対象を lockfile 一つに限ってプロンプトを飛ばすためである。他のファイルのローカル変更には影響しない。
+
+```bash
+chezmoi apply --force ~/.config/mise/mise.lock
+chezmoi status
+```
+
+`chezmoi status` から `.config/mise/mise.lock` が消えれば復旧している。
+
 ## shell 起動時に `mise WARN missing:` が出る
 
 `mise upgrade` 等で `private_mise.lock` が更新された後、対応する `mise install` / `mise reshim` が走っていないと shim と install marker が古いまま残り、`mise hook-env` で `WARN missing:` が出る。

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -36,6 +36,11 @@ cargo-make = "latest"
 [settings]
 experimental = true
 lockfile = true
+# auto-lock と `--platform` 未指定の `mise lock` が使う基準集合を固定する。
+# 未指定だと mise install の auto-lock が musl を含む既定集合を書き足し、
+# chezmoi apply が lockfile の差分を検知して非対話環境で停止する。
+# 実行中のプラットフォームは、この配列に無くても必ず対象へ加わる。
+lockfile_platforms = ["linux-x64", "linux-arm64", "macos-arm64", "windows-x64", "windows-arm64"]
 fetch_remote_versions_timeout = "60s"
 
 [tool_alias]

--- a/tests/test_mise_config.py
+++ b/tests/test_mise_config.py
@@ -64,6 +64,19 @@ def _tool_alias(config: str, tool: str) -> str:
     return match.group(1)
 
 
+def _config_toml(config: str) -> dict:
+    """chezmoi のテンプレート行を除いた config.toml.tmpl を TOML として読む。"""
+    stripped = re.sub(r"(?m)^\{\{.*\}\}[ \t]*$\n?", "", config)
+    return tomllib.loads(stripped)
+
+
+def _lockfile_platforms(config: str) -> list[str]:
+    settings = _config_toml(config).get("settings", {})
+    if "lockfile_platforms" not in settings:
+        raise AssertionError("[settings] に lockfile_platforms がありません")
+    return settings["lockfile_platforms"]
+
+
 def _mise_warning_helpers() -> str:
     zshrc = ZSHRC_PATH.read_text(encoding="utf-8")
     start = zshrc.index("_mise_normalize_log_line() {")
@@ -363,17 +376,26 @@ $result = @{{
         self.assertTrue(state["log_exists"])
 
     def test_mise_lock_platform_contract_stays_aligned(self) -> None:
+        config = CONFIG_PATH.read_text(encoding="utf-8")
         zshrc = ZSHRC_PATH.read_text(encoding="utf-8")
         profile = POWERSHELL_PROFILE_PATH.read_text(encoding="utf-8")
         operations = OPERATIONS_PATH.read_text(encoding="utf-8")
         troubleshooting = TROUBLESHOOTING_PATH.read_text(encoding="utf-8")
 
+        # config.toml が正本。CLI と文書はここから導出した値と突き合わせる。
+        platforms = _lockfile_platforms(config)
+        platform_csv = ",".join(platforms)
+        self.assertEqual(platforms, list(MISE_LOCK_PLATFORMS))
         self.assertIn(
-            f"mise lock --global --platform {MISE_LOCK_PLATFORM_CSV}",
+            f"lockfile_platforms = {json.dumps(platforms)}",
+            operations,
+        )
+        self.assertIn(
+            f"mise lock --global --platform {platform_csv}",
             zshrc,
         )
         self.assertIn(
-            f'-Arguments @("lock", "--global", "--platform", "{MISE_LOCK_PLATFORM_CSV}")',
+            f'-Arguments @("lock", "--global", "--platform", "{platform_csv}")',
             profile,
         )
         for path, document in (
@@ -387,7 +409,7 @@ $result = @{{
                 )
                 self.assertEqual(
                     set(platform_values),
-                    {MISE_LOCK_PLATFORM_CSV},
+                    {platform_csv},
                 )
 
     def test_cargo_make_linux_arm64_constraint_stays_aligned(self) -> None:


### PR DESCRIPTION
## 背景

Codespace で `chezmoi status` が `MM .config/mise/mise.lock` を示し、`chezmoi apply` が「`.config/mise/mise.lock` has changed since chezmoi last wrote it?」と問い合わせて `could not open a new TTY` で停止した。

差分の方向を確認すると、source (`home/dot_config/mise/private_mise.lock`) は git クリーンで、デプロイ済みの `~/.config/mise/mise.lock` にプラットフォームエントリ 129 行 (`linux-arm64-musl`, `linux-x64-baseline`, `linux-x64-musl`, `linux-x64-musl-baseline`, `windows-x64-baseline`) が追加されていた。バージョンと既存 URL は変わらず、source は deployed の厳密な部分集合だった。

原因は `[settings] lockfile = true` のもとでの auto-lock である。`mise install` が実インストールを行うと、mise は対象ツールのエントリを既定のプラットフォーム集合で書き直す ([mise#8277](https://github.com/jdx/mise/pull/8277), 2026-02-21)。

このリポジトリは同種の混入を `mise lock --global --platform ...` の CLI フラグで既に防いでおり、`.github/copilot-instructions.md` にもトラップとして記録済みだった。しかし `mise install` 経由の書き戻しはこのフラグでは塞げない。ADR-013 の sync hook が実行する `mise install` も同じ経路を通る。

## 変更内容

- `home/dot_config/mise/config.toml.tmpl` の `[settings]` に mise 標準設定 `lockfile_platforms` を追加。auto-lock と `--platform` 省略時の `mise lock` が使う基準集合を固定する
- `tests/test_mise_config.py`: config.toml を TOML として解析した値から CLI の CSV を導出し、zsh / PowerShell / 文書との一致を検査する形へ変更。config.toml が正本になる
- `docs/adr/021-mise-lockfile-platforms.md` (新規, Accepted) と `docs/adr/INDEX.md`
- `docs/operations.md`: 「対象プラットフォームの定義元」節を追加。設定の四つの性質と、`--platform` を常時指定し続ける理由を記載
- `docs/troubleshooting.md`: このドリフトからの復旧手順を追加。mise 最低バージョンの確認と、対象を限定した `chezmoi apply --force`
- `README.md`: macOS は Apple Silicon のみと明記
- `.github/copilot-instructions.md`: 「lockfile を書き戻すのは `mise lock` だけではない」旨を追記。あわせて既存の「既定の 8 プラットフォーム」という誤記を実測値の 7 種へ修正

## 注意点・判断

- **mise の標準機能を選んだ。** 環境変数 `MISE_LOCKFILE_PLATFORMS` を各スクリプト (sync hook, bootstrap の複数箇所) へ配る独自の仕組みも検討したが、経路の網羅が運用者の注意に依存する。`lockfile_platforms` は [mise#8966](https://github.com/jdx/mise/pull/8966) で追加され `2026.4.8` 以降に含まれる公式設定で、その後も継続して手入れされている
- **`mise-upgrade` の明示 `--platform` は撤去しない。** 既存 lockfile を削除してから再生成する破壊的操作であり、設定が読まれない状況 (古い mise、設定ファイルの欠落) でも意図した集合になる保証が要る。明示値が設定より優先されることは実測で確認した。冗長だが、テストが config.toml から導出した値との一致を強制するため乖離しない
- **設定は厳密な許可リストではない。** 実行中のプラットフォームは配列に無くても必ず加わる。この性質は operations.md と ADR に明記した
- **グローバル設定なので他リポジトリにも及ぶ。** auto-lock が影響を受けるのは、そのリポジトリ自身が `lockfile = true` を有効にしている場合に限る (`lockfile = true` はグローバルからリポジトリへ波及しない)。`mise lock` の明示実行時は基準集合が使われるが、`--platform` で上書きできる
- **macOS は Apple Silicon 限定と確定させた。** `install.sh` が `darwin-amd64` を扱い `dot_profile.tmpl` が Intel の Homebrew パスも探す一方、lockfile には `macos-arm64` しか無く、判断が割れていた。`macos-x64` を集合へ加えると lockfile の再生成が必要になるため、対応環境を Apple Silicon に限定する方を選び README に明記した
- **`2026.4.8` 未満の mise では設定が警告なく無視される。** `run_once_before_20-install-mise.sh` は既存の mise があるとバージョンを問わず何もしないため、古い端末では従来どおりドリフトする。ただしドリフト自体は `chezmoi apply` が検知するので沈黙しない。バージョン検査を追加するより、troubleshooting の復旧手順で扱う方を選んだ
- 検討して見送り: lockfile の内容そのものを検査するテスト。bun は musl / baseline をリリース成果物として持ち source lockfile にも正当なエントリがあるため、単純な禁止検査は書けない

## 検証

実環境 (Codespaces, mise 2026.7.12 linux-x64) で実測した。

- **因果の対照実験**: クリーンな lockfile から `mise uninstall yq && mise install yq` を実行。設定なしでは musl / baseline 5 種が付着してドリフト、レンダリング済みテンプレートを配置した設定ありでは lockfile の md5 が不変で NO DRIFT
- **発火条件**: `all tools are installed` で終わる `mise install` は lockfile を変更しない。実インストールが起きたときだけ書き戻す
- **実行中プラットフォームの加算**: 設定を `macos-arm64,windows-x64` に絞って yq のエントリを空から再生成 → 実行環境の `linux-x64` を含む 3 種になった
- **既存エントリの保持**: 設定を絞っても lockfile にあるプラットフォームは残る ([mise#9621](https://github.com/jdx/mise/pull/9621) と整合)
- **スコープ**: global config.toml にのみ設定を置き、別ディレクトリのプロジェクトで `mise lock --dry-run` → 設定なし 7 種、設定あり 5 種。`lockfile = true` を opt-in していないプロジェクトでは `mise install` しても `mise.lock` は生成されない
- **明示の優先**: `mise lock --global --dry-run --platform macos-arm64` は「Targeting 1 platform(s)」
- **最低バージョン**: `gh api repos/jdx/mise/compare/v2026.4.7...efaedc24` が `ahead`、`v2026.4.8...` が `behind`。`2026.4.8` が初出と確定
- **テストが番人として働くこと**: config から 1 種削除 → `Lists differ`、`lockfile_platforms` 行を削除 → 専用の AssertionError、TOML を破壊 → `TOMLDecodeError` の 3 通りで検知を確認
- `uv run pytest tests/` : 255 passed, 8 skipped, 87 subtests passed
- 検証で触った `~/.config/mise/{config.toml,mise.lock}` は原状復帰済み。当初のドリフト 129 行も解消している
