### PR TITLE
feat: deliver gitleaks pre-commit via config-based hooks

### DIFF
--- a/docs/adr/018-git-hooks-via-init-templatedir.md
+++ b/docs/adr/018-git-hooks-via-init-templatedir.md
@@ -24,3 +24,5 @@ Python の `pre-commit` フレームワークには `pre-commit init-templatedir
 - テンプレートディレクトリは `hooks/pre-commit` のみを持ち、Git 既定の `*.sample` 等は引き継がない（この用途では無害・許容）。
 - 「chezmoi apply のたびに旧共有ディレクトリの不明ファイルを自動削除する」案は、他プロジェクトの正規 hook を無警告で無効化しうる（hook ファイル欠落は git が黙って無視する）ため設計段階で明示的に却下した。可視性を保ちつつ自動破壊的操作を避けるため、読み取り専用の `git-hooks-audit` を採用した。
 - Windows: hook 本体の POSIX `sh` 互換要件（Git for Windows が `/usr/bin/env bash` を WSL の bash.exe に解決し `C:/...` パスを開けない問題への対応）は変わらず適用される。
+- Git 2.54 以降では、ADR-020 の設定ベースフックが別レイヤとして加算的に走る。本 ADR の `init.templateDir` は撤去せず、Git 2.54 より前のバージョンでの唯一の配布経路として残す。
+- 上記のバックフィルは実際には実行されず、既存リポジトリで gitleaks が約 3 週間にわたり一度も走らない状態が続いた。本 ADR は、この状態を検知する仕組みを持たない。経緯と対処は ADR-020 に記す。

--- a/docs/adr/020-git-hooks-via-config.md
+++ b/docs/adr/020-git-hooks-via-config.md
@@ -4,7 +4,7 @@
 
 Proposed
 
-macOS、Linux コンテナ、Windows、WSL で検証した。結果は「検証記録」に記す。Dev Container と Codespaces は未検証であり、残る検証項目は「引き継ぐ検証」に記す。
+macOS、Linux コンテナ、Windows、WSL、Codespaces で検証した。結果は「検証記録」に記す。Dev Container は未検証であり、残る検証項目は「引き継ぐ検証」に記す。
 
 ## Context
 
@@ -58,12 +58,26 @@ Git 2.54 は、`gitconfig` に hook を定義する設定ベースフックを�
 | プラットフォーム | 入手方法 | dotfiles 側の変更 |
 | --- | --- | --- |
 | macOS | Homebrew | `run_once_before_10-install-packages.sh.tmpl` の `brew install` へ `git` を追加し、`dot_zprofile.tmpl` で PATH を調整する |
-| Linux | `ppa:git-core/ppa` | `run_once_before_10-install-packages.sh.tmpl` の apt ブロックへ PPA 追加を挿入する |
+| Linux | `ppa:git-core/ppa` | `run_once_before_10-install-packages.sh.tmpl` の apt ブロックへ PPA 追加を挿入し、PPA 版を隠す実体があれば `/usr/bin` 側へ張り替える |
 | Windows | Git for Windows | 変更なし。既定のインストーラが要件を満たすバージョンを配る |
+
+いずれのプラットフォームでも、要件を満たす git を入れるだけでは足りない。PATH で先に解決される実体が古ければ、新しい git は使われないまま残る。macOS と Linux では、この問題が別々の形で現れる。
 
 macOS では、`brew install git` だけでは要件を満たさない。`/etc/zprofile` の `path_helper` が login shell の PATH を再構築し、`/etc/paths` に載るシステムディレクトリを先頭へ、それ以外を末尾へ移す。`~/.zshenv` 経由で `~/.profile` が先頭に置いたディレクトリも、login zsh ではここで `/usr/bin` より後ろへ回る。`~/.profile` は多重読み込みガードにより再実行されないため、並びは `~/.zprofile` で戻す。
 
 戻す対象は `/opt/homebrew/opt/git/bin` に限る。このディレクトリは git 関連の実行ファイルだけを持つため、影響が git に閉じる。`~/.local/bin` や mise の shims をまとめて `/usr/bin` より前へ出すと、システムツール全般を shadow して影響範囲が読めなくなる。
+
+Linux では、Codespaces と Dev Container のベースイメージが同じ問題を作る。これらのイメージは devcontainers の git feature を `version: latest`、`ppa: false` で使い、git をソースからビルドして `/usr/local` へ入れる。`/usr/local/bin` は PATH で `/usr/bin` より先に来るため、PPA が新しい git を `/usr/bin` へ入れても、解決されるのはイメージ同梱の実体のままである。イメージのビルド時点で最新だった git が 2.54 に満たなければ、PPA の追加が成功しても設定ベースフックは無効のままになる。
+
+そこで `run_once_before_10-install-packages.sh.tmpl` は、`/usr/local/bin` 側の実体を `/usr/bin` の同名ファイルへの symlink で置き換える。適用範囲は次の三つで絞る。
+
+- 実行する環境を Codespaces と Dev Container に限る。他の Linux で `/usr/local` にある git は、その機械の利用者が自分で置いたものであり、dotfiles が判断してよい対象ではない。
+- 隠している側が 2.54 未満で、かつ `/usr/bin` 側が 2.54 以上のときだけ張り替える。設定ベースフックが有効か無効かを分ける場合に限る条件であり、イメージが要件を満たすようになれば何もしない。単に新しい方を選ぶ条件にすると、どちらでも保護が成立する状況で介入することになる。
+- 張り替える対象は `/usr/bin` に同名の実行ファイルがあるものだけに限る。この条件により、同じディレクトリにあって git 本体とは別に配布される `git-lfs` は対象から外れる。
+
+すでに symlink になっている `/usr/local/bin/git` は書き換えない。symlink は誰かが明示的に選んだ結果である可能性が高い。この場合に保護が満たされないままであれば、後述の報告が状態を伝える。
+
+削除ではなく symlink を選んだのは、`/usr/local/bin/git` を直接指す設定（VS Code の `git.path` など）をそのまま生かすためである。この張り替えは、shell を経由しない呼び出しにも効く。macOS の `~/.zprofile` による調整が login shell の PATH だけを直すのに対し、実体そのものを差し替えるため、どの経路から起動しても新しい git が使われる。
 
 Linux で PPA を追加できない環境では、ディストリビューション標準の git のまま処理を続ける。設定ベースフックは無効になるが、`init.templateDir` による保護は残る。
 
@@ -91,6 +105,10 @@ fi
 
 判定には git のバージョン番号ではなく `git hook list` の出力を使う。バージョンが条件を満たしていても設定が届いていなければ保護は効かないため、両方をまとめて確認できる。
 
+無効な場合の案内は、原因によって分かれる。走っている git がすでに 2.54 以上であれば、原因は git ではなく設定の欠落である。この場合に git の更新を案内しても状況は変わらないため、global gitconfig の確認と `chezmoi apply ~/.gitconfig` を案内する。この分岐はプラットフォームを問わない。
+
+走っている git が 2.54 に満たない場合、Linux では原因がさらに二つに分かれる。apt 側が要件を満たしていなければ PPA の追加を案内する。apt 側が 2.54 以上であれば、原因は apt ではなく PATH である。Codespaces と Dev Container で、隠しているのが `/usr/local/bin/git` の通常ファイルであればベースイメージのソースビルドと分かるので、張り替えるコマンドまで示す。それ以外のパス、すでに symlink である場合、コンテナ以外の環境では、mise の shim や利用者自身のビルドである可能性があり、出所を判定できない。この場合は状況を伝えるだけにして書き換えは案内しない。
+
 `init.templateDir` を撤去しない以上、この報告が無くても保護が完全に消えるわけではない。それでも報告する理由は、ADR-018 で失われたのが保護そのものではなく、失われたことに気づく手段だったからである。
 
 ### リポジトリ単位の無効化
@@ -108,23 +126,24 @@ git config --local hook.dotfiles-gitleaks.enabled false
 - 保護の有無は、実行された git バイナリのバージョンで決まる。PATH の解決が経路ごとに異なる環境では、保護される経路とされない経路が混在し得る。macOS の login shell については `~/.zprofile` で対処したが、Finder から起動した GUI アプリのように shell の設定を読まない経路は対象外である。
 - `$GIT_DIR/hooks` の hook は git が実行可能性を確認して欠落時は無視するのに対し、設定ベースフックには存在確認がない。`~/.local/bin/gitleaks-pre-commit` が読めなければ commit が拒否される。`chezmoi apply` が中断した場合などにこの状態が起こり得る。秘密情報の走査が無言で消えるよりも、commit が止まって原因が表示される方を選ぶ。この状態からの復旧は `chezmoi apply ~/.local/bin/gitleaks-pre-commit` で済む。
 - 走査スクリプトは設定ベースフック用とテンプレート用の二つに分かれる。探索ロジックを変更するときは両方を更新する。共有すると、片方を撤去する際にもう片方が壊れる結合が生まれるため、重複を選んだ。
+- Codespaces と Dev Container での張り替えは `run_once_before_10-install-packages.sh` が担うため、chezmoi の run_once の状態が残ったままイメージ側の git が元に戻る場合、張り替えは再実行されない。この状態は `run_after_40-check-git-hooks` が apply のたびに警告するので、保護が無いまま黙って進むことはない。復旧は `docs/operations.md` の手動手順で行う。
 - `--no-verify` で回避できる点は `init.templateDir` 方式と変わらない。誤って秘密情報を commit する事故を早期に止めることが目的であり、意図的な持ち出しを防ぐ境界は GitHub 側の secret scanning と push protection が担う。
 
 ## 検証記録
 
-macOS 実機、Linux コンテナ、Windows 実機、WSL (Ubuntu 22.04) で確認した。使用した git は、macOS が Homebrew の 2.55.0、Linux コンテナが `ppa:git-core/ppa` の 2.54.0、Windows が Git for Windows 2.55.0、WSL が同じ PPA の 2.54.0 である。WSL の git は apply 前が 2.34.1 であり、`run_once_before_10-install-packages.sh` の PPA 追加によって 2.54.0 へ更新された。
+macOS 実機、Linux コンテナ、Windows 実機、WSL (Ubuntu 22.04)、Codespaces で確認した。使用した git は、macOS が Homebrew の 2.55.0、Linux コンテナが `ppa:git-core/ppa` の 2.54.0、Windows が Git for Windows 2.55.0、WSL と Codespaces が同じ PPA の 2.54.0 である。WSL の git は apply 前が 2.34.1 であり、`run_once_before_10-install-packages.sh` の PPA 追加によって 2.54.0 へ更新された。
 
 commit を拒否したことの判定には、出力に `leaks found: 1` が現れること、git の終了コードが 1 であること、commit が作られないことの三つを使った。
 
-| 確認項目 | macOS / Linux | Windows | WSL |
-| --- | --- | --- | --- |
-| 要件 1: `.git/hooks` に hook を持たないリポジトリで秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した |
-| 要件 2: lefthook 生成の hook で上書きした状態で秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した |
-| 要件 2: 同じ状態で lefthook 自身の job も実行される | 実行した | 実行した | 実行した |
-| 設定ベースフック有効時の走査回数 | 1 回 | 1 回 | 1 回 |
-| リポジトリ単位で無効化した場合の走査回数 | 1 回 | 1 回 | 1 回 |
-| hook の中で解決される `git` が hook を起動した git と同一である | 同一 | 同一 | 同一 |
-| `chezmoi apply` 時の報告が、有効なら無出力、無効なら警告になる | 一致した | 一致した | 一致した |
+| 確認項目 | macOS / Linux | Windows | WSL | Codespaces |
+| --- | --- | --- | --- | --- |
+| 要件 1: `.git/hooks` に hook を持たないリポジトリで秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した | 拒否した |
+| 要件 2: lefthook 生成の hook で上書きした状態で秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した | 拒否した |
+| 要件 2: 同じ状態で lefthook 自身の job も実行される | 実行した | 実行した | 実行した | 実行した |
+| 設定ベースフック有効時の走査回数 | 1 回 | 1 回 | 1 回 | 1 回 |
+| リポジトリ単位で無効化した場合の走査回数 | 1 回 | 1 回 | 1 回 | 1 回 |
+| hook の中で解決される `git` が hook を起動した git と同一である | 同一 | 同一 | 同一 | 同一 |
+| `chezmoi apply` 時の報告が、有効なら無出力、無効なら警告になる | 一致した | 一致した | 一致した | 一致した |
 
 プラットフォームごとに個別に確認した事項を記す。
 
@@ -132,16 +151,21 @@ commit を拒否したことの判定には、出力に `leaks found: 1` が現�
 - macOS と Linux コンテナ: gitleaks が PATH にも mise shims にも無い場合、警告のみで commit は成功する (fail-open)。
 - Windows: hook の中で `sh` は `/usr/bin/sh` に解決される。これは Git for Windows が同梱する MSYS の sh であり、WSL の bash ではない。`command` に書いた `~` は Windows のユーザプロファイルを指す。
 - WSL: hook の中で `sh` は `/usr/bin/sh`、`git` は `/usr/lib/git-core/git` に解決される。`appendWindowsPath` を無効にしているため、Windows 側の実行ファイルは経路に入らない。
+- Codespaces: universal イメージ 5.1.5 (2026-03-11 ビルド) は git 2.53.0 を `/usr/local/bin` に持つ。PPA の追加と `apt-get install git` はどちらも成功して `/usr/bin/git` を 2.54.0 にしたが、張り替えを入れる前は `git` が 2.53.0 に解決され、要件 1 の試験で秘密鍵が commit された。張り替え後は `/usr/local/bin/git` が `/usr/bin/git` への symlink になり、`git-lfs` は元のまま残った。同じスクリプトを二度実行しても symlink は変わらない。hook の中で `git` は `/usr/lib/git-core/git` に解決される。
+
+Codespaces のイメージが git 2.53.0 を持つのは、devcontainers の git feature がイメージのビルド時点で最新のタグを解決するためである。git 2.54.0 のリリースは 2026-04-20 であり、5.1.5 のビルド (2026-03-11) より後にあたる。したがってイメージが更新されれば張り替えは不要になるが、更新の時期は利用者側で決められない。
+
+張り替えの条件分岐は、偽の bin ディレクトリを使って `tests/test_git_shadow_resolution.py` で確認した。テストはブートストラップから当該の関数を抜き出し、対象ディレクトリを引数で渡して `bash -euo pipefail` で実行する。対象を引数で受け取るのは、テストのために環境変数で書き換え先を差し替えられる余地を本番のスクリプトへ残さないためである。確認した内容は、2.53 から 2.54 へは張り替えること、2.54 から 2.55 へは張り替えないこと、`/usr/bin` 側が 2.43 なら張り替えないこと、`/usr/bin` に対応の無い `git-lfs` と `gitk` を残すこと、既存の symlink を書き換えないこと、隠している git がバージョンを返せなくても apply を止めないこと、二度目の実行が何も変えないことである。
 
 判定方法について確認した事項を記す。`git hook list` は該当する hook が無い場合に exit 1 を返し、サブコマンド自体を知らない git は exit 129 を返す。終了コードだけでは両者と「対応しているが未設定」を区別できないため、判定には標準出力の内容を使う。`--show-scope` を付けない場合、スコープと `disabled` の表示は出ない。
 
-`run_after_40-check-git-hooks` の警告経路は、`GIT_CONFIG_GLOBAL` を空のファイルへ向けて設定ベースフックが見えない状態を作り、Windows と WSL の双方で確認した。どちらも警告を出したうえで終了コード 0 を返し、apply を失敗させない。Windows 版は powershell.exe 5.1 で実行し、構文が通ることもあわせて確認した。
+`run_after_40-check-git-hooks` の警告経路は、`GIT_CONFIG_GLOBAL` を空のファイルへ向けて設定ベースフックが見えない状態を作り、Windows と WSL の双方で確認した。どちらも警告を出したうえで終了コード 0 を返し、apply を失敗させない。Windows 版は powershell.exe 5.1 で実行し、構文が通ることもあわせて確認した。Codespaces では案内の分岐を五通り確認した。走っている git が 2.54 以上であれば設定の確認と `chezmoi apply` を案内すること、張り替え済みの状態では PPA の案内を出すこと（symlink 越しに 2.54 が走る状態を隠蔽と呼ばないこと）、`/usr/local/bin/git` が古い通常ファイルであれば張り替えコマンドを示すこと、それ以外のパスの git が隠している場合は PATH と提供元の確認だけを促して書き換えを案内しないこと、`/usr/bin/git` が 2.54 に満たない場合は PPA の案内へ戻ることである。同じテストが、偽の git を PATH の先頭へ置いてレンダリング済みの警告スクリプトを実行し、設定欠落の案内と、コンテナ以外へレンダリングした場合に張り替えを一切案内しないことを確認する。
 
 ## 引き継ぐ検証
 
-Dev Container と Codespaces では未検証である。ベースイメージが配る git は現時点で 2.54 に満たないため、設定ベースフックが有効になるかは `run_once_before_10-install-packages.sh.tmpl` の PPA 追加が効くかで決まる。コンテナを作成して `chezmoi apply` を実行したうえで、次を確認する。
+Dev Container では未検証である。Codespaces と同じ devcontainers の git feature を使うイメージであれば、`/usr/local` のソースビルドを張り替える処理がそのまま効くと考えられるが、ベースイメージによって git の入手経路は異なる。イメージを起動して `chezmoi apply` を実行したうえで、次を確認する。
 
-1. `git --version` が 2.54 以降であること。満たさない場合は PPA の追加が失敗した理由を確認する。ベースイメージの sudo の扱い、apt のプロキシ設定、`software-properties-common` の有無が候補になる。
+1. `git --version` が 2.54 以降であること。満たさない場合は、`command -v git` が返す実体と `/usr/bin/git --version` を比べる。両者が食い違うなら PATH の問題であり、一致するなら PPA の追加が失敗している。後者ではベースイメージの sudo の扱い、apt のプロキシ設定、`software-properties-common` の有無が候補になる。
 2. `git hook list pre-commit --show-scope` が `dotfiles-gitleaks` を含む行を返すこと。
 3. 要件 1（作成時期を問わず走る）。`init.templateDir` 由来の hook を持たない状態を作って確認する。
 
@@ -157,7 +181,8 @@ Dev Container と Codespaces では未検証である。ベースイメージが
    期待する結果は、出力に `leaks found: 1` が現れ、`git rev-list --count HEAD` が commit を数えないことである。本文を短くしてはならない。gitleaks の private-key ルールは本文の長さも見ており、33 文字では検出しなかった（macOS で実測）。上記の 55 文字は検出を確認した値である。
 
 4. 走査が 1 回だけであること。手順 3 の削除をしない状態で commit し、`git commit -m t 2>&1 | grep -c 'no leaks found'` が 1 を返すこと。
-5. git が 2.54 に満たないまま終わった場合、`chezmoi apply` が `run_after_40-check-git-hooks.sh` の警告を出し、かつ apply 自体は成功すること。この経路では `init.templateDir` 由来の hook だけが保護を担う。
+5. `git-lfs` が張り替えの対象になっていないこと。`ls -l /usr/local/bin/git-lfs` が symlink ではない実体を示し、`git lfs version` が成功すること。
+6. git が 2.54 に満たないまま終わった場合、`chezmoi apply` が `run_after_40-check-git-hooks.sh` の警告を出し、かつ apply 自体は成功すること。この経路では `init.templateDir` 由来の hook だけが保護を担う。
 
 ### apply が途中で止まった場合
 

--- a/docs/adr/020-git-hooks-via-config.md
+++ b/docs/adr/020-git-hooks-via-config.md
@@ -1,0 +1,215 @@
+# ADR-020: gitleaks の pre-commit は Git の設定ベースフックで配る
+
+## Status
+
+Proposed
+
+Windows と WSL での検証が完了していない。macOS と Linux コンテナでの検証結果は「検証記録」に、残る検証項目は「引き継ぐ検証」に記す。
+
+## Context
+
+ADR-018 で、機械全体への Git hook 配布を `core.hooksPath` から `init.templateDir` へ移した。`init.templateDir` は `git init` / `git clone` の瞬間に `~/.config/git/templates/hooks/pre-commit` を各リポジトリの `.git/hooks/` へコピーする。コピー後は repo-local な通常ファイルになるため、ADR-018 が対処した「共有 hooks ディレクトリが全リポジトリを汚染する」問題は起きない。
+
+この方式には、gitleaks の適用範囲を狭める性質が二つ残っていた。
+
+第一に、リポジトリ固有の hook マネージャがコピー済みの hook を置き換える。lefthook を導入したリポジトリで開発者が `lefthook install` を実行すると、lefthook は `.git/hooks/pre-commit` を自身の生成物へ差し替える。lefthook は退避先 `pre-commit.old` を作ったと表示するが、生成した hook は `pre-commit.old` を呼び出さない。したがって以後の commit で gitleaks は実行されず、その事実を知らせる出力も出ない。
+
+第二に、既存リポジトリが対象にならない。`init.templateDir` は新規作成時にしかコピーしないため、開発者が各リポジトリで `git init` を再実行して backfill する必要がある。この操作は安全かつ冪等だが、実行の判断と実施が開発者に委ねられている。
+
+### ADR-018 の運用で実際に起きたこと
+
+第二の性質は、想定されたトレードオフにとどまらなかった。ADR-018 を採用した機械で、gitleaks が約 3 週間にわたり既存リポジトリで一度も実行されない状態が続いた。経緯は次のとおりである。
+
+1. lefthook を使うリポジトリを clone し、`lefthook install` を実行した。当時の配布方式は global の `core.hooksPath` であり、lefthook はこれを尊重して共有 hooks ディレクトリへ書き込んだ。結果として全リポジトリの hook が置き換わった。
+2. この事故への対処として、配布方式を `init.templateDir` へ移した（ADR-018）。同時に、汚染された共有 hooks ディレクトリの実体を削除した。
+3. 既存リポジトリへの backfill は実行されなかった。ADR-018 はこれを開発者の手作業として残していた。
+
+結果として、既存リポジトリは新しい配布経路からも古い配布経路からも外れた。ADR-018 はこの状態を検知する仕組みを持たないため、開発者は保護が失われたことに気づけなかった。
+
+この経緯から、本 ADR は次の二つを要件とする。
+
+- **要件 1**: gitleaks の pre-commit が、リポジトリの作成時期を問わず実行される。
+- **要件 2**: リポジトリレベルの hook マネージャを導入しても、gitleaks が実行され続ける。
+
+### Git 2.54 の設定ベースフック
+
+Git 2.54 は、`gitconfig` に hook を定義する設定ベースフックを追加した。設定ベースフックは `$GIT_DIR/hooks` とは別の層で管理され、両者は加算的に実行される。global スコープに定義すれば、リポジトリの作成時期や `.git/hooks` の内容に関わらず実行される。この二つの性質が、要件 1 と要件 2 にそれぞれ対応する。
+
+一方で、この機能は git のバージョンに依存する。2.54 より前の git は `[hook]` セクションをエラーも警告も出さずに無視する。したがって、設定を配るだけでは保護が効いているか分からない。ADR-018 で起きた沈黙と同じ形の失敗を繰り返さないために、バージョン要件を満たす git を各プラットフォームで用意し、満たせない場合はそれを開発者へ伝える必要がある。
+
+## Decision
+
+### 1. 設定ベースフックとして gitleaks を登録する
+
+`~/.gitconfig`（`home/dot_gitconfig.tmpl`）へ次を追加し、走査スクリプトを `~/.local/bin/gitleaks-pre-commit`（`home/dot_local/bin/executable_gitleaks-pre-commit`）へ配置する。
+
+```ini
+[hook "dotfiles-gitleaks"]
+	event = pre-commit
+	command = "sh ~/.local/bin/gitleaks-pre-commit"
+```
+
+`command` は `sh` 経由で呼ぶ。パスを直接書くと、実行ビットが立っていない場合に gitleaks が一度も走らないまま commit だけが拒否される。`sh` を挟めばこの依存が無くなる。Windows でファイルの実行ビットがどう扱われるかは検証していないため、依存しない形を選んだ。
+
+`gitconfig` の値は引用しないと `;` や `#` 以降が切り捨てられるため、`command` の値は二重引用符で囲む。friendly-name にイベント名（`pre-commit` など）を使うと `hook.<event>.enabled` のような既存キーと曖昧になり、git が fatal error を出す。名前はイベント名と重ならないものにする。
+
+### 2. 各プラットフォームで git 2.54 以降を用意する
+
+| プラットフォーム | 入手方法 | dotfiles 側の変更 |
+| --- | --- | --- |
+| macOS | Homebrew | `run_once_before_10-install-packages.sh.tmpl` の `brew install` へ `git` を追加し、`dot_zprofile.tmpl` で PATH を調整する |
+| Linux | `ppa:git-core/ppa` | `run_once_before_10-install-packages.sh.tmpl` の apt ブロックへ PPA 追加を挿入する |
+| Windows | Git for Windows | 変更なし。既定のインストーラが要件を満たすバージョンを配る |
+
+macOS では、`brew install git` だけでは要件を満たさない。`/etc/zprofile` の `path_helper` が login shell の PATH を再構築し、`/etc/paths` に載るシステムディレクトリを先頭へ、それ以外を末尾へ移す。`~/.zshenv` 経由で `~/.profile` が先頭に置いたディレクトリも、login zsh ではここで `/usr/bin` より後ろへ回る。`~/.profile` は多重読み込みガードにより再実行されないため、並びは `~/.zprofile` で戻す。
+
+戻す対象は `/opt/homebrew/opt/git/bin` に限る。このディレクトリは git 関連の実行ファイルだけを持つため、影響が git に閉じる。`~/.local/bin` や mise の shims をまとめて `/usr/bin` より前へ出すと、システムツール全般を shadow して影響範囲が読めなくなる。
+
+Linux で PPA を追加できない環境では、ディストリビューション標準の git のまま処理を続ける。設定ベースフックは無効になるが、`init.templateDir` による保護は残る。
+
+### 3. `init.templateDir` は撤去せず、二重実行を hook 側で抑止する
+
+`init.templateDir` と `~/.config/git/templates/hooks/pre-commit` は ADR-018 のまま残す。git 2.54 より前のバージョンでは、これが唯一の配布経路であり続ける。
+
+両方が有効な環境では、設定ベースフックが先に、`$GIT_DIR/hooks` の hook が後に実行される。同じ staged tree を二度走査しても結果は変わらないが、テンプレート側の hook が自身の実行を抑止する。
+
+```sh
+if git hook list pre-commit --show-scope 2>/dev/null \
+  | awk -F'\t' '$NF == "dotfiles-gitleaks" && $0 !~ /\tdisabled\t/ { found = 1 }
+                END { exit !found }'; then
+  exit 0
+fi
+```
+
+この判定が安全である理由は二つある。第一に、git は hook を実行する前に自身の `GIT_EXEC_PATH` を PATH の先頭へ置くため、hook の中で解決される `git` は hook を起動した git と同一である。`hook list` を知らない git は標準出力へ何も書かないので、判定は成立しない。第二に、設定ベースフックは fail-closed であり、git が実行できなければ commit を中断する。一覧に現れることは、走査が済んでいることを意味する。
+
+どちらの条件も満たされない場合、判定は成立せずテンプレート側の走査が実行される。したがって失敗の向きは「二度走る」であって「一度も走らない」ではない。
+
+### 4. 保護が効いていない状態を apply のたびに報告する
+
+`run_after_40-check-git-hooks.sh.tmpl`（Windows は `.ps1.tmpl`）を追加する。このスクリプトは `chezmoi apply` のたびに実行され、設定ベースフックが有効かを確認する。有効でなければ、保護される範囲と git の更新手順を標準エラーへ出力する。apply は失敗させない。
+
+判定には git のバージョン番号ではなく `git hook list` の出力を使う。バージョンが条件を満たしていても設定が届いていなければ保護は効かないため、両方をまとめて確認できる。
+
+`init.templateDir` を撤去しない以上、この報告が無くても保護が完全に消えるわけではない。それでも報告する理由は、ADR-018 で失われたのが保護そのものではなく、失われたことに気づく手段だったからである。
+
+### リポジトリ単位の無効化
+
+```sh
+git config --local hook.dotfiles-gitleaks.enabled false
+```
+
+これは設定ベースフックだけを無効にする。同じリポジトリが `init.templateDir` 由来の hook を持つ場合、そちらは実行され続ける。両方を止めるには hook ファイルも削除する。
+
+## Consequences
+
+- 設定ベースフックは `.git/hooks` を参照しないため、`lefthook install` が `.git/hooks/pre-commit` を置き換えても gitleaks は実行され続ける。lefthook 自身の job も従来どおり実行される。
+- 既存リポジトリにも適用される。backfill を実行していないリポジトリでも gitleaks が走る。
+- 保護の有無は、実行された git バイナリのバージョンで決まる。PATH の解決が経路ごとに異なる環境では、保護される経路とされない経路が混在し得る。macOS の login shell については `~/.zprofile` で対処したが、Finder から起動した GUI アプリのように shell の設定を読まない経路は対象外である。
+- `$GIT_DIR/hooks` の hook は git が実行可能性を確認して欠落時は無視するのに対し、設定ベースフックには存在確認がない。`~/.local/bin/gitleaks-pre-commit` が読めなければ commit が拒否される。`chezmoi apply` が中断した場合などにこの状態が起こり得る。秘密情報の走査が無言で消えるよりも、commit が止まって原因が表示される方を選ぶ。
+- 走査スクリプトは設定ベースフック用とテンプレート用の二つに分かれる。探索ロジックを変更するときは両方を更新する。共有すると、片方を撤去する際にもう片方が壊れる結合が生まれるため、重複を選んだ。
+- `--no-verify` で回避できる点は `init.templateDir` 方式と変わらない。誤って秘密情報を commit する事故を早期に止めることが目的であり、意図的な持ち出しを防ぐ境界は GitHub 側の secret scanning と push protection が担う。
+
+## 検証記録
+
+macOS 実機（Homebrew git）と Linux コンテナで確認した。使用した git のバージョンは macOS が 2.55.0、Linux が `ppa:git-core/ppa` の 2.54.0、比較対象の Apple Git が 2.50.1 である。
+
+| 確認項目 | 結果 |
+| --- | --- |
+| 要件 1: `.git/hooks` に hook を持たないリポジトリで秘密鍵の commit を拒否する | 拒否した（`leaks found: 1`、exit 1、commit 数 0） |
+| 要件 2: lefthook 生成の hook で上書きした状態で秘密鍵の commit を拒否する | 拒否した。lefthook 側の hook も実行された |
+| 設定ベースフック有効時の走査回数 | 1 回 |
+| リポジトリ単位で無効化した場合の走査回数 | 1 回（テンプレート由来の hook が実行される） |
+| Apple Git 2.50.1 での走査回数 | 1 回。`[hook]` セクションによるエラーは出ない |
+| gitleaks が PATH にも mise shims にも無い場合 | 警告のみで commit は成功する（fail-open） |
+| hook の中で解決される `git` | hook を起動した git と同一のバイナリ |
+| login zsh での `git` の解決先 | `/opt/homebrew/opt/git/bin/git`。PATH に重複は無い |
+| `chezmoi apply` 時の報告 | 設定ベースフックが有効なら無出力、無効なら警告を出力する |
+
+判定方法について確認した事項を記す。`git hook list` は該当する hook が無い場合に exit 1 を返し、サブコマンド自体を知らない git は exit 129 を返す。終了コードだけでは両者と「対応しているが未設定」を区別できないため、判定には標準出力の内容を使う。`--show-scope` を付けない場合、スコープと `disabled` の表示は出ない。
+
+## 引き継ぐ検証
+
+Windows と WSL では未検証である。Windows と WSL は `~` の指す先も chezmoi の状態も別なので、**それぞれで branch を pull して `chezmoi apply` を実行する**。片方だけでは他方へ反映されない。
+
+### 検証用の秘密情報
+
+`ssh-keygen` は使わない。PowerShell 5.1 は空文字列の引数を外部コマンドへ渡す際の挙動が一定でなく、`-N ''` が意図どおり渡らないことがある。実鍵を作らずに済む点でも次の方が扱いやすい。gitleaks は鍵の中身ではなく PEM のヘッダ形式で検出するため、合成したブロックでブロックされることを macOS で確認済みである。
+
+```powershell
+@'
+-----BEGIN OPENSSH PRIVATE KEY-----
+NOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEY
+-----END OPENSSH PRIVATE KEY-----
+'@ | Set-Content -Path fake_key -NoNewline
+```
+
+改行コードと末尾改行の有無は検出に影響しない（CRLF かつ末尾改行なしでも検出することを macOS で確認済み）。
+
+### apply が途中で止まった場合
+
+設定ベースフックは fail-closed である。`~/.gitconfig` が配られた後、`~/.local/bin/gitleaks-pre-commit` が配られる前に `chezmoi apply` が中断すると、**その機械のすべての commit が拒否される**。復旧は次の 1 コマンドで済む。
+
+```powershell
+chezmoi apply ~/.local/bin/gitleaks-pre-commit
+```
+
+### Windows（Git for Windows）
+
+1. `git --version` が 2.54 以降であること。満たさない場合は `winget upgrade --id Git.Git` で更新し、新しいシェルで再確認する。dotfiles 側に Windows 用の git 導入処理は無いため、この更新は手動になる。
+2. `chezmoi apply` が `run_after_40-check-git-hooks.ps1` の警告を出さないこと。このスクリプトは PowerShell の実行環境が無い機械で書いたため、構文が通ることの確認も兼ねる。git を更新する前に一度 apply すれば、警告を出す経路の表示も確認できる。
+3. `git hook list pre-commit --show-scope` が `dotfiles-gitleaks` を含む行を返すこと。
+4. 要件 1（作成時期を問わず走る）。`init.templateDir` 由来の hook を持たない状態を作って確認する。`git init` しただけでは hook が入るため、明示的に削除する。
+
+   ```powershell
+   mkdir $env:TEMP\gl1; cd $env:TEMP\gl1
+   git init
+   git config commit.gpgsign false   # 署名の失敗を gitleaks の結果と取り違えないため
+   Remove-Item (Join-Path (git rev-parse --git-path hooks) 'pre-commit') -ErrorAction SilentlyContinue
+   # 上記の fake_key を作成
+   git add fake_key
+   git commit -m t
+   ```
+
+   期待する結果は、出力に `leaks found: 1` が現れ、`git rev-list --count HEAD` が commit を数えないことである。
+
+5. 要件 2（lefthook と併用できる）。lefthook を使うリポジトリで `lefthook install` を実行した後、同じ commit がブロックされ、かつ lefthook 自身の job も実行されること。
+6. 走査が 1 回だけであること。`init.templateDir` 由来の hook を持つリポジトリ（手順 4 の削除をしない状態）で commit し、出力に含まれる gitleaks の要約行を数える。
+
+   ```powershell
+   mkdir $env:TEMP\gl2; cd $env:TEMP\gl2
+   git init
+   git config commit.gpgsign false
+   'ok' | Set-Content -Path f; git add f
+   (git commit -m t 2>&1 | Select-String 'no leaks found').Count   # 期待値: 1
+   ```
+
+7. `command` に書いた `sh ~/.local/bin/gitleaks-pre-commit` の解決先。手順 4 が成功すれば `sh` と `~` の解決は両方とも成立している。失敗した場合に切り分けるため、`sh` が Git for Windows のものか（WSL の bash ではないか）、`~` が Windows のユーザプロファイルを指すかを個別に確認する。
+
+### WSL
+
+WSL 側の git はディストリビューションの apt から入る。`appendWindowsPath` を無効にしているため、WSL から Windows 側の実行ファイルを PATH 経由で呼べない。WSL 側は Linux ネイティブの git と gitleaks で完結させる。
+
+1. WSL 内でこの branch を pull し、`chezmoi apply` を実行する。Windows 側の apply は WSL の `~` に反映されない。
+2. `git --version` が 2.54 以降であること。`run_once_before_10-install-packages.sh` は内容を変更したため、`chezmoi apply` で再実行され `ppa:git-core/ppa` が追加される。PPA を追加できない環境では警告を出して処理を続けるので、その場合は git がディストリビューション版のままになる。
+3. `~/.gitconfig` に `[hook "dotfiles-gitleaks"]` が届いていること。
+4. 上記 Windows の手順 4、5、6 を、次のように読み替えて WSL 側で実行する。
+
+   ```sh
+   mkdir -p /tmp/gl1 && cd /tmp/gl1 && git init
+   git config commit.gpgsign false
+   rm -f "$(git rev-parse --git-path hooks)/pre-commit"     # 手順 4 のみ
+   printf -- '-----BEGIN OPENSSH PRIVATE KEY-----\nNOTAREALKEY\n-----END OPENSSH PRIVATE KEY-----\n' > fake_key
+   git add fake_key && git commit -m t
+   ```
+
+   走査回数は `git commit -m t 2>&1 | grep -c 'no leaks found'` で数える。
+
+### 未検証のまま残る範囲
+
+- Finder から起動した GUI アプリのように、shell の設定を読まない経路で解決される git のバージョン。
+- Dev Container と Codespaces のベースイメージが配る git。現時点では 2.54 に満たない。ベースイメージが更新されるか、`run_once_before_10-install-packages.sh.tmpl` の PPA 追加が効くかで決まる。
+
+## 関連
+
+- ADR-018: `init.templateDir` による配布。本 ADR はこれを置き換えず、git 2.54 より前の環境での配布経路として残す。

--- a/docs/adr/020-git-hooks-via-config.md
+++ b/docs/adr/020-git-hooks-via-config.md
@@ -146,6 +146,8 @@ NOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEY
 
 改行コードと末尾改行の有無は検出に影響しない（CRLF かつ末尾改行なしでも検出することを macOS で確認済み）。
 
+本文を短くしてはならない。gitleaks の private-key ルールは本文の長さも見ており、33 文字では検出しなかった（macOS で実測）。上記の 55 文字は検出を確認した値である。
+
 ### apply が途中で止まった場合
 
 設定ベースフックは fail-closed である。`~/.gitconfig` が配られた後、`~/.local/bin/gitleaks-pre-commit` が配られる前に `chezmoi apply` が中断すると、**その機械のすべての commit が拒否される**。復旧は次の 1 コマンドで済む。
@@ -199,7 +201,8 @@ WSL 側の git はディストリビューションの apt から入る。`appen
    mkdir -p /tmp/gl1 && cd /tmp/gl1 && git init
    git config commit.gpgsign false
    rm -f "$(git rev-parse --git-path hooks)/pre-commit"     # 手順 4 のみ
-   printf -- '-----BEGIN OPENSSH PRIVATE KEY-----\nNOTAREALKEY\n-----END OPENSSH PRIVATE KEY-----\n' > fake_key
+   printf -- '-----BEGIN OPENSSH PRIVATE KEY-----\n%s\n-----END OPENSSH PRIVATE KEY-----\n' \
+     'NOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEY' > fake_key
    git add fake_key && git commit -m t
    ```
 

--- a/docs/adr/020-git-hooks-via-config.md
+++ b/docs/adr/020-git-hooks-via-config.md
@@ -4,7 +4,7 @@
 
 Proposed
 
-Windows と WSL での検証が完了していない。macOS と Linux コンテナでの検証結果は「検証記録」に、残る検証項目は「引き継ぐ検証」に記す。
+macOS、Linux コンテナ、Windows、WSL で検証した。結果は「検証記録」に記す。Dev Container と Codespaces は未検証であり、残る検証項目は「引き継ぐ検証」に記す。
 
 ## Context
 
@@ -106,112 +106,70 @@ git config --local hook.dotfiles-gitleaks.enabled false
 - 設定ベースフックは `.git/hooks` を参照しないため、`lefthook install` が `.git/hooks/pre-commit` を置き換えても gitleaks は実行され続ける。lefthook 自身の job も従来どおり実行される。
 - 既存リポジトリにも適用される。backfill を実行していないリポジトリでも gitleaks が走る。
 - 保護の有無は、実行された git バイナリのバージョンで決まる。PATH の解決が経路ごとに異なる環境では、保護される経路とされない経路が混在し得る。macOS の login shell については `~/.zprofile` で対処したが、Finder から起動した GUI アプリのように shell の設定を読まない経路は対象外である。
-- `$GIT_DIR/hooks` の hook は git が実行可能性を確認して欠落時は無視するのに対し、設定ベースフックには存在確認がない。`~/.local/bin/gitleaks-pre-commit` が読めなければ commit が拒否される。`chezmoi apply` が中断した場合などにこの状態が起こり得る。秘密情報の走査が無言で消えるよりも、commit が止まって原因が表示される方を選ぶ。
+- `$GIT_DIR/hooks` の hook は git が実行可能性を確認して欠落時は無視するのに対し、設定ベースフックには存在確認がない。`~/.local/bin/gitleaks-pre-commit` が読めなければ commit が拒否される。`chezmoi apply` が中断した場合などにこの状態が起こり得る。秘密情報の走査が無言で消えるよりも、commit が止まって原因が表示される方を選ぶ。この状態からの復旧は `chezmoi apply ~/.local/bin/gitleaks-pre-commit` で済む。
 - 走査スクリプトは設定ベースフック用とテンプレート用の二つに分かれる。探索ロジックを変更するときは両方を更新する。共有すると、片方を撤去する際にもう片方が壊れる結合が生まれるため、重複を選んだ。
 - `--no-verify` で回避できる点は `init.templateDir` 方式と変わらない。誤って秘密情報を commit する事故を早期に止めることが目的であり、意図的な持ち出しを防ぐ境界は GitHub 側の secret scanning と push protection が担う。
 
 ## 検証記録
 
-macOS 実機（Homebrew git）と Linux コンテナで確認した。使用した git のバージョンは macOS が 2.55.0、Linux が `ppa:git-core/ppa` の 2.54.0、比較対象の Apple Git が 2.50.1 である。
+macOS 実機、Linux コンテナ、Windows 実機、WSL (Ubuntu 22.04) で確認した。使用した git は、macOS が Homebrew の 2.55.0、Linux コンテナが `ppa:git-core/ppa` の 2.54.0、Windows が Git for Windows 2.55.0、WSL が同じ PPA の 2.54.0 である。WSL の git は apply 前が 2.34.1 であり、`run_once_before_10-install-packages.sh` の PPA 追加によって 2.54.0 へ更新された。
 
-| 確認項目 | 結果 |
-| --- | --- |
-| 要件 1: `.git/hooks` に hook を持たないリポジトリで秘密鍵の commit を拒否する | 拒否した（`leaks found: 1`、exit 1、commit 数 0） |
-| 要件 2: lefthook 生成の hook で上書きした状態で秘密鍵の commit を拒否する | 拒否した。lefthook 側の hook も実行された |
-| 設定ベースフック有効時の走査回数 | 1 回 |
-| リポジトリ単位で無効化した場合の走査回数 | 1 回（テンプレート由来の hook が実行される） |
-| Apple Git 2.50.1 での走査回数 | 1 回。`[hook]` セクションによるエラーは出ない |
-| gitleaks が PATH にも mise shims にも無い場合 | 警告のみで commit は成功する（fail-open） |
-| hook の中で解決される `git` | hook を起動した git と同一のバイナリ |
-| login zsh での `git` の解決先 | `/opt/homebrew/opt/git/bin/git`。PATH に重複は無い |
-| `chezmoi apply` 時の報告 | 設定ベースフックが有効なら無出力、無効なら警告を出力する |
+commit を拒否したことの判定には、出力に `leaks found: 1` が現れること、git の終了コードが 1 であること、commit が作られないことの三つを使った。
+
+| 確認項目 | macOS / Linux | Windows | WSL |
+| --- | --- | --- | --- |
+| 要件 1: `.git/hooks` に hook を持たないリポジトリで秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した |
+| 要件 2: lefthook 生成の hook で上書きした状態で秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した |
+| 要件 2: 同じ状態で lefthook 自身の job も実行される | 実行した | 実行した | 実行した |
+| 設定ベースフック有効時の走査回数 | 1 回 | 1 回 | 1 回 |
+| リポジトリ単位で無効化した場合の走査回数 | 1 回 | 1 回 | 1 回 |
+| hook の中で解決される `git` が hook を起動した git と同一である | 同一 | 同一 | 同一 |
+| `chezmoi apply` 時の報告が、有効なら無出力、無効なら警告になる | 一致した | 一致した | 一致した |
+
+プラットフォームごとに個別に確認した事項を記す。
+
+- macOS: Apple Git 2.50.1 でも走査回数は 1 回であり、`[hook]` セクションによるエラーは出ない。login zsh での `git` は `/opt/homebrew/opt/git/bin/git` に解決され、PATH に重複は無い。
+- macOS と Linux コンテナ: gitleaks が PATH にも mise shims にも無い場合、警告のみで commit は成功する (fail-open)。
+- Windows: hook の中で `sh` は `/usr/bin/sh` に解決される。これは Git for Windows が同梱する MSYS の sh であり、WSL の bash ではない。`command` に書いた `~` は Windows のユーザプロファイルを指す。
+- WSL: hook の中で `sh` は `/usr/bin/sh`、`git` は `/usr/lib/git-core/git` に解決される。`appendWindowsPath` を無効にしているため、Windows 側の実行ファイルは経路に入らない。
 
 判定方法について確認した事項を記す。`git hook list` は該当する hook が無い場合に exit 1 を返し、サブコマンド自体を知らない git は exit 129 を返す。終了コードだけでは両者と「対応しているが未設定」を区別できないため、判定には標準出力の内容を使う。`--show-scope` を付けない場合、スコープと `disabled` の表示は出ない。
 
+`run_after_40-check-git-hooks` の警告経路は、`GIT_CONFIG_GLOBAL` を空のファイルへ向けて設定ベースフックが見えない状態を作り、Windows と WSL の双方で確認した。どちらも警告を出したうえで終了コード 0 を返し、apply を失敗させない。Windows 版は powershell.exe 5.1 で実行し、構文が通ることもあわせて確認した。
+
 ## 引き継ぐ検証
 
-Windows と WSL では未検証である。Windows と WSL は `~` の指す先も chezmoi の状態も別なので、**それぞれで branch を pull して `chezmoi apply` を実行する**。片方だけでは他方へ反映されない。
+Dev Container と Codespaces では未検証である。ベースイメージが配る git は現時点で 2.54 に満たないため、設定ベースフックが有効になるかは `run_once_before_10-install-packages.sh.tmpl` の PPA 追加が効くかで決まる。コンテナを作成して `chezmoi apply` を実行したうえで、次を確認する。
 
-### 検証用の秘密情報
-
-`ssh-keygen` は使わない。PowerShell 5.1 は空文字列の引数を外部コマンドへ渡す際の挙動が一定でなく、`-N ''` が意図どおり渡らないことがある。実鍵を作らずに済む点でも次の方が扱いやすい。gitleaks は鍵の中身ではなく PEM のヘッダ形式で検出するため、合成したブロックでブロックされることを macOS で確認済みである。
-
-```powershell
-@'
------BEGIN OPENSSH PRIVATE KEY-----
-NOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEY
------END OPENSSH PRIVATE KEY-----
-'@ | Set-Content -Path fake_key -NoNewline
-```
-
-改行コードと末尾改行の有無は検出に影響しない（CRLF かつ末尾改行なしでも検出することを macOS で確認済み）。
-
-本文を短くしてはならない。gitleaks の private-key ルールは本文の長さも見ており、33 文字では検出しなかった（macOS で実測）。上記の 55 文字は検出を確認した値である。
-
-### apply が途中で止まった場合
-
-設定ベースフックは fail-closed である。`~/.gitconfig` が配られた後、`~/.local/bin/gitleaks-pre-commit` が配られる前に `chezmoi apply` が中断すると、**その機械のすべての commit が拒否される**。復旧は次の 1 コマンドで済む。
-
-```powershell
-chezmoi apply ~/.local/bin/gitleaks-pre-commit
-```
-
-### Windows（Git for Windows）
-
-1. `git --version` が 2.54 以降であること。満たさない場合は `winget upgrade --id Git.Git` で更新し、新しいシェルで再確認する。dotfiles 側に Windows 用の git 導入処理は無いため、この更新は手動になる。
-2. `chezmoi apply` が `run_after_40-check-git-hooks.ps1` の警告を出さないこと。このスクリプトは PowerShell の実行環境が無い機械で書いたため、構文が通ることの確認も兼ねる。git を更新する前に一度 apply すれば、警告を出す経路の表示も確認できる。
-3. `git hook list pre-commit --show-scope` が `dotfiles-gitleaks` を含む行を返すこと。
-4. 要件 1（作成時期を問わず走る）。`init.templateDir` 由来の hook を持たない状態を作って確認する。`git init` しただけでは hook が入るため、明示的に削除する。
-
-   ```powershell
-   mkdir $env:TEMP\gl1; cd $env:TEMP\gl1
-   git init
-   git config commit.gpgsign false   # 署名の失敗を gitleaks の結果と取り違えないため
-   Remove-Item (Join-Path (git rev-parse --git-path hooks) 'pre-commit') -ErrorAction SilentlyContinue
-   # 上記の fake_key を作成
-   git add fake_key
-   git commit -m t
-   ```
-
-   期待する結果は、出力に `leaks found: 1` が現れ、`git rev-list --count HEAD` が commit を数えないことである。
-
-5. 要件 2（lefthook と併用できる）。lefthook を使うリポジトリで `lefthook install` を実行した後、同じ commit がブロックされ、かつ lefthook 自身の job も実行されること。
-6. 走査が 1 回だけであること。`init.templateDir` 由来の hook を持つリポジトリ（手順 4 の削除をしない状態）で commit し、出力に含まれる gitleaks の要約行を数える。
-
-   ```powershell
-   mkdir $env:TEMP\gl2; cd $env:TEMP\gl2
-   git init
-   git config commit.gpgsign false
-   'ok' | Set-Content -Path f; git add f
-   (git commit -m t 2>&1 | Select-String 'no leaks found').Count   # 期待値: 1
-   ```
-
-7. `command` に書いた `sh ~/.local/bin/gitleaks-pre-commit` の解決先。手順 4 が成功すれば `sh` と `~` の解決は両方とも成立している。失敗した場合に切り分けるため、`sh` が Git for Windows のものか（WSL の bash ではないか）、`~` が Windows のユーザプロファイルを指すかを個別に確認する。
-
-### WSL
-
-WSL 側の git はディストリビューションの apt から入る。`appendWindowsPath` を無効にしているため、WSL から Windows 側の実行ファイルを PATH 経由で呼べない。WSL 側は Linux ネイティブの git と gitleaks で完結させる。
-
-1. WSL 内でこの branch を pull し、`chezmoi apply` を実行する。Windows 側の apply は WSL の `~` に反映されない。
-2. `git --version` が 2.54 以降であること。`run_once_before_10-install-packages.sh` は内容を変更したため、`chezmoi apply` で再実行され `ppa:git-core/ppa` が追加される。PPA を追加できない環境では警告を出して処理を続けるので、その場合は git がディストリビューション版のままになる。
-3. `~/.gitconfig` に `[hook "dotfiles-gitleaks"]` が届いていること。
-4. 上記 Windows の手順 4、5、6 を、次のように読み替えて WSL 側で実行する。
+1. `git --version` が 2.54 以降であること。満たさない場合は PPA の追加が失敗した理由を確認する。ベースイメージの sudo の扱い、apt のプロキシ設定、`software-properties-common` の有無が候補になる。
+2. `git hook list pre-commit --show-scope` が `dotfiles-gitleaks` を含む行を返すこと。
+3. 要件 1（作成時期を問わず走る）。`init.templateDir` 由来の hook を持たない状態を作って確認する。
 
    ```sh
    mkdir -p /tmp/gl1 && cd /tmp/gl1 && git init
    git config commit.gpgsign false
-   rm -f "$(git rev-parse --git-path hooks)/pre-commit"     # 手順 4 のみ
+   rm -f "$(git rev-parse --git-path hooks)/pre-commit"
    printf -- '-----BEGIN OPENSSH PRIVATE KEY-----\n%s\n-----END OPENSSH PRIVATE KEY-----\n' \
      'NOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEY' > fake_key
    git add fake_key && git commit -m t
    ```
 
-   走査回数は `git commit -m t 2>&1 | grep -c 'no leaks found'` で数える。
+   期待する結果は、出力に `leaks found: 1` が現れ、`git rev-list --count HEAD` が commit を数えないことである。本文を短くしてはならない。gitleaks の private-key ルールは本文の長さも見ており、33 文字では検出しなかった（macOS で実測）。上記の 55 文字は検出を確認した値である。
 
-### 未検証のまま残る範囲
+4. 走査が 1 回だけであること。手順 3 の削除をしない状態で commit し、`git commit -m t 2>&1 | grep -c 'no leaks found'` が 1 を返すこと。
+5. git が 2.54 に満たないまま終わった場合、`chezmoi apply` が `run_after_40-check-git-hooks.sh` の警告を出し、かつ apply 自体は成功すること。この経路では `init.templateDir` 由来の hook だけが保護を担う。
 
-- Finder から起動した GUI アプリのように、shell の設定を読まない経路で解決される git のバージョン。
-- Dev Container と Codespaces のベースイメージが配る git。現時点では 2.54 に満たない。ベースイメージが更新されるか、`run_once_before_10-install-packages.sh.tmpl` の PPA 追加が効くかで決まる。
+### apply が途中で止まった場合
+
+設定ベースフックは fail-closed である。`~/.gitconfig` が配られた後、`~/.local/bin/gitleaks-pre-commit` が配られる前に `chezmoi apply` が中断すると、その環境のすべての commit が拒否される。復旧は次の 1 コマンドで済む。
+
+```sh
+chezmoi apply ~/.local/bin/gitleaks-pre-commit
+```
+
+### 検証の対象外
+
+Finder から起動した GUI アプリのように、shell の設定を読まない経路で解決される git のバージョンは検証しない。設定ベースフックが有効かどうかは、その経路で実行された git のバージョンに依存する。
 
 ## 関連
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -32,6 +32,7 @@
 | [017](017-msvc-linker-env-var-override-windows.md) | Windows の MSVC リンカーは CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER で明示指定する | Accepted |
 | [018](018-git-hooks-via-init-templatedir.md) | 機械全体への Git hook 配布は init.templateDir で行う | Accepted |
 | [019](019-cross-platform-parity-contract.md) | クロスプラットフォーム機能等価性はプラットフォーム契約と静的検査で担保する | Accepted |
+| [020](020-git-hooks-via-config.md) | gitleaks の pre-commit は Git の設定ベースフックで配る | Proposed |
 
 ## テンプレート
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@ home/                           ← chezmoi source
 ├── dot_profile.tmpl            ← POSIX 互換の共通 env（PATH, brew shellenv, mise shims）
 ├── dot_{zprofile,zshenv,bash_profile,bashrc}.tmpl ← 全て ~/.profile を source
 ├── dot_config/git/templates/hooks/executable_pre-commit  ← gitleaks (init.templateDir 経由)
+├── dot_local/bin/executable_gitleaks-pre-commit          ← gitleaks (設定ベースフック経由)
 ├── dot_config/mise/{config.toml.tmpl,private_mise.lock}
 ├── PowerShell_profile.ps1.tmpl
 ├── private_dot_copilot/        ← ~/.copilot/ 配下（instructions, hooks, mcp, skills）
@@ -28,7 +29,7 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 - `copilot-guard.py` / `uv-enforcer.py` / `node-global-enforcer.py` でネットワーク以外の危険操作を抑止、`postToolUse` で監査ログ
 - Copilot CLI local sandbox を有効化
 - `copilot-guardrails` で利便性と秘匿環境変数の扱いを固定
-- `gitleaks` 付き pre-commit を `init.templateDir` 経由で配布（ADR-018）
+- `gitleaks` 付き pre-commit を `init.templateDir`（ADR-018）と設定ベースフック（ADR-020）の 2 レイヤで配布
 
 ## Copilot Guard の設計
 
@@ -48,6 +49,8 @@ shell command の外部ネットワーク通信は、`~/.copilot/settings.json` 
 `~/.config/git/templates/hooks/pre-commit` を配置し、`git config --global init.templateDir` で有効化（ADR-018）。`git init`/`git clone` の瞬間に各リポジトリの `.git/hooks/pre-commit` へコピーされ、以降は通常のローカル hook として扱われる。`core.hooksPath` のようにグローバルに強制するのではなく「新規リポジトリの既定値」として配る方式のため、lefthook/husky 等の repo-local hook manager を導入した他リポジトリを巻き込まない。
 
 トレードオフとして、既存リポジトリには自動適用されない（`git init` を一度再実行して backfill するか、独自 hook manager を使うリポジトリはそのままにする）。`git-hooks-audit`（zsh 関数 / PowerShell `Invoke-GitHooksAudit`）で ghq 管理下の全リポジトリの状態（hook 未配置・local hooksPath 上書き・gitleaks 以外の hook に置き換え済み）を確認できる。
+
+Git 2.54 以降では、これに加えて `~/.gitconfig` の `[hook "dotfiles-gitleaks"]` が `~/.local/bin/gitleaks-pre-commit` を実行する（ADR-020）。設定ベースフックは `.git/hooks` とは別レイヤで加算的に走るため、`lefthook install` が `.git/hooks/pre-commit` を置き換えても gitleaks は実行され続け、backfill していない既存リポジトリも対象になる。Git 2.54 より前のバージョンは `[hook]` セクションを無視するため、そこでは `init.templateDir` だけが効く。リポジトリ単位の無効化は `git config --local hook.dotfiles-gitleaks.enabled false`。
 
 ## プラットフォーム検出
 
@@ -97,6 +100,10 @@ helm、gh、azd、trivy、kubectl、Azure CLIの補完はzshとPowerShellの両�
 ### 各シェルの読み込み経路
 
 `sh` / `bash(login)` は `.profile` を直接、`zsh(login)` は `.zprofile`、`zsh(非login)` は `.zshenv`、`bash(interactive non-login)` は `.bashrc` のみ読む。いずれからも `~/.profile` に誘導することで PATH が揃う。`bash -c` 等の非対話は親から env 継承する。
+
+ただし macOS の login zsh では、並び順までは揃わない。`~/.zshenv` が `~/.profile` を読んだ後に `/etc/zprofile` が `path_helper` を実行し、`/etc/paths` に載るシステムディレクトリを先頭へ、それ以外を末尾へ移す。`~/.profile` は `__DOTFILES_PROFILE_LOADED` により再実行されないため、`~/.local/bin` や mise shims は `/usr/bin` より後ろに置かれたままになる。
+
+`~/.zprofile` はこのうち `/opt/homebrew/opt/git/bin` だけを先頭へ戻す。gitleaks の設定ベースフックが git 2.54 以降を必要とするためである（ADR-020）。他のディレクトリを戻さないのは、システムツール全般を shadow したときの影響範囲を限定するためである。
 
 ### macOS GUI アプリ経由の PATH 注入
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -154,7 +154,7 @@ git config --local hook.dotfiles-gitleaks.enabled false   # リポジトリ単�
 
 `git hook list` が `unknown subcommand` で失敗する場合、その git は 2.54 より前であり `init.templateDir` だけが効いている。設定ベースフックには存在確認が無いため、`~/.local/bin/gitleaks-pre-commit` が未配置だと commit が拒否される。その場合は `chezmoi apply` で再配置する。
 
-設定ベースフックが有効かどうかは `chezmoi apply` のたびに確認され、無効なら警告が出る。警告が出た場合は git を更新する。
+設定ベースフックが有効かどうかは `chezmoi apply` のたびに確認され、無効なら警告が出る。警告は原因ごとに案内を変える。走っている git が 2.54 以降であれば、原因は git ではなく設定の欠落であり、`git config --global --get-regexp '^hook\.dotfiles-gitleaks\.'` が何も返さなければ `chezmoi apply ~/.gitconfig` で再配置する。git が 2.54 より前であれば更新する。
 
 ```bash
 brew install git                                    # macOS
@@ -164,6 +164,17 @@ winget upgrade --id Git.Git                         # Windows
 ```
 
 macOS では `brew install git` の後、新しい login shell で `git --version` が 2.54 以降になることを確認する。`/etc/zprofile` の `path_helper` が PATH を並べ替えるため、`~/.zprofile` が `/opt/homebrew/opt/git/bin` を先頭へ戻している。
+
+Linux で apt を実行しても `git --version` が変わらない場合は、より前の PATH にある別の実体が新しい git を隠している。Codespaces と Dev Container のベースイメージは git をソースビルドして `/usr/local/bin` へ入れるため、この状態になる。`chezmoi apply` の bootstrap がこの二つの環境でだけ張り替える。手動で直す場合は、対象が確かにベースイメージのビルドであることを先に確かめる。
+
+```bash
+command -v git                       # /usr/local/bin/git が返るか確認
+test -L /usr/local/bin/git           # symlink なら誰かが張り替えた後なので触らない
+/usr/bin/git --version               # apt 側が 2.54 以降か確認
+sudo ln -sfn /usr/bin/git /usr/local/bin/git
+```
+
+この張り替えはコンテナイメージが `/usr/local` へ入れた通常ファイルにだけ当てはまる。`command -v git` が `/usr/local/bin/git` 以外を返す場合や、すでに symlink である場合は、mise の shim や利用者自身のビルドである可能性がある。張り替える前に、その git の出所と PATH の並びを確認する。
 
 ## `run_once_*` の再実行
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -144,6 +144,27 @@ git -C <repo-path> init
 
 状態の確認は `git-hooks-audit`（zsh）/ `Invoke-GitHooksAudit`（PowerShell）で ghq 管理下の全リポジトリを一括チェックできる。
 
+Git 2.54 以降では、設定ベースフック（ADR-020）が全リポジトリで加算的に走る。
+
+```bash
+git hook list --show-scope pre-commit   # 期待値: global<TAB>dotfiles-gitleaks
+chezmoi edit ~/.local/bin/gitleaks-pre-commit && chezmoi apply
+git config --local hook.dotfiles-gitleaks.enabled false   # リポジトリ単位で無効化
+```
+
+`git hook list` が `unknown subcommand` で失敗する場合、その git は 2.54 より前であり `init.templateDir` だけが効いている。設定ベースフックには存在確認が無いため、`~/.local/bin/gitleaks-pre-commit` が未配置だと commit が拒否される。その場合は `chezmoi apply` で再配置する。
+
+設定ベースフックが有効かどうかは `chezmoi apply` のたびに確認され、無効なら警告が出る。警告が出た場合は git を更新する。
+
+```bash
+brew install git                                    # macOS
+sudo add-apt-repository -y ppa:git-core/ppa \
+  && sudo apt-get update && sudo apt-get install -y git   # Linux / WSL
+winget upgrade --id Git.Git                         # Windows
+```
+
+macOS では `brew install git` の後、新しい login shell で `git --version` が 2.54 以降になることを確認する。`/etc/zprofile` の `path_helper` が PATH を並べ替えるため、`~/.zprofile` が `/opt/homebrew/opt/git/bin` を先頭へ戻している。
+
 ## `run_once_*` の再実行
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,6 +111,16 @@ chezmoi apply ~/.config/git/templates/hooks/pre-commit
 
 Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin/env bash` が WSL の `bash.exe` を拾い、Windows 形式の `C:/...` パスを開けていない可能性がある。この pre-commit hook はその経路を避けるため POSIX `sh` 互換で管理する。mise の Windows shim も extensionless 版は `/bin/bash` スクリプトなので、hook 内では `gitleaks.exe` を優先する。
 
+Git 2.54 以降なら、`.git/hooks/pre-commit` の有無に関わらず設定ベースフックが走る（ADR-020）。`git hook list --show-scope pre-commit` が `global<TAB>dotfiles-gitleaks` を返すか確認する。返さない場合は `git --version` を確認し、2.54 より前ならこの経路は使えない。
+
+## commit が gitleaks-pre-commit not found で拒否される
+
+設定ベースフックには `$GIT_DIR/hooks` のような存在確認が無く、`command` が実行できないと commit が失敗する（ADR-020）。`chezmoi apply` の中断などで `~/.local/bin/gitleaks-pre-commit` が未配置になった場合に起きる。
+
+```bash
+chezmoi apply ~/.local/bin/gitleaks-pre-commit
+```
+
 ## Copilot CLI: preToolUse フックが並列実行時にすり抜ける
 
 症状: 短時間に複数のツール呼び出しが走った際、`copilot-guard.py` / `uv-enforcer.py` の deny が適用されず、ブロックすべき操作が実行される。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,7 +111,7 @@ chezmoi apply ~/.config/git/templates/hooks/pre-commit
 
 Windows で hook が存在するのに同じエラーが出る場合、`/usr/bin/env bash` が WSL の `bash.exe` を拾い、Windows 形式の `C:/...` パスを開けていない可能性がある。この pre-commit hook はその経路を避けるため POSIX `sh` 互換で管理する。mise の Windows shim も extensionless 版は `/bin/bash` スクリプトなので、hook 内では `gitleaks.exe` を優先する。
 
-Git 2.54 以降なら、`.git/hooks/pre-commit` の有無に関わらず設定ベースフックが走る（ADR-020）。`git hook list --show-scope pre-commit` が `global<TAB>dotfiles-gitleaks` を返すか確認する。返さない場合は `git --version` を確認し、2.54 より前ならこの経路は使えない。
+Git 2.54 以降なら、`.git/hooks/pre-commit` の有無に関わらず設定ベースフックが走る（ADR-020）。`git hook list --show-scope pre-commit` が `global<TAB>dotfiles-gitleaks` を返すか確認する。返さない場合は `git --version` を確認する。2.54 以降であれば原因は設定の欠落なので、`git config --global --get-regexp '^hook\.dotfiles-gitleaks\.'` を確認し、何も返さなければ `chezmoi apply ~/.gitconfig` を実行する。2.54 より前であれば git を更新する。Linux では `/usr/bin/git --version` と比べ、そちらが 2.54 以降なら、より前の PATH にある実体が隠している。それが `/usr/local/bin/git` の通常ファイル（Codespaces と Dev Container のベースイメージがソースビルドしたもの）なら `sudo ln -sfn /usr/bin/git /usr/local/bin/git` で張り替える。別のパス、またはすでに symlink であれば、その git の出所を確認してから判断する。
 
 ## commit が gitleaks-pre-commit not found で拒否される
 

--- a/home/dot_config/git/templates/hooks/executable_pre-commit
+++ b/home/dot_config/git/templates/hooks/executable_pre-commit
@@ -21,6 +21,27 @@ set -eu
 # Keep this POSIX sh compatible so Windows Git does not pick up WSL bash
 # through /usr/bin/env bash and pass it an unopenable C:/... hook path.
 
+# Skip when the config-based hook (ADR-020) already scanned this commit.
+#
+# On git >= 2.54 the config-based hook runs first and this hookdir hook runs
+# afterwards, so gitleaks would scan the same staged tree twice. The check
+# below asks git which pre-commit hooks it sees and skips only when it names
+# dotfiles-gitleaks without the "disabled" marker.
+#
+# Two properties make this safe:
+#   - git prepends its own GIT_EXEC_PATH to PATH before running a hook, so the
+#     `git` resolved here is the same binary that invoked this hook. A git that
+#     does not know `hook list` prints nothing to stdout and the check fails.
+#   - config-based hooks are fail-closed: git aborts the commit when it cannot
+#     run one. Being listed therefore means the scan already happened.
+# Any other outcome leaves the scan below in place, so the failure mode is a
+# duplicate scan rather than a skipped one.
+if git hook list pre-commit --show-scope 2>/dev/null \
+  | awk -F'\t' '$NF == "dotfiles-gitleaks" && $0 !~ /\tdisabled\t/ { found = 1 }
+                END { exit !found }'; then
+  exit 0
+fi
+
 find_gitleaks() {
   # Windows (Git Bash): prefer the .exe shim. The extensionless mise shim is a
   # /bin/bash script and can still route to WSL bash in this environment.

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -17,6 +17,19 @@
 	# clobbered across repositories. Existing repos need a one-time backfill;
 	# run the git-hooks-audit helper to find repos missing the seeded hook.
 	templateDir = ~/.config/git/templates
+# Config-based hook (git >= 2.54): runs for every repository, additively with
+# whatever lives in $GIT_DIR/hooks, so `lefthook install` can no longer displace
+# the secret scan. git < 2.54 ignores this section entirely, which is why
+# init.templateDir above stays. See ADR-020.
+# Opt out per repository: git config --local hook.dotfiles-gitleaks.enabled false
+[hook "dotfiles-gitleaks"]
+	event = pre-commit
+	# Quote the value: an unquoted gitconfig value is truncated at ';' or '#'.
+	# Invoke through sh so the hook does not depend on how the platform reports
+	# the file's executable bit. A config-based hook is not existence-checked by
+	# git, so a hook that cannot be executed blocks the commit instead of being
+	# skipped; going through sh removes one way to reach that state.
+	command = "sh ~/.local/bin/gitleaks-pre-commit"
 [help]
 	autocorrect = 20
 [alias]

--- a/home/dot_local/bin/executable_gitleaks-pre-commit
+++ b/home/dot_local/bin/executable_gitleaks-pre-commit
@@ -1,0 +1,76 @@
+#!/bin/sh
+set -eu
+
+# gitleaks secret detection, run as a config-based pre-commit hook.
+#
+# Deployed by chezmoi to ~/.local/bin/gitleaks-pre-commit and wired up via
+# `[hook "dotfiles-gitleaks"]` in ~/.gitconfig (see
+# docs/adr/020-git-hooks-via-config.md). Git >= 2.54 runs config-based hooks
+# for every repository, additively with any hook in $GIT_DIR/hooks, so a
+# repo-local hook manager (lefthook, husky, ...) that owns
+# <repo>/.git/hooks/pre-commit cannot displace this one. Git < 2.54 ignores
+# the [hook] section entirely, so this file is simply never invoked there and
+# ~/.config/git/templates/hooks/pre-commit (ADR-018) remains the only path.
+#
+# Opt out for a single repository with:
+#   git config --local hook.dotfiles-gitleaks.enabled false
+#
+# Unlike hooks in $GIT_DIR/hooks, a config-based hook is not existence-checked
+# by git: if this file is missing or unreadable the shell fails and the commit
+# is blocked. That is intentional — a secret scanner must not disappear
+# quietly — but it means this file must stay deployed alongside the gitconfig
+# entry.
+#
+# Keep this POSIX sh compatible so Windows Git does not pick up WSL bash
+# through /usr/bin/env bash and pass it an unopenable C:/... hook path.
+
+find_gitleaks() {
+  # Windows (Git Bash): prefer the .exe shim. The extensionless mise shim is a
+  # /bin/bash script and can still route to WSL bash in this environment.
+  if [ -n "${LOCALAPPDATA:-}" ]; then
+    localappdata_unix="$(cygpath -u "${LOCALAPPDATA}" 2>/dev/null || echo "${LOCALAPPDATA}")"
+    if [ -x "${localappdata_unix}/mise/shims/gitleaks.exe" ]; then
+      echo "${localappdata_unix}/mise/shims/gitleaks.exe"
+      return 0
+    fi
+  fi
+  if [ -x "${HOME}/.local/share/mise/shims/gitleaks.exe" ]; then
+    echo "${HOME}/.local/share/mise/shims/gitleaks.exe"
+    return 0
+  fi
+  if command -v gitleaks.exe >/dev/null 2>&1; then
+    command -v gitleaks.exe
+    return 0
+  fi
+
+  if command -v gitleaks >/dev/null 2>&1; then
+    command -v gitleaks
+    return 0
+  fi
+
+  # Try mise shim locations when not in PATH (git hooks don't source shell rc).
+  if [ -x "${HOME}/.local/share/mise/shims/gitleaks" ]; then
+    echo "${HOME}/.local/share/mise/shims/gitleaks"
+    return 0
+  fi
+
+  if [ -n "${LOCALAPPDATA:-}" ]; then
+    if [ -x "${localappdata_unix}/mise/shims/gitleaks" ]; then
+      echo "${localappdata_unix}/mise/shims/gitleaks"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+GITLEAKS=$(find_gitleaks) || {
+  echo "⚠️  gitleaks not found — skipping secret scan."
+  echo "   Install with: mise install gitleaks"
+  # fail-open: allow commit when gitleaks is not installed
+  GITLEAKS=""
+}
+
+if [ -n "${GITLEAKS}" ]; then
+  "${GITLEAKS}" git --pre-commit --staged --redact --verbose --no-banner
+fi

--- a/home/dot_zprofile.tmpl
+++ b/home/dot_zprofile.tmpl
@@ -2,4 +2,23 @@
 # zsh は ~/.profile を読まないため、login 時に明示的に source する。
 # PATH/shims など共通 env は ~/.profile に集約する（bash/sh との共有のため）。
 [ -r "$HOME/.profile" ] && . "$HOME/.profile"
+{{ if eq .chezmoi.os "darwin" }}
+# macOS: /etc/zprofile の path_helper は PATH を再構築し、/etc/paths に載る
+# システムディレクトリを先頭へ、それ以外を末尾へ移す。~/.zshenv 経由で
+# ~/.profile が先頭に置いたディレクトリも、login zsh ではここで後ろへ回る。
+# ~/.profile は __DOTFILES_PROFILE_LOADED ガードで再実行されないため、
+# 並びは自力で戻す必要がある。
+#
+# ここで戻すのは git だけに絞る。~/.local/bin や mise shims をまとめて
+# /usr/bin より前に出すと、システムツール全般を shadow して影響が読めない。
+# /opt/homebrew/opt/git/bin は git 関連の実行ファイルしか持たないため、
+# 影響範囲が git に閉じる。
+#
+# 目的は ADR-020 の設定ベースフック (git >= 2.54) を login shell 由来の
+# git でも有効にすること。Apple Git 2.50 では [hook] が警告なく無視される。
+if [ -d /opt/homebrew/opt/git/bin ]; then
+  PATH="/opt/homebrew/opt/git/bin:$(printf '%s' "$PATH" | sed -e 's|/opt/homebrew/opt/git/bin:||g' -e 's|:/opt/homebrew/opt/git/bin||g')"
+  export PATH
+fi
+{{ end }}
 {{ end -}}

--- a/home/run_after_40-check-git-hooks.ps1.tmpl
+++ b/home/run_after_40-check-git-hooks.ps1.tmpl
@@ -1,0 +1,55 @@
+{{- if eq .chezmoi.os "windows" -}}
+# gitleaks の pre-commit フックが実際に届いているかを apply のたびに報告する (Windows)
+#
+# 背景:
+#   ADR-020 の設定ベースフックは git >= 2.54 でしか解釈されない。それより古い
+#   git は [hook] セクションを警告なく無視するため、設定を配っただけでは保護が
+#   効いているか分からない。ADR-018 では既存リポジトリへの backfill が実行されず、
+#   3 週間にわたり gitleaks が動かない状態が続いた。同じ形の沈黙を避けるため、
+#   ここで状態を明示する。
+#
+# 判定方法:
+#   git のバージョン番号ではなく `git hook list` の出力で判定する。バージョンが
+#   条件を満たしていても設定が届いていなければ保護は効かないため、両方をまとめて
+#   確認できるこちらを使う。終了コードは「未対応の git」と「対応しているが hook 0 件」
+#   を区別できないので使わない。
+#
+# 出力を英語にしている理由:
+#   chezmoi は Windows で powershell.exe (5.1) を既定の実行系に使う。5.1 は BOM の
+#   無いファイルを ANSI として読むため、日本語の出力は文字化けし得る。他の .ps1
+#   スクリプトと同じく、コメントは日本語、出力は英語で書く。
+#
+# 関連:
+#   - docs/adr/020-git-hooks-via-config.md
+#
+# このスクリプトは apply を失敗させない。保護の有無を伝えるだけである。
+
+$ErrorActionPreference = 'Continue'
+
+$listed = & git hook list pre-commit --show-scope 2>$null
+$active = $false
+foreach ($line in @($listed)) {
+  if ([string]::IsNullOrWhiteSpace($line)) { continue }
+  $fields = [string]$line -split "`t"
+  if ($fields[-1] -eq 'dotfiles-gitleaks' -and $fields -notcontains 'disabled') {
+    $active = $true
+  }
+}
+
+if ($active) {
+  exit 0
+}
+
+$gitVersion = & git --version 2>$null
+if (-not $gitVersion) { $gitVersion = 'git not found' }
+
+Write-Warning @"
+The gitleaks config-based hook is not active ($gitVersion).
+  Only repositories seeded from init.templateDir are scanned. Repositories that
+  installed lefthook or husky, and repositories created before the templateDir
+  hook was seeded, commit without a secret scan.
+  Enabling it requires git 2.54 or later:
+    winget upgrade --id Git.Git
+  See docs/adr/020-git-hooks-via-config.md
+"@
+{{- end -}}

--- a/home/run_after_40-check-git-hooks.ps1.tmpl
+++ b/home/run_after_40-check-git-hooks.ps1.tmpl
@@ -43,13 +43,38 @@ if ($active) {
 $gitVersion = & git --version 2>$null
 if (-not $gitVersion) { $gitVersion = 'git not found' }
 
+# 版番号を取り出して、原因が git の古さか設定の欠落かを分ける。
+# 取り出せない場合は「古い git」として扱い、更新を案内する側へ倒す。
+$supportsConfigHooks = $false
+if ("$gitVersion" -match '(\d+)\.(\d+)') {
+  $major = [int]$Matches[1]
+  $minor = [int]$Matches[2]
+  $supportsConfigHooks = ($major -gt 2) -or ($major -eq 2 -and $minor -ge 54)
+}
+
+if ($supportsConfigHooks) {
+  # git は設定ベースフックを解釈できる。したがって原因は設定側にあり、
+  # git を更新しても直らない。
+  $remediation = @"
+  This git already supports config-based hooks, so the hook config did not
+  reach the global gitconfig. Check what git reads:
+    git config --global --get-regexp '^hook\.dotfiles-gitleaks\.'
+  If it prints nothing, re-apply the dotfiles:
+    chezmoi apply ~/.gitconfig
+"@
+} else {
+  $remediation = @"
+  Enabling it requires git 2.54 or later:
+    winget upgrade --id Git.Git
+"@
+}
+
 Write-Warning @"
 The gitleaks config-based hook is not active ($gitVersion).
   Only repositories seeded from init.templateDir are scanned. Repositories that
   installed lefthook or husky, and repositories created before the templateDir
   hook was seeded, commit without a secret scan.
-  Enabling it requires git 2.54 or later:
-    winget upgrade --id Git.Git
+$remediation
   See docs/adr/020-git-hooks-via-config.md
 "@
 {{- end -}}

--- a/home/run_after_40-check-git-hooks.sh.tmpl
+++ b/home/run_after_40-check-git-hooks.sh.tmpl
@@ -1,0 +1,48 @@
+{{- if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+# gitleaks の pre-commit フックが実際に届いているかを apply のたびに報告する。
+#
+# 背景:
+#   ADR-020 の設定ベースフックは git >= 2.54 でしか解釈されない。それより古い
+#   git は [hook] セクションを警告なく無視するため、設定を配っただけでは保護が
+#   効いているか分からない。ADR-018 では既存リポジトリへの backfill が実行されず、
+#   3 週間にわたり gitleaks が動かない状態が続いた。同じ形の沈黙を避けるため、
+#   ここで状態を明示する。
+#
+# 判定方法:
+#   git のバージョン番号ではなく `git hook list` の出力で判定する。バージョンが
+#   条件を満たしていても設定が届いていなければ保護は効かないため、両方をまとめて
+#   確認できるこちらを使う。終了コードは「未対応の git」と「対応しているが hook 0 件」
+#   を区別できないので使わない。
+#
+# 関連:
+#   - docs/adr/020-git-hooks-via-config.md
+#
+# このスクリプトは apply を失敗させない。保護の有無を伝えるだけである。
+
+set -uo pipefail
+
+if git hook list pre-commit --show-scope 2>/dev/null \
+  | awk -F'\t' '$NF == "dotfiles-gitleaks" && $0 !~ /\tdisabled\t/ { found = 1 }
+                END { exit !found }'; then
+  exit 0
+fi
+
+git_version="$(git --version 2>/dev/null || echo 'git not found')"
+
+cat >&2 <<EOF
+
+Warning: the gitleaks config-based hook is not active (${git_version}).
+  Only repositories seeded from init.templateDir are scanned. Repositories that
+  installed lefthook or husky, and repositories created before the templateDir
+  hook was seeded, commit without a secret scan.
+  Enabling it requires git 2.54 or later:
+{{ if eq .chezmoi.os "darwin" }}    brew install git
+  Then open a new login shell and confirm 'git --version' reports 2.54 or later.
+  (~/.zprofile puts /opt/homebrew/opt/git/bin back at the front of PATH.)
+{{ else }}    sudo add-apt-repository -y ppa:git-core/ppa \\
+      && sudo apt-get update && sudo apt-get install -y git
+{{ end }}  See docs/adr/020-git-hooks-via-config.md
+
+EOF
+{{- end -}}

--- a/home/run_after_40-check-git-hooks.sh.tmpl
+++ b/home/run_after_40-check-git-hooks.sh.tmpl
@@ -29,20 +29,77 @@ if git hook list pre-commit --show-scope 2>/dev/null \
 fi
 
 git_version="$(git --version 2>/dev/null || echo 'git not found')"
+git_version_number="$(printf '%s\n' "${git_version}" | awk '{print $3}')"
 
+# dpkg に依存せずに比較する。この判定は macOS でも通る必要がある。
+# 版を取得できなかった場合は「古い git」として扱い、案内を出す側へ倒す。
+supports_config_hooks() {
+  awk -v version="${1:-0}" 'BEGIN {
+    split(version, part, ".")
+    major = part[1] + 0
+    minor = part[2] + 0
+    exit !(major > 2 || (major == 2 && minor >= 54))
+  }'
+}
+
+if supports_config_hooks "${git_version_number}"; then
+  # git は設定ベースフックを解釈できる。したがって原因は設定側にあり、
+  # git を入れ替えても直らない。この分岐はプラットフォームを問わない。
+  remediation="  This git already supports config-based hooks, so the hook config did not
+  reach the global gitconfig. Check what git reads:
+    git config --global --get-regexp '^hook\.dotfiles-gitleaks\.'
+  If it prints nothing, re-apply the dotfiles:
+    chezmoi apply ~/.gitconfig"
+{{ if eq .chezmoi.os "darwin" -}}
+else
+  remediation="  Enabling it requires git 2.54 or later:
+    brew install git
+  Then open a new login shell and confirm 'git --version' reports 2.54 or later.
+  (~/.zprofile puts /opt/homebrew/opt/git/bin back at the front of PATH.)"
+fi
+{{ else -}}
+else
+  # 古い git が走っている原因は二つに分かれる。apt が要件を満たす git を持って
+  # いないか、持っていても PATH でより前にある別の実体に隠されているかである。
+  # 後者で apt の再実行を案内すると空振りするため、どちらであるかを判定する。
+  remediation="  Enabling it requires git 2.54 or later:
+    sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git"
+  resolved_git="$(command -v git 2>/dev/null || true)"
+  apt_git_version="$(/usr/bin/git --version 2>/dev/null | awk '{print $3}' || true)"
+  if [ -n "${resolved_git}" ] && [ "${resolved_git}" != "/usr/bin/git" ] \
+    && supports_config_hooks "${apt_git_version}"; then
+{{- if or .codespaces .devcontainer }}
+    # ベースイメージがソースビルドした git を /usr/local へ入れた場合に限り、
+    # 張り替えるコマンドまで示す。symlink であれば利用者か過去の張り替えが
+    # 作ったものなので、出所を判定できたことにはならない。
+    if [ "${resolved_git}" = "/usr/local/bin/git" ] && [ ! -L /usr/local/bin/git ]; then
+      remediation="  Enabling it requires git 2.54 or later. /usr/bin/git is ${apt_git_version},
+  but /usr/local/bin/git shadows it, so installing git through apt will not
+  change which binary runs. This container image builds git from source there.
+  Relink it:
+    sudo ln -sfn /usr/bin/git /usr/local/bin/git"
+    else
+{{- end }}
+    # 出所を判定できないため、張り替えは案内しない。mise の shim や利用者が
+    # 置いた git を壊し得るためである。
+    remediation="  Enabling it requires git 2.54 or later. /usr/bin/git is ${apt_git_version},
+  but PATH resolves git to ${resolved_git}, so installing git through apt will
+  not change which binary runs. Check PATH and whichever tool manager provides
+  ${resolved_git}."
+{{- if or .codespaces .devcontainer }}
+    fi
+{{- end }}
+  fi
+fi
+{{ end -}}
 cat >&2 <<EOF
 
 Warning: the gitleaks config-based hook is not active (${git_version}).
   Only repositories seeded from init.templateDir are scanned. Repositories that
   installed lefthook or husky, and repositories created before the templateDir
   hook was seeded, commit without a secret scan.
-  Enabling it requires git 2.54 or later:
-{{ if eq .chezmoi.os "darwin" }}    brew install git
-  Then open a new login shell and confirm 'git --version' reports 2.54 or later.
-  (~/.zprofile puts /opt/homebrew/opt/git/bin back at the front of PATH.)
-{{ else }}    sudo add-apt-repository -y ppa:git-core/ppa \\
-      && sudo apt-get update && sudo apt-get install -y git
-{{ end }}  See docs/adr/020-git-hooks-via-config.md
+${remediation}
+  See docs/adr/020-git-hooks-via-config.md
 
 EOF
 {{- end -}}

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -40,6 +40,55 @@ sudo apt-get install -y -qq \
   xdg-utils \
   zsh
 
+{{ if or .codespaces .devcontainer -}}
+# PPA で入れた git を実際に解決させる。
+# Codespaces と Dev Container のベースイメージは devcontainers の git feature を
+# version=latest, ppa=false で使い、git をソースからビルドして prefix=/usr/local
+# へ入れる。/usr/local/bin は PATH で /usr/bin より先に来るため、上の apt が
+# 新しい git を入れても解決されるのは古いソースビルド版のままになる。
+# イメージのビルド時点で最新だった git が 2.54 未満なら、ADR-020 の設定ベース
+# フックは無効のままになる (Codespaces universal 5.1.5 = git 2.53.0 で実測)。
+#
+# 張り替えるのは、設定ベースフックが有効か無効かを分ける場合だけに限る。
+# 隠している側が 2.54 未満で、かつ /usr/bin 側が 2.54 以上のときにしか動かない。
+# イメージが要件を満たすようになれば、この処理は何もしない。
+# 削除ではなく symlink へ置き換えるのは、/usr/local/bin/git を直接指す設定
+# (VS Code の git.path など) をそのまま生かすためである。
+# >>> git-unshadow: tests/test_git_shadow_resolution.py がこの関数を抽出して実行する
+# 対象ディレクトリは呼び出し側が引数で渡す。テストが偽のディレクトリを渡せる一方、
+# 実行時に環境変数で対象を差し替えられないようにするためである。
+git_unshadow() {
+  local unshadow_from="${1}"
+  local unshadow_to="${2}"
+  local unshadow_required="2.54"
+  local shadowing_version target_version shadowing_path shadowing_name
+
+  [ -x "${unshadow_from}/git" ] || return 0
+  ! [ -L "${unshadow_from}/git" ] || return 0
+  [ -x "${unshadow_to}/git" ] || return 0
+
+  # 実行できない git を掴んでいても apply を止めないよう、取得できなければ空にする。
+  shadowing_version="$("${unshadow_from}/git" --version 2>/dev/null | awk '{print $3}' || true)"
+  target_version="$("${unshadow_to}/git" --version 2>/dev/null | awk '{print $3}' || true)"
+  [ -n "${shadowing_version}" ] && [ -n "${target_version}" ] || return 0
+  dpkg --compare-versions "${shadowing_version}" lt "${unshadow_required}" 2>/dev/null || return 0
+  dpkg --compare-versions "${target_version}" ge "${unshadow_required}" 2>/dev/null || return 0
+
+  echo "Redirecting ${unshadow_from} git ${shadowing_version} to ${unshadow_to} git ${target_version}..."
+  for shadowing_path in "${unshadow_from}"/git "${unshadow_from}"/git-* "${unshadow_from}"/scalar; do
+    shadowing_name="$(basename "${shadowing_path}")"
+    # 移動先に対応が無いものは残す。git-lfs のように git 本体とは別に配布される
+    # ツールを巻き込まないための条件である。
+    if [ -e "${shadowing_path}" ] && [ ! -L "${shadowing_path}" ] && [ -x "${unshadow_to}/${shadowing_name}" ]; then
+      sudo ln -sfn "${unshadow_to}/${shadowing_name}" "${shadowing_path}"
+    fi
+  done
+  hash -r
+}
+# <<< git-unshadow
+git_unshadow /usr/local/bin /usr/bin
+
+{{ end -}}
 # Copilot CLI — mise の github: バックエンドでは更新が遅れるため、
 # 公式インストールスクリプトで導入し、更新は copilot update で行う
 # 判定に command -v を使わない: Codespaces / Dev Container のベースイメージには

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -11,6 +11,18 @@ export DEBIAN_FRONTEND=noninteractive
 
 {{ if eq .chezmoi.os "linux" -}}
 echo "Installing system packages via apt..."
+# git: ディストロ標準の git は設定ベースフック (git >= 2.54) に届かない
+# （Ubuntu 24.04 = 2.43、26.04 = 2.53、devcontainer ベース = 2.52 を確認）。
+# ADR-020 の gitleaks フックはこの機能に依存するため、git-core PPA を使う。
+# PPA が使えない環境ではディストロ版のまま続行し、設定フックは無効になる
+# （chezmoi apply 時の run_after_40-check-git-hooks が警告する）。
+if ! command -v add-apt-repository >/dev/null 2>&1; then
+  sudo apt-get update -qq || echo "Warning: apt-get update had errors, continuing..." >&2
+  sudo apt-get install -y -qq software-properties-common
+fi
+if ! sudo add-apt-repository -y ppa:git-core/ppa 2>/dev/null; then
+  echo "Warning: could not add ppa:git-core/ppa; falling back to distro git (config-based hooks will be inactive)." >&2
+fi
 # サードパーティリポジトリのGPGキー期限切れ等でupdate全体が失敗することがあるため、警告に留める
 if ! sudo apt-get update -qq; then
   echo "Warning: apt-get update had errors (possibly from third-party repos), continuing..." >&2
@@ -83,11 +95,16 @@ brew trust --formula azure/azd/azd \
 # gh: mise install 前にトークン取得手段を確保する（mise 版 gh が shim で shadow する）
 # azure-cli / azd / copilot-cli: GUI アプリや github: バックエンド都合を避けるため
 # macOS では brew で管理
+# git: Apple Git は 2.50 系で停滞しており、設定ベースフック (git >= 2.54) を
+# 使えない。ADR-020 の gitleaks フックはこの機能に依存するため、brew 版を入れる。
+# PATH で Apple Git より優先させる処理は ~/.zprofile 側にある（後述の理由により
+# /etc/zprofile の path_helper より後で prepend する必要がある）。
 brew install \
   azure-cli \
   azure/azd/azd \
   copilot-cli \
   gh \
+  git \
   poppler \
   watch \
   zsh-completions

--- a/tests/test_git_shadow_resolution.py
+++ b/tests/test_git_shadow_resolution.py
@@ -1,0 +1,336 @@
+"""Exercise the git un-shadowing step from the Linux package bootstrap.
+
+Codespaces / Dev Container base images build git from source into /usr/local
+(devcontainers git feature, version=latest, ppa=false, prefix=/usr/local).
+/usr/local/bin precedes /usr/bin in PATH, so installing a newer git through
+ppa:git-core/ppa leaves the older source build as the binary that actually
+runs. When that build predates git 2.54, the ADR-020 config-based gitleaks
+hook stays inactive even though the PPA step reported success.
+
+The bootstrap relinks the shadowing binaries to their /usr/bin counterparts,
+and the post-apply check reports what to do while the hook stays inactive.
+Both touch paths the base image owns, so these tests drive the real code
+against fakes rather than matching its source text: the relink step is a shell
+function that takes the two directories as arguments, and the check script is
+rendered and run against a fake git on PATH.
+"""
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+BOOTSTRAP_PATH = REPO_ROOT / "home/run_once_before_10-install-packages.sh.tmpl"
+CHECK_SCRIPT_PATH = REPO_ROOT / "home/run_after_40-check-git-hooks.sh.tmpl"
+BLOCK_START = "# >>> git-unshadow"
+BLOCK_END = "# <<< git-unshadow"
+CONTAINER_GUARD = "{{ if or .codespaces .devcontainer -}}"
+
+# The block only relinks when it decides the config-based hook is at stake, so
+# the fixtures below name the versions on either side of that threshold.
+BEFORE_CONFIG_HOOKS = "2.53.0"
+AFTER_CONFIG_HOOKS = "2.54.0"
+
+
+def extract_unshadow_block() -> str:
+    """Return the bootstrap's relink function, which carries no template syntax."""
+    lines = BOOTSTRAP_PATH.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(BLOCK_START))
+    end = next(i for i, line in enumerate(lines) if line.startswith(BLOCK_END))
+    block = lines[start + 1 : end]
+    if any("{{" in line for line in block):
+        raise AssertionError("the extracted block must not contain template actions")
+    return "\n".join(block)
+
+
+@unittest.skipUnless(shutil.which("bash"), "bash is required")
+@unittest.skipUnless(shutil.which("dpkg"), "dpkg --compare-versions is required")
+class GitUnshadowBehaviourTests(unittest.TestCase):
+    """Run the real block against fake bin directories."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.block = extract_unshadow_block()
+
+    def setUp(self) -> None:
+        self.root = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.source_bin = self.root / "local"
+        self.target_bin = self.root / "usr"
+        self.source_bin.mkdir()
+        self.target_bin.mkdir()
+        # The block calls sudo; the stub keeps the test unprivileged.
+        self.stub_bin = self.root / "stub"
+        self.stub_bin.mkdir()
+        self._write_executable(self.stub_bin / "sudo", '#!/bin/sh\nexec "$@"\n')
+
+    def _write_executable(self, path: pathlib.Path, body: str) -> None:
+        path.write_text(body, encoding="utf-8")
+        path.chmod(0o755)
+
+    def _fake_git(self, path: pathlib.Path, version: str) -> None:
+        self._write_executable(path, f'#!/bin/sh\necho "git version {version}"\n')
+
+    def run_block(self) -> subprocess.CompletedProcess:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.stub_bin}{os.pathsep}{env['PATH']}"
+        # The directories are arguments, not environment variables: nothing in
+        # the runtime environment may redirect what the step rewrites.
+        script = f'{self.block}\ngit_unshadow "{self.source_bin}" "{self.target_bin}"\n'
+        # -euo pipefail matches how chezmoi runs the bootstrap, so a non-zero
+        # exit here is an exit that would abort the whole apply.
+        return subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def assert_block_succeeded(self, result: subprocess.CompletedProcess) -> None:
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
+
+    def test_relinks_when_the_shadowing_git_predates_config_hooks(self) -> None:
+        self._fake_git(self.source_bin / "git", BEFORE_CONFIG_HOOKS)
+        self._fake_git(self.target_bin / "git", AFTER_CONFIG_HOOKS)
+
+        result = self.run_block()
+
+        self.assert_block_succeeded(result)
+        self.assertTrue((self.source_bin / "git").is_symlink())
+        self.assertEqual(
+            os.readlink(self.source_bin / "git"), str(self.target_bin / "git")
+        )
+
+    def test_leaves_a_shadowing_git_that_already_supports_config_hooks(self) -> None:
+        # Relinking here would swap one working git for another, which is not
+        # what ADR-020 asks for.
+        self._fake_git(self.source_bin / "git", AFTER_CONFIG_HOOKS)
+        self._fake_git(self.target_bin / "git", "2.55.0")
+
+        result = self.run_block()
+
+        self.assert_block_succeeded(result)
+        self.assertFalse((self.source_bin / "git").is_symlink())
+
+    def test_leaves_both_sides_alone_when_apt_cannot_supply_config_hooks(self) -> None:
+        # Without the PPA the distro git is older still; relinking would downgrade.
+        self._fake_git(self.source_bin / "git", BEFORE_CONFIG_HOOKS)
+        self._fake_git(self.target_bin / "git", "2.43.0")
+
+        result = self.run_block()
+
+        self.assert_block_succeeded(result)
+        self.assertFalse((self.source_bin / "git").is_symlink())
+
+    def test_keeps_binaries_that_have_no_counterpart(self) -> None:
+        # git-lfs shares the directory but ships separately from git itself.
+        self._fake_git(self.source_bin / "git", BEFORE_CONFIG_HOOKS)
+        self._fake_git(self.target_bin / "git", AFTER_CONFIG_HOOKS)
+        self._write_executable(self.source_bin / "git-lfs", "#!/bin/sh\nexit 0\n")
+        self._write_executable(self.source_bin / "gitk", "#!/bin/sh\nexit 0\n")
+        self._write_executable(self.source_bin / "git-upload-pack", "#!/bin/sh\n")
+        self._write_executable(self.target_bin / "git-upload-pack", "#!/bin/sh\n")
+
+        result = self.run_block()
+
+        self.assert_block_succeeded(result)
+        self.assertFalse((self.source_bin / "git-lfs").is_symlink())
+        self.assertFalse((self.source_bin / "gitk").is_symlink())
+        self.assertTrue((self.source_bin / "git-upload-pack").is_symlink())
+
+    def test_leaves_an_existing_symlink_alone(self) -> None:
+        # A symlink is somebody's explicit choice, so the step defers to it.
+        self._fake_git(self.target_bin / "git", AFTER_CONFIG_HOOKS)
+        elsewhere = self.root / "chosen-git"
+        self._fake_git(elsewhere, BEFORE_CONFIG_HOOKS)
+        (self.source_bin / "git").symlink_to(elsewhere)
+
+        result = self.run_block()
+
+        self.assert_block_succeeded(result)
+        self.assertEqual(os.readlink(self.source_bin / "git"), str(elsewhere))
+
+    def test_survives_a_shadowing_git_that_cannot_report_its_version(self) -> None:
+        # An unreadable version must not abort the apply under `set -e`.
+        self._write_executable(self.source_bin / "git", "#!/bin/sh\nexit 127\n")
+        self._fake_git(self.target_bin / "git", AFTER_CONFIG_HOOKS)
+
+        result = self.run_block()
+
+        self.assert_block_succeeded(result)
+        self.assertFalse((self.source_bin / "git").is_symlink())
+
+    def test_is_a_no_op_when_nothing_shadows(self) -> None:
+        self._fake_git(self.target_bin / "git", AFTER_CONFIG_HOOKS)
+
+        result = self.run_block()
+
+        self.assert_block_succeeded(result)
+        self.assertFalse((self.source_bin / "git").exists())
+
+    def test_second_run_changes_nothing(self) -> None:
+        self._fake_git(self.source_bin / "git", BEFORE_CONFIG_HOOKS)
+        self._fake_git(self.target_bin / "git", AFTER_CONFIG_HOOKS)
+
+        self.assert_block_succeeded(self.run_block())
+        first = os.readlink(self.source_bin / "git")
+        second_result = self.run_block()
+
+        self.assert_block_succeeded(second_result)
+        self.assertEqual(os.readlink(self.source_bin / "git"), first)
+        self.assertEqual(second_result.stdout, "")
+
+
+class GitUnshadowScopeTests(unittest.TestCase):
+    """Pin the decisions the behaviour tests cannot reach."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.bootstrap = BOOTSTRAP_PATH.read_text(encoding="utf-8")
+        cls.check_script = CHECK_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    def test_relink_runs_only_in_container_images(self) -> None:
+        # Elsewhere a git under /usr/local is the machine owner's own build.
+        block_start = self.bootstrap.index(BLOCK_START)
+        guard = self.bootstrap.rindex(CONTAINER_GUARD, 0, block_start)
+        self.assertNotIn(
+            "{{ end",
+            self.bootstrap[guard:block_start],
+            msg="the guard closes before the relink block starts",
+        )
+        after_block = self.bootstrap[self.bootstrap.index(BLOCK_END) :]
+        self.assertLess(
+            after_block.index("{{ end -}}"),
+            after_block.index("{{ if"),
+            msg="the guard does not close before the next template branch",
+        )
+
+    def test_ppa_is_still_added(self) -> None:
+        # Relinking only helps because apt holds a git the image predates.
+        self.assertIn("add-apt-repository -y ppa:git-core/ppa", self.bootstrap)
+
+    def test_warning_offers_a_relink_only_for_the_known_image_build(self) -> None:
+        # /usr/local/bin/git cannot be faked without root, so this one branch is
+        # pinned by source. The behaviour tests below cover the other branches.
+        self.assertIn("sudo ln -sfn /usr/bin/git /usr/local/bin/git", self.check_script)
+        self.assertIn("[ ! -L /usr/local/bin/git ]", self.check_script)
+        self.assertNotIn("sudo ln -sfn /usr/bin/git ${resolved_git}", self.check_script)
+
+
+@unittest.skipUnless(shutil.which("bash"), "bash is required")
+@unittest.skipUnless(shutil.which("chezmoi"), "chezmoi renders the check script")
+class GitHookWarningBehaviourTests(unittest.TestCase):
+    """Run the rendered check script against a fake git.
+
+    The check script is the safety net for every case the bootstrap declines to
+    touch, so what it tells the reader has to be right for the cause at hand.
+    """
+
+    def setUp(self) -> None:
+        self.root = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.fake_bin = self.root / "bin"
+        self.fake_bin.mkdir()
+
+    def _render(self, *, container: bool) -> str:
+        env = dict(os.environ)
+        env.pop("CODESPACES", None)
+        env.pop("REMOTE_CONTAINERS", None)
+        if container:
+            env["CODESPACES"] = "true"
+        config = self.root / f"config-{container}.toml"
+        config.write_text(
+            subprocess.run(
+                ["chezmoi", "execute-template", "--init"],
+                input=(REPO_ROOT / "home/.chezmoi.toml.tmpl").read_text(
+                    encoding="utf-8"
+                ),
+                capture_output=True,
+                text=True,
+                env=env,
+                check=True,
+            ).stdout,
+            encoding="utf-8",
+        )
+        return subprocess.run(
+            ["chezmoi", "--config", str(config), "execute-template"],
+            input=CHECK_SCRIPT_PATH.read_text(encoding="utf-8"),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        ).stdout
+
+    def _fake_git(self, version: str) -> None:
+        # `git hook list` reports nothing, which is the state that triggers the
+        # warning; `git --version` decides which cause the script reports.
+        (self.fake_bin / "git").write_text(
+            f'#!/bin/sh\ncase "$1" in\n'
+            f'  --version) echo "git version {version}" ;;\n'
+            f"  *) exit 1 ;;\nesac\n",
+            encoding="utf-8",
+        )
+        (self.fake_bin / "git").chmod(0o755)
+
+    def _run(self, script: str) -> str:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.fake_bin}{os.pathsep}{env['PATH']}"
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        return result.stderr
+
+    def test_points_at_the_config_when_git_already_supports_hooks(self) -> None:
+        # Reinstalling git cannot fix a gitconfig that never arrived, so the
+        # warning has to name the config instead of the package.
+        self._fake_git(AFTER_CONFIG_HOOKS)
+
+        warning = self._run(self._render(container=True))
+
+        self.assertIn("chezmoi apply ~/.gitconfig", warning)
+        self.assertIn("hook\\.dotfiles-gitleaks\\.", warning)
+        self.assertNotIn("add-apt-repository", warning)
+        self.assertNotIn("ln -sfn", warning)
+
+    @unittest.skipUnless(
+        pathlib.Path("/usr/bin/git").exists(), "the apt git decides the branch"
+    )
+    def test_reports_the_shadowing_path_without_prescribing_a_relink(self) -> None:
+        # A git this script cannot attribute to the base image may belong to a
+        # tool manager, so the warning describes the situation and stops there.
+        self._fake_git(BEFORE_CONFIG_HOOKS)
+
+        warning = self._run(self._render(container=True))
+
+        apt_version = subprocess.run(
+            ["/usr/bin/git", "--version"], capture_output=True, text=True, check=False
+        ).stdout.split()
+        apt_supports_hooks = len(apt_version) > 2 and apt_version[2] >= "2.54"
+        if apt_supports_hooks:
+            self.assertIn(f"PATH resolves git to {self.fake_bin}/git", warning)
+            self.assertNotIn("ln -sfn", warning)
+        else:
+            # Without a newer git in /usr/bin there is nothing to un-shadow.
+            self.assertIn("add-apt-repository", warning)
+            self.assertNotIn("ln -sfn", warning)
+
+    def test_never_prescribes_a_relink_outside_container_images(self) -> None:
+        # Elsewhere a git under /usr/local is the machine owner's own build.
+        self.assertNotIn("ln -sfn", self._render(container=False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

ADR-018 で採用した `init.templateDir` による Git hook 配布には、gitleaks の適用範囲を狭める性質が二つ残っていた。

1. リポジトリ固有の hook マネージャ（lefthook 等）が `.git/hooks/pre-commit` を差し替えると、以後 gitleaks は実行されず、その事実も出力されない
2. `init.templateDir` は `git init` / `git clone` 時にしかコピーしないため、既存リポジトリは対象外になる

実際に、ある機械で gitleaks が約 3 週間にわたり既存リポジトリで一度も実行されない状態が続いた。ADR-018 はこの状態を検知する仕組みを持たないため、保護が失われたことに気づけなかった。

## 変更内容

ADR-020 として、Git 2.54 の設定ベースフックへ配布方式を移す。

- **設定ベースフックの登録**: `~/.gitconfig` に `[hook "dotfiles-gitleaks"]` を定義し、走査本体を `~/.local/bin/gitleaks-pre-commit` へ配置する。設定ベースフックは `$GIT_DIR/hooks` と別の層で加算的に実行されるため、リポジトリの作成時期と `.git/hooks` の内容によらず動く
- **git 2.54 以降の確保**: macOS は Homebrew の git を `~/.zprofile` で PATH 先頭へ戻す。Linux は `ppa:git-core/ppa` を追加し、Codespaces / Dev Container では `/usr/local/bin` のイメージ同梱 git を `/usr/bin` への symlink へ張り替える。Windows は既定のインストーラで要件を満たす
- **`init.templateDir` の維持**: 古い git のための fallback として残し、両経路が同時に効く環境では hook 側で二重実行を抑止する
- **状態の報告**: `run_after_40-check-git-hooks.{sh,ps1}` が apply のたびに保護の有効性を確認し、無効なら警告する（終了コードは 0）
- **テスト**: `tests/test_git_shadow_resolution.py` を追加し、symlink 張り替えの適用条件を検証する

## 注意点・判断

- `command` は `sh` 経由で呼ぶ。パスを直接書くと、実行ビットが立っていない場合に gitleaks が走らないまま commit だけが拒否される
- `gitconfig` の値は二重引用符で囲む。囲まないと `;` や `#` 以降が切り捨てられる
- friendly-name にイベント名を使うと `hook.<event>.enabled` と曖昧になり git が fatal error を出すため、イベント名と重ならない名前にした
- symlink の張り替えは「Codespaces / Dev Container」「隠している側が 2.54 未満かつ `/usr/bin` 側が 2.54 以上」「`/usr/bin` に同名の実行ファイルがある」の三条件で絞る。この条件により `git-lfs` は対象外になる。すでに symlink のものは書き換えない
- 削除ではなく symlink を選んだのは、`/usr/local/bin/git` を直接指す設定（VS Code の `git.path` 等）を生かすため

## 検証

macOS、Linux コンテナ、Windows、WSL、Codespaces で検証済み（詳細は ADR-020 の「検証記録」）。Dev Container は未検証で、「引き継ぐ検証」に残している。

この Codespace（本ブランチを既定にして作成）では次を確認した。

- `/usr/local/bin/git` が `/usr/bin/git` への symlink に張り替わり、git 2.54.0 が解決される。`git-lfs` は実体のまま
- `git hook list pre-commit --show-scope` が `global dotfiles-gitleaks` を返す
- 要件 1: hook を持たないリポジトリで、秘密情報を含む commit が拒否される（`leaks found: 1`、exit 1）
- 要件 2: lefthook 相当の `.git/hooks/pre-commit` を置いても gitleaks が拒否し、かつ override 側の処理も実行される
- 二重実行の抑止: `no leaks found` の出力が 1 回だけ
- `run_after_40-check-git-hooks.sh`: 有効時は無出力で exit 0、無効時は警告を出して exit 0

テストスイート: 269 passed / 8 skipped。

なお main（#119）を取り込み、`docs/adr/INDEX.md` の ADR 一覧の競合を 020 / 021 の両行を残す形で解消している。
