### PR TITLE
feat: support Dev Container development and accept ADR-020

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  // このリポジトリを Dev Container で開発するための構成である。
+  //
+  // dotfiles 自体はここでは適用しない。VS Code の Dotfiles ユーザ設定
+  // (Repository: torumakabe/dotfiles, Install Command: install.sh) で入れる。
+  // Codespaces がアカウント設定から dotfiles を入れる構造と揃えるためであり、
+  // 手順は README の「Dev Container (ローカル)」節に記載している。
+  // uv, mise, chezmoi, gitleaks はその適用で入る。
+  "name": "dotfiles",
+
+  // git は base イメージが焼き込んだものをそのまま使う。ここで git feature を
+  // 指定し直すと /usr/local へ新しい git を作り直すことになり、ADR-020 が対象と
+  // する「ベースイメージのソースビルドが apt 版を隠す」状態を再現できなくなる。
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+
+  "features": {
+    // ベースイメージに git-lfs が無い。ADR-020 の張り替えが git-lfs を対象から
+    // 外すことを実機で確認するには /usr/local/bin/git-lfs が要る。
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    // dotfiles は Linux に pwsh を入れないため、tests/test_platform_parity.py と
+    // tests/test_mise_config.py の PowerShell 依存テストが skip される。CI
+    // (ubuntu-latest) は同梱の pwsh を使っている。同じ範囲を流すために入れる。
+    "ghcr.io/devcontainers/features/powershell:1": {}
+  },
+
+  "remoteUser": "vscode"
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,3 +33,4 @@ mise 設定を変更する際は、以下のツールの対応状況を確認し
 ## ワークアラウンド（定期チェック対象）
 
 - **op-ssh-sign-wsl.exe CRLF (ADR-012)**: `home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl` で stdout/stderr の CR を剥がして `git verify-commit` を成立させている。1Password が WSL バイナリの改行を LF に揃えた、または git 本体が find-principals 結果の `\r` を剥がすようになったら wrapper と `.gitconfig-linux` の `program` 切替を撤去する
+- **git の張り替え (ADR-020)**: `home/run_once_before_10-install-packages.sh.tmpl` の `git_unshadow` が、Codespaces と Dev Container のベースイメージが `/usr/local/bin` へソースビルドした古い git を `/usr/bin` の PPA 版へ symlink で張り替えている。ADR-020 の設定ベースフックが git 2.54 以上を要求するためである。対象イメージの `/usr/local/bin/git` がすべて 2.54 以上になったら、関数と呼び出しを撤去する（`devcontainers/base:ubuntu` は 2.55.0 で条件を満たす。Codespaces universal 5.1.5 は 2.53.0 で満たさない）

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ GITHUB_TOKEN=$(gh auth token) mise install --yes
 
 `mise install` は作成時にはスキップする。追加の注意点は [`docs/troubleshooting.md`](docs/troubleshooting.md#dev-container-で-mise-ツールが入っていない) を参照。
 
+このリポジトリ自体を Dev Container で開発する場合は `.devcontainer/devcontainer.json` を使う。構成の意図と起動後の手順は [`docs/operations.md`](docs/operations.md#このリポジトリを-dev-container-で開発する) を参照。
+
 ### Windows
 
 ```powershell

--- a/docs/adr/012-wsl-op-ssh-sign-crlf-wrapper.md
+++ b/docs/adr/012-wsl-op-ssh-sign-crlf-wrapper.md
@@ -17,7 +17,7 @@ WSL 上で 1Password の SSH 署名 (`gpg.format = ssh`) を使うと、`git ver
 
 ## Decision
 
-WSL 限定で `op-ssh-sign-wsl.exe` の stdout/stderr から CR を剥がすラッパー `~/.local/bin/op-ssh-sign-wrapper.sh` を経由させる。`isWSL` データで 3 ヶ所をゲート:
+WSL 限定で `op-ssh-sign-wsl.exe` の stdout/stderr から CR を剥がすラッパー `~/.local/bin/op-ssh-sign-wrapper.sh` を経由させる。`isWSL` と WSL interop の実体の論理積で 3 ヶ所をゲート:
 
 | 配置 | WSL | ネイティブ Linux | macOS / Windows |
 | --- | --- | --- | --- |
@@ -26,9 +26,25 @@ WSL 限定で `op-ssh-sign-wsl.exe` の stdout/stderr から CR を剥がすラ�
 
 署名 (`-Y sign`) は `-s <file>` にバイナリを書き出し stdout を経由しないため、CR 除去で改ざんされない。
 
+`isWSL` (`home/.chezmoi.toml.tmpl`) は `/proc/sys/kernel/osrelease` が `microsoft` を含むかどうかだけで判定する。しかし Docker Desktop の WSL2 バックエンドで動く Dev Container はホストの WSL カーネルを共有するため、`osrelease` は実 WSL と同一の値になる。この条件だけでは両者を区別できないことを実測で確認した。
+
+そこで本 ADR の 3 ヶ所では、`isWSL` に加えて `/proc/sys/fs/binfmt_misc/WSLInterop` の存在を確認する。ラッパーは Windows 側の `op-ssh-sign-wsl.exe` を interop 経由で起動するため、interop が無ければ機能しない。`/run/WSL` や `/mnt/wsl` の有無でも同じ結果になるが、これらは interop が使えることを直接には示さない。ラッパーは `windowsUser` から `/mnt/c/Users/<user>/...` を組み立てるため、この値が空の場合も機能しない。`chezmoi init` を非対話で実行した場合や、interop が無い状態で初期化した場合に空になる。3 ヶ所の条件は次のとおり。
+
+- `home/dot_gitconfig-linux.tmpl`：`{{ if and .isWSL (stat "/proc/sys/fs/binfmt_misc/WSLInterop") (ne .windowsUser "") }}` で `gpg.ssh.program` を切り替える
+- `home/.chezmoiignore`：同じ条件の否定でラッパーの配布を除外する
+- `home/.chezmoi.toml.tmpl`：`isWSL`、interop、`stdinIsATTY` の論理積で `windowsUser` の prompt をゲートする
+
+参照側と配布側の条件が食い違うと、`gpg.ssh.program` が配布されていないファイルを指す。`tests/test_platform_parity.py` の `WrapperGateParityTests` が、両テンプレートが同じ述語を使っていることを静的に検査する。
+
+`isWSL` 自体を 2 条件の論理積へ変更する案は採らなかった。`isWSL` は `home/run_once_after_30-install-tools.sh.tmpl` で Docker Engine と draw.io の導入判断にも使われており、そこで求められる意味は「native Linux か」である。interop 条件を `isWSL` へ入れると、interop を持たない Dev Container や interop を無効化した WSL でこれらが導入対象になる。加えて、新しいデータキーを増やすと、既存環境の `~/.config/chezmoi/chezmoi.toml` に当該キーが無いまま `chezmoi apply` した際に `map has no entry for key` で失敗する（実測）。`.chezmoi.toml.tmpl` は `chezmoi init` 時にしか評価されないのに対し、`dot_gitconfig-linux.tmpl` と `.chezmoiignore` は `chezmoi apply` のたびに評価されるため、この形なら環境の変化に追従する。
+
 ## Consequences
 
 - WSL でも `git verify-commit` / `git log --show-signature` がローカル検証できる
 - 1Password が CRLF 出力を改善した場合は wrapper を撤去できる（`.github/copilot-instructions.md` のワークアラウンド節で追跡）
 - 将来 git 本体が find-principals 出力の `\r` を剥がすよう修正された場合も同様に撤去可能
 - wrapper は bash の `set -o pipefail` と process substitution に依存するため、`/usr/bin/env bash` が必須
+- `wsl.conf` で interop を無効化した WSL では `isWSL` は真のままだが、本 ADR の 3 ヶ所では偽と同じ扱いになる。その環境では `.exe` を起動できずラッパーも機能しないため、この扱いが正しい
+- interop を確認していなかった時期は、Dev Container で `gpg.ssh.program` がラッパーを指し、`home/.chezmoiignore` の `not .isWSL` ゲートが外れてラッパーが不要に配布され、TTY があれば `windowsUser` の入力を求められた（実測）
+- `stat "/proc/sys/fs/binfmt_misc/WSLInterop"` を含む同じ条件が `dot_gitconfig-linux.tmpl` と `.chezmoiignore` に重複する。いずれかを変更する場合は両方を揃える必要があり、`tests/test_platform_parity.py` がその一致を検査する
+- `windowsUser` が空の WSL では、ラッパーではなく `/opt/1Password/op-ssh-sign` を指す。どちらもその環境では機能しないが、空のユーザー名を含むパスを指すよりは失敗の原因を追いやすい。`chezmoi init` を対話的に再実行すれば解消する

--- a/docs/adr/020-git-hooks-via-config.md
+++ b/docs/adr/020-git-hooks-via-config.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Proposed
+Accepted
 
-macOS、Linux コンテナ、Windows、WSL、Codespaces で検証した。結果は「検証記録」に記す。Dev Container は未検証であり、残る検証項目は「引き継ぐ検証」に記す。
+macOS、Linux コンテナ、Windows、WSL、Codespaces、Dev Container の 6 環境で検証した。結果は「検証記録」に記す。Dev Container では張り替え処理の発火条件が揃わなかったため、この経路の実機確認は済んでいない。張り替えは本 ADR の判断そのものではなく、古いイメージ向けの移行処理である。同じ処理は Codespaces の実機で確認済みであり、条件分岐は `tests/test_git_shadow_resolution.py` が確認する。詳細は「引き継ぐ検証」に記す。
 
 ## Context
 
@@ -131,19 +131,19 @@ git config --local hook.dotfiles-gitleaks.enabled false
 
 ## 検証記録
 
-macOS 実機、Linux コンテナ、Windows 実機、WSL (Ubuntu 22.04)、Codespaces で確認した。使用した git は、macOS が Homebrew の 2.55.0、Linux コンテナが `ppa:git-core/ppa` の 2.54.0、Windows が Git for Windows 2.55.0、WSL と Codespaces が同じ PPA の 2.54.0 である。WSL の git は apply 前が 2.34.1 であり、`run_once_before_10-install-packages.sh` の PPA 追加によって 2.54.0 へ更新された。
+macOS 実機、Linux コンテナ、Windows 実機、WSL (Ubuntu 22.04)、Codespaces、Dev Container で確認した。使用した git は、macOS が Homebrew の 2.55.0、Linux コンテナが `ppa:git-core/ppa` の 2.54.0、Windows が Git for Windows 2.55.0、WSL と Codespaces が同じ PPA の 2.54.0、Dev Container がベースイメージ同梱の 2.55.0 である。WSL の git は apply 前が 2.34.1 であり、`run_once_before_10-install-packages.sh` の PPA 追加によって 2.54.0 へ更新された。
 
-commit を拒否したことの判定には、出力に `leaks found: 1` が現れること、git の終了コードが 1 であること、commit が作られないことの三つを使った。
+commit を拒否したことの判定には、出力に `leaks found: 1` が現れること、git の終了コードが 1 であること、commit が作られないことの三つを使った。判定に使うダミー鍵の本文は 55 文字とした。gitleaks の private-key ルールは本文の長さも見ており、33 文字では検出しなかった (macOS で実測)。
 
-| 確認項目 | macOS / Linux | Windows | WSL | Codespaces |
-| --- | --- | --- | --- | --- |
-| 要件 1: `.git/hooks` に hook を持たないリポジトリで秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した | 拒否した |
-| 要件 2: lefthook 生成の hook で上書きした状態で秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した | 拒否した |
-| 要件 2: 同じ状態で lefthook 自身の job も実行される | 実行した | 実行した | 実行した | 実行した |
-| 設定ベースフック有効時の走査回数 | 1 回 | 1 回 | 1 回 | 1 回 |
-| リポジトリ単位で無効化した場合の走査回数 | 1 回 | 1 回 | 1 回 | 1 回 |
-| hook の中で解決される `git` が hook を起動した git と同一である | 同一 | 同一 | 同一 | 同一 |
-| `chezmoi apply` 時の報告が、有効なら無出力、無効なら警告になる | 一致した | 一致した | 一致した | 一致した |
+| 確認項目 | macOS / Linux | Windows | WSL | Codespaces | Dev Container |
+| --- | --- | --- | --- | --- | --- |
+| 要件 1: `.git/hooks` に hook を持たないリポジトリで秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した | 拒否した | 拒否した |
+| 要件 2: lefthook 生成の hook で上書きした状態で秘密鍵の commit を拒否する | 拒否した | 拒否した | 拒否した | 拒否した | 拒否した |
+| 要件 2: 同じ状態で lefthook 自身の job も実行される | 実行した | 実行した | 実行した | 実行した | 実行した |
+| 設定ベースフック有効時の走査回数 | 1 回 | 1 回 | 1 回 | 1 回 | 1 回 |
+| リポジトリ単位で無効化した場合の走査回数 | 1 回 | 1 回 | 1 回 | 1 回 | 1 回 |
+| hook の中で解決される `git` が hook を起動した git と同一である | 同一 | 同一 | 同一 | 同一 | 同一 |
+| `chezmoi apply` 時の報告が、有効なら無出力、無効なら警告になる | 一致した | 一致した | 一致した | 一致した | 一致した |
 
 プラットフォームごとに個別に確認した事項を記す。
 
@@ -152,37 +152,21 @@ commit を拒否したことの判定には、出力に `leaks found: 1` が現�
 - Windows: hook の中で `sh` は `/usr/bin/sh` に解決される。これは Git for Windows が同梱する MSYS の sh であり、WSL の bash ではない。`command` に書いた `~` は Windows のユーザプロファイルを指す。
 - WSL: hook の中で `sh` は `/usr/bin/sh`、`git` は `/usr/lib/git-core/git` に解決される。`appendWindowsPath` を無効にしているため、Windows 側の実行ファイルは経路に入らない。
 - Codespaces: universal イメージ 5.1.5 (2026-03-11 ビルド) は git 2.53.0 を `/usr/local/bin` に持つ。PPA の追加と `apt-get install git` はどちらも成功して `/usr/bin/git` を 2.54.0 にしたが、張り替えを入れる前は `git` が 2.53.0 に解決され、要件 1 の試験で秘密鍵が commit された。張り替え後は `/usr/local/bin/git` が `/usr/bin/git` への symlink になり、`git-lfs` は元のまま残った。同じスクリプトを二度実行しても symlink は変わらない。hook の中で `git` は `/usr/lib/git-core/git` に解決される。
+- Dev Container: `mcr.microsoft.com/devcontainers/base:ubuntu` を Windows の Docker Desktop で起動した。`/usr/local/bin/git` はイメージ同梱の通常ファイルで 2.55.0 であり、`/usr/bin/git` は apply 前が 2.53.0、PPA の追加によって 2.54.0 になった。隠している側が 2.54 を満たすため張り替えは発火せず、`git` は `/usr/local/bin/git` に解決されたままである。hook の中で解決される git も同じ 2.55.0 である。gitleaks 8.30.1 の出力は `WRN leaks found: 1` の形式だが、判定に使う部分文字列を含むため判定は成立する。
 
-Codespaces のイメージが git 2.53.0 を持つのは、devcontainers の git feature がイメージのビルド時点で最新のタグを解決するためである。git 2.54.0 のリリースは 2026-04-20 であり、5.1.5 のビルド (2026-03-11) より後にあたる。したがってイメージが更新されれば張り替えは不要になるが、更新の時期は利用者側で決められない。
+Codespaces のイメージが git 2.53.0 を持つのは、devcontainers の git feature がイメージのビルド時点で最新のタグを解決するためである。git 2.54.0 のリリースは 2026-04-20 であり、5.1.5 のビルド (2026-03-11) より後にあたる。したがってイメージが更新されれば張り替えは不要になるが、更新の時期は利用者側で決められない。Dev Container で使った `base:ubuntu` は更新後のイメージにあたり、同じ git feature が 2.55.0 を入れていた。張り替えが発火するかどうかは、イメージの更新状況で決まる。
 
 張り替えの条件分岐は、偽の bin ディレクトリを使って `tests/test_git_shadow_resolution.py` で確認した。テストはブートストラップから当該の関数を抜き出し、対象ディレクトリを引数で渡して `bash -euo pipefail` で実行する。対象を引数で受け取るのは、テストのために環境変数で書き換え先を差し替えられる余地を本番のスクリプトへ残さないためである。確認した内容は、2.53 から 2.54 へは張り替えること、2.54 から 2.55 へは張り替えないこと、`/usr/bin` 側が 2.43 なら張り替えないこと、`/usr/bin` に対応の無い `git-lfs` と `gitk` を残すこと、既存の symlink を書き換えないこと、隠している git がバージョンを返せなくても apply を止めないこと、二度目の実行が何も変えないことである。
 
 判定方法について確認した事項を記す。`git hook list` は該当する hook が無い場合に exit 1 を返し、サブコマンド自体を知らない git は exit 129 を返す。終了コードだけでは両者と「対応しているが未設定」を区別できないため、判定には標準出力の内容を使う。`--show-scope` を付けない場合、スコープと `disabled` の表示は出ない。
 
-`run_after_40-check-git-hooks` の警告経路は、`GIT_CONFIG_GLOBAL` を空のファイルへ向けて設定ベースフックが見えない状態を作り、Windows と WSL の双方で確認した。どちらも警告を出したうえで終了コード 0 を返し、apply を失敗させない。Windows 版は powershell.exe 5.1 で実行し、構文が通ることもあわせて確認した。Codespaces では案内の分岐を五通り確認した。走っている git が 2.54 以上であれば設定の確認と `chezmoi apply` を案内すること、張り替え済みの状態では PPA の案内を出すこと（symlink 越しに 2.54 が走る状態を隠蔽と呼ばないこと）、`/usr/local/bin/git` が古い通常ファイルであれば張り替えコマンドを示すこと、それ以外のパスの git が隠している場合は PATH と提供元の確認だけを促して書き換えを案内しないこと、`/usr/bin/git` が 2.54 に満たない場合は PPA の案内へ戻ることである。同じテストが、偽の git を PATH の先頭へ置いてレンダリング済みの警告スクリプトを実行し、設定欠落の案内と、コンテナ以外へレンダリングした場合に張り替えを一切案内しないことを確認する。
+`run_after_40-check-git-hooks` の警告経路は、`GIT_CONFIG_GLOBAL` を空のファイルへ向けて設定ベースフックが見えない状態を作り、Windows と WSL の双方で確認した。Dev Container でも同じ方法で確認し、走っている git が 2.54 以上であることから設定の欠落を伝える分岐に入ることを確認した。どちらも警告を出したうえで終了コード 0 を返し、apply を失敗させない。Windows 版は powershell.exe 5.1 で実行し、構文が通ることもあわせて確認した。Codespaces では案内の分岐を五通り確認した。走っている git が 2.54 以上であれば設定の確認と `chezmoi apply` を案内すること、張り替え済みの状態では PPA の案内を出すこと（symlink 越しに 2.54 が走る状態を隠蔽と呼ばないこと）、`/usr/local/bin/git` が古い通常ファイルであれば張り替えコマンドを示すこと、それ以外のパスの git が隠している場合は PATH と提供元の確認だけを促して書き換えを案内しないこと、`/usr/bin/git` が 2.54 に満たない場合は PPA の案内へ戻ることである。同じテストが、偽の git を PATH の先頭へ置いてレンダリング済みの警告スクリプトを実行し、設定欠落の案内と、コンテナ以外へレンダリングした場合に張り替えを一切案内しないことを確認する。
 
 ## 引き継ぐ検証
 
-Dev Container では未検証である。Codespaces と同じ devcontainers の git feature を使うイメージであれば、`/usr/local` のソースビルドを張り替える処理がそのまま効くと考えられるが、ベースイメージによって git の入手経路は異なる。イメージを起動して `chezmoi apply` を実行したうえで、次を確認する。
+Dev Container では、`/usr/local` のソースビルドを `/usr/bin` の apt 版へ張り替える処理が発火しなかった。ベースイメージ `mcr.microsoft.com/devcontainers/base:ubuntu` の `/usr/local/bin/git` が 2.55.0 であり、発火条件である「隠している側が 2.54 に満たないこと」を満たさないためである。したがって Dev Container では、張り替え処理そのものと、`git-lfs` が張り替えの対象から外れることを実機で確認していない。
 
-1. `git --version` が 2.54 以降であること。満たさない場合は、`command -v git` が返す実体と `/usr/bin/git --version` を比べる。両者が食い違うなら PATH の問題であり、一致するなら PPA の追加が失敗している。後者ではベースイメージの sudo の扱い、apt のプロキシ設定、`software-properties-common` の有無が候補になる。
-2. `git hook list pre-commit --show-scope` が `dotfiles-gitleaks` を含む行を返すこと。
-3. 要件 1（作成時期を問わず走る）。`init.templateDir` 由来の hook を持たない状態を作って確認する。
-
-   ```sh
-   mkdir -p /tmp/gl1 && cd /tmp/gl1 && git init
-   git config commit.gpgsign false
-   rm -f "$(git rev-parse --git-path hooks)/pre-commit"
-   printf -- '-----BEGIN OPENSSH PRIVATE KEY-----\n%s\n-----END OPENSSH PRIVATE KEY-----\n' \
-     'NOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEYNOTAREALKEY' > fake_key
-   git add fake_key && git commit -m t
-   ```
-
-   期待する結果は、出力に `leaks found: 1` が現れ、`git rev-list --count HEAD` が commit を数えないことである。本文を短くしてはならない。gitleaks の private-key ルールは本文の長さも見ており、33 文字では検出しなかった（macOS で実測）。上記の 55 文字は検出を確認した値である。
-
-4. 走査が 1 回だけであること。手順 3 の削除をしない状態で commit し、`git commit -m t 2>&1 | grep -c 'no leaks found'` が 1 を返すこと。
-5. `git-lfs` が張り替えの対象になっていないこと。`ls -l /usr/local/bin/git-lfs` が symlink ではない実体を示し、`git lfs version` が成功すること。
-6. git が 2.54 に満たないまま終わった場合、`chezmoi apply` が `run_after_40-check-git-hooks.sh` の警告を出し、かつ apply 自体は成功すること。この経路では `init.templateDir` 由来の hook だけが保護を担う。
+どちらも Codespaces では確認しており、条件分岐は `tests/test_git_shadow_resolution.py` が偽の bin ディレクトリを使って確認する。残るのは、Dev Container のベースイメージが git 2.54 に満たない構成での再確認である。そのような構成を使う場合は、`chezmoi apply` の後に `ls -l /usr/local/bin/git-lfs` が symlink ではない実体を示すこと、`git lfs version` が成功すること、`git --version` が 2.54 以降になることを確認する。
 
 ### apply が途中で止まった場合
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -32,7 +32,7 @@
 | [017](017-msvc-linker-env-var-override-windows.md) | Windows の MSVC リンカーは CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER で明示指定する | Accepted |
 | [018](018-git-hooks-via-init-templatedir.md) | 機械全体への Git hook 配布は init.templateDir で行う | Accepted |
 | [019](019-cross-platform-parity-contract.md) | クロスプラットフォーム機能等価性はプラットフォーム契約と静的検査で担保する | Accepted |
-| [020](020-git-hooks-via-config.md) | gitleaks の pre-commit は Git の設定ベースフックで配る | Proposed |
+| [020](020-git-hooks-via-config.md) | gitleaks の pre-commit は Git の設定ベースフックで配る | Accepted |
 | [021](021-mise-lockfile-platforms.md) | lockfile の対象プラットフォームは lockfile_platforms で固定する | Accepted |
 
 ## テンプレート

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ home/                           ← chezmoi source
 ├── PowerShell_profile.ps1.tmpl
 ├── private_dot_copilot/        ← ~/.copilot/ 配下（instructions, hooks, mcp, skills）
 └── run_once_{before,after}_*   ← bootstrap スクリプト
+.devcontainer/devcontainer.json  ← このリポジトリを開発する Dev Container の構成
 reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 ```
 
@@ -58,8 +59,8 @@ Git 2.54 以降では、これに加えて `~/.gitconfig` の `[hook "dotfiles-g
 |------|------|
 | `.chezmoi.os` | `linux`, `darwin`, `windows` |
 | `.isLinux` / `.isMac` / `.isWindows` | 上から導出 |
-| `.isWSL` | Linux かつ `kernel.osrelease` に `microsoft` を含む |
-| `.codespaces` / `.devcontainer` | 各環境判定 |
+| `.isWSL` | Linux かつ `kernel.osrelease` に `microsoft` を含む。Docker Desktop の WSL2 バックエンドで動くコンテナはホストの WSL カーネルを共有するため、この変数だけでは実 WSL と区別できない。区別が要る箇所では `/proc/sys/fs/binfmt_misc/WSLInterop` の存在を併せて確認する（ADR-012） |
+| `.codespaces` / `.devcontainer` | それぞれ環境変数 `CODESPACES` / `REMOTE_CONTAINERS` の有無で判定。`REMOTE_CONTAINERS` を立てるのは VS Code の Dev Containers 拡張であり、`@devcontainers/cli` は立てない |
 | `.windowsUser` / `.corpUser` | 初回セットアップで入力 |
 
 ## プラットフォーム機能契約
@@ -80,7 +81,7 @@ helm、gh、azd、trivy、kubectl、Azure CLIの補完はzshとPowerShellの両�
 
 ## Git `includeIf`
 
-`home/dot_gitconfig.tmpl` はベース設定のみを置き、`includeIf` でプラットフォーム差分を切り替える: `gitdir:/home/` → Linux/WSL、`gitdir:/Users/` → macOS、`gitdir/i:C:/` 等 → Windows。WSL は Linux 側を読みつつ `.isWSL` で 1Password 連携パスを切り替える。
+`home/dot_gitconfig.tmpl` はベース設定のみを置き、`includeIf` でプラットフォーム差分を切り替える: `gitdir:/home/` → Linux/WSL、`gitdir:/Users/` → macOS、`gitdir/i:C:/` 等 → Windows。WSL は Linux 側を読みつつ、`.isWSL` と WSL interop の有無で 1Password 連携パスを切り替える。
 
 ## コミット署名
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,6 +133,29 @@ sed '/^{{/d' home/run_once_before_20-install-mise.sh.tmpl | bash -n
 sed '/^{{/d' home/run_once_after_10-setup-shell.sh.tmpl | bash -n
 ```
 
+## このリポジトリを Dev Container で開発する
+
+`.devcontainer/devcontainer.json` は、このリポジトリ自体を開発するための構成である。dotfiles を任意のプロジェクトの Dev Container へ適用する手順（`README.md` の「Dev Container (ローカル)」節）とは別のものを指す。
+
+dotfiles は `devcontainer.json` からは適用しない。VS Code の Dotfiles ユーザ設定（Repository に `torumakabe/dotfiles`、Install Command に `install.sh`）で入れる。Codespaces がアカウント設定から dotfiles を入れる構造と揃えるためである。**この設定をしていないコンテナには `uv`、`mise`、`chezmoi`、`gitleaks` が入らず、テストを実行できない。**
+
+コンテナ起動後に次を実行する。
+
+```bash
+gh auth login
+GITHUB_TOKEN=$(gh auth token) mise install --yes
+```
+
+構成上の判断は次のとおりである。
+
+- **`image`**：`mcr.microsoft.com/devcontainers/base:ubuntu` を使い、`git` feature は指定し直さない。指定すると `/usr/local` へ git を作り直すことになり、ADR-020 が対象とする「ベースイメージのソースビルドが apt 版を隠す」状態を再現できなくなる
+- **`git-lfs` feature**：ベースイメージに `git-lfs` が含まれないため足す。ADR-020 の張り替えが `git-lfs` を対象から外すことを実機で確認するには、`/usr/local/bin/git-lfs` が存在する必要がある
+- **`powershell` feature**：dotfiles は Linux に pwsh を入れないため、これが無いと `tests/test_platform_parity.py` と `tests/test_mise_config.py` の PowerShell 依存テストが skip される。CI（ubuntu-latest）は同梱の pwsh を使うので、同じ範囲を流すために足す
+
+`@devcontainers/cli` で起動したコンテナでは `REMOTE_CONTAINERS` が立たないため、chezmoi の `.devcontainer` が false になる。CLI で検証するときは `--remote-env REMOTE_CONTAINERS=true` を渡す。
+
+Windows ホストでは、`tests/test_git_shadow_resolution.py` のうち POSIX 版のチェックスクリプトを実行するテストが skip される。`bash` が WSL の interop 版に解決され、テストが用意した偽の git を参照できないためである。全件を実行するには、このコンテナか WSL、または CI を使う。
+
 ## プラットフォーム契約の運用確認
 
 開発者は公開関数、alias、補完、ツール導入を変更した後、契約とmise設定の回帰検査を実行する。

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,4 +1,8 @@
 {{- $codespaces := env "CODESPACES" | not | not -}}
+{{- /* REMOTE_CONTAINERS を立てるのは VS Code の Dev Containers 拡張である。
+       devcontainer CLI (@devcontainers/cli) は立てないため、CLI で起動した
+       コンテナでは devcontainer が false になる。CLI で検証するときは
+       --remote-env REMOTE_CONTAINERS=true を渡す。 */ -}}
 {{- $devcontainer := env "REMOTE_CONTAINERS" | not | not -}}
 {{- $isLinux := eq .chezmoi.os "linux" -}}
 {{- $isMac := eq .chezmoi.os "darwin" -}}
@@ -13,9 +17,14 @@
 {{- end -}}
 
 {{- $windowsUser := "" -}}
+{{- /* windowsUser は ADR-012 の op-ssh-sign-wsl.exe パスと Windows 用 gitconfig で
+       しか使わない。WSL 側では interop が無いと wsl.exe 経由の実行そのものが
+       成立しないため、interop の実体を確認してから尋ねる。Docker Desktop の
+       WSL2 バックエンドで動くコンテナはホストの WSL カーネルを共有するので、
+       osrelease だけでは実 WSL と区別できない。 */ -}}
 {{- if $isWindows -}}
 {{-   $windowsUser = env "USERNAME" -}}
-{{- else if and $isWSL stdinIsATTY -}}
+{{- else if and $isWSL stdinIsATTY (stat "/proc/sys/fs/binfmt_misc/WSLInterop") -}}
 {{-   $windowsUser = promptStringOnce . "windowsUser" "Windows username (for WSL 1Password paths)" -}}
 {{- end -}}
 

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -20,7 +20,9 @@ run_once_after_05-setup-mise-shims-path.ps1
 .bash_profile
 .bashrc
 {{ end -}}
-{{ if not .isWSL -}}
+# ADR-012 の wrapper は WSL interop 経由でしか機能せず、windowsUser が空でも
+# パスを組み立てられない。dot_gitconfig-linux.tmpl と同じ条件で配布可否を決める。
+{{ if not (and .isWSL (stat "/proc/sys/fs/binfmt_misc/WSLInterop") (ne .windowsUser "")) -}}
 .local/bin/op-ssh-sign-wrapper.sh
 {{ end -}}
 

--- a/home/dot_gitconfig-linux.tmpl
+++ b/home/dot_gitconfig-linux.tmpl
@@ -1,4 +1,9 @@
-{{- if .isWSL -}}
+{{- /* ADR-012 の wrapper は wsl.exe interop 経由で op-ssh-sign-wsl.exe を呼ぶため、
+       interop が無い環境では機能しない。Docker Desktop の WSL2 バックエンドで動く
+       コンテナはホストの WSL カーネルを共有し isWSL が true になるので、
+       interop の実体を確認して分岐する。windowsUser が空だと wrapper は
+       /mnt/c/Users// を組み立てて機能しないため、これも条件に含める。 */ -}}
+{{- if and .isWSL (stat "/proc/sys/fs/binfmt_misc/WSLInterop") (ne .windowsUser "") -}}
 [core]
 	editor = vim -c \"set fenc=utf-8\"
 [gpg "ssh"]

--- a/home/run_once_before_10-install-packages.sh.tmpl
+++ b/home/run_once_before_10-install-packages.sh.tmpl
@@ -12,7 +12,7 @@ export DEBIAN_FRONTEND=noninteractive
 {{ if eq .chezmoi.os "linux" -}}
 echo "Installing system packages via apt..."
 # git: ディストロ標準の git は設定ベースフック (git >= 2.54) に届かない
-# （Ubuntu 24.04 = 2.43、26.04 = 2.53、devcontainer ベース = 2.52 を確認）。
+# （Ubuntu 24.04 = 2.43、26.04 = 2.53 を確認）。
 # ADR-020 の gitleaks フックはこの機能に依存するため、git-core PPA を使う。
 # PPA が使えない環境ではディストロ版のまま続行し、設定フックは無効になる
 # （chezmoi apply 時の run_after_40-check-git-hooks が警告する）。
@@ -126,7 +126,9 @@ fi
 
 {{ if and (not .codespaces) (not .devcontainer) -}}
 # Azure CLI — 公式インストールスクリプト (https://aka.ms/InstallAzureCLIDeb)
-# Codespaces / Dev Container では devcontainer Feature で導入するためスキップ
+# Codespaces では devcontainer Feature で導入するためスキップ。このリポジトリの
+# .devcontainer/devcontainer.json は chezmoi テンプレートと Python テストの開発だけを
+# 対象とするため az / azd の Feature を含めない
 if ! command -v az >/dev/null 2>&1; then
   echo "Installing Azure CLI via official script..."
   curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/tests/test_git_shadow_resolution.py
+++ b/tests/test_git_shadow_resolution.py
@@ -225,6 +225,19 @@ class GitUnshadowScopeTests(unittest.TestCase):
         self.assertNotIn("sudo ln -sfn /usr/bin/git ${resolved_git}", self.check_script)
 
 
+# On Windows shutil.which("bash") resolves to the WSL interop bash, which runs
+# in a different filesystem namespace: the fake bin directory these tests put on
+# PATH lives in a Windows temporary directory that WSL's PATH does not pick up,
+# so the real git inside WSL answers instead of the fixture. The check script is
+# the POSIX variant, whose hosts are macOS, Linux, WSL and containers; Windows
+# runs the PowerShell variant. Skipping here keeps the suite from reporting a
+# result it did not measure. Running the suite inside WSL exercises these tests.
+runs_the_posix_check_script = unittest.skipIf(
+    os.name == "nt",
+    "bash on Windows resolves to WSL, where the fake git on PATH does not apply",
+)
+
+
 @unittest.skipUnless(shutil.which("bash"), "bash is required")
 @unittest.skipUnless(shutil.which("chezmoi"), "chezmoi renders the check script")
 class GitHookWarningBehaviourTests(unittest.TestCase):
@@ -293,6 +306,7 @@ class GitHookWarningBehaviourTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         return result.stderr
 
+    @runs_the_posix_check_script
     def test_points_at_the_config_when_git_already_supports_hooks(self) -> None:
         # Reinstalling git cannot fix a gitconfig that never arrived, so the
         # warning has to name the config instead of the package.
@@ -305,6 +319,7 @@ class GitHookWarningBehaviourTests(unittest.TestCase):
         self.assertNotIn("add-apt-repository", warning)
         self.assertNotIn("ln -sfn", warning)
 
+    @runs_the_posix_check_script
     @unittest.skipUnless(
         pathlib.Path("/usr/bin/git").exists(), "the apt git decides the branch"
     )

--- a/tests/test_platform_parity.py
+++ b/tests/test_platform_parity.py
@@ -479,5 +479,39 @@ $result = @{{
                 self.assertLess(self.workflow.index(prerequisite), unittest_position)
 
 
+class WrapperGateParityTests(unittest.TestCase):
+    """ADR-012 の wrapper は参照側と配布側で同じ条件を使う必要がある。
+
+    条件が食い違うと ``gpg.ssh.program`` が存在しないファイルを指し、署名が
+    失敗する。条件は ``home/.chezmoi.toml.tmpl`` の data に置けないため
+    （``chezmoi init`` 時にしか評価されず環境の変化へ追従しない）、2 つの
+    テンプレートへ重複して書いている。その重複が崩れていないことを検査する。
+    """
+
+    PREDICATE = (
+        'and .isWSL (stat "/proc/sys/fs/binfmt_misc/WSLInterop") '
+        '(ne .windowsUser "")'
+    )
+
+    def setUp(self) -> None:
+        self.gitconfig = (REPO_ROOT / "home/dot_gitconfig-linux.tmpl").read_text(
+            encoding="utf-8"
+        )
+        self.ignore = (REPO_ROOT / "home/.chezmoiignore").read_text(encoding="utf-8")
+        self.wrapper = (
+            REPO_ROOT / "home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl"
+        ).read_text(encoding="utf-8")
+
+    def test_gitconfig_selects_wrapper_with_the_shared_predicate(self) -> None:
+        self.assertIn("{{- if " + self.PREDICATE + " -}}", self.gitconfig)
+
+    def test_chezmoiignore_excludes_wrapper_with_the_negated_predicate(self) -> None:
+        self.assertIn("{{ if not (" + self.PREDICATE + ") -}}", self.ignore)
+        self.assertIn(".local/bin/op-ssh-sign-wrapper.sh", self.ignore)
+
+    def test_wrapper_depends_on_windows_user(self) -> None:
+        self.assertIn("{{ .windowsUser }}", self.wrapper)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 背景

ADR-020（gitleaks の pre-commit を Git 2.54 の設定ベースフックで配る）は、Dev Container を「引き継ぐ検証」に残したまま Proposed で止まっていた。この検証を行うには、このリポジトリを Dev Container で開けるようにする必要がある。

検証の過程で、Dev Container で `isWSL` が誤って真になることが判明した。Docker Desktop の WSL2 バックエンドで動くコンテナはホストの WSL カーネルを共有するため、`/proc/sys/kernel/osrelease` が実 WSL と同じ値を返す。

## 変更内容

### Dev Container 対応

`.devcontainer/devcontainer.json` を追加する。`devcontainers/base:ubuntu` に `git-lfs` と `powershell` の Feature を重ねる。git-lfs は ADR-020 の張り替えが git-lfs を対象外にすることを実機で確認するために入れており、ベースイメージには含まれない。構成の意図と起動後の手順は `docs/operations.md` に置き、`README.md` から誘導する。

`tests/test_git_shadow_resolution.py` の bash 依存 2 メソッドを Windows ホストで skip する。`shutil.which("bash")` が WSL の bash を返し、テストが用意した偽 git は Windows の一時パスにあるため WSL の PATH で効かず、WSL 側の実 git が応答していた。WSL に dotfiles を適用済みなら誤って失敗し、未適用なら偽 git を測らないまま誤って成功する。Linux、WSL、CI では従来どおり実行する。

### ADR-012 の署名ラッパーを実 WSL に限定

`isWSL` 自体は osrelease のみの判定のまま残す。この値は `run_once_after_30-install-tools.sh.tmpl` で Docker Engine と draw.io の導入判断にも使われており、そこで求められる意味は「native Linux か」だからである。条件を強めると、`REMOTE_CONTAINERS` が立たない `@devcontainers/cli` 経路のコンテナや interop を無効化した WSL で、これらが導入対象になる。

代わりに ADR-012 に関係する箇所で `/proc/sys/fs/binfmt_misc/WSLInterop` の存在を確認する。ラッパーは Windows 側の `op-ssh-sign-wsl.exe` を interop 経由で起動するため、interop が無ければ機能しない。併せて `windowsUser` が空でないことも確認する。空だとラッパーは `/mnt/c/Users//...` を組み立てて機能しない。

### ADR-020 を Accepted へ

Dev Container での実測により、残っていた検証項目が埋まった。`git_unshadow` は撤去できるまで維持する必要があるため、`.github/copilot-instructions.md` のワークアラウンド節へ登録し、撤去条件を記録する。

## 注意点・判断

- 新しいデータキーを増やす案は採らなかった。既存環境の `chezmoi.toml` に当該キーが無いまま `chezmoi apply` すると `map has no entry for key` で失敗する（実測）。また `.chezmoi.toml.tmpl` は `chezmoi init` 時にしか評価されないのに対し、`dot_gitconfig-linux.tmpl` と `.chezmoiignore` は apply のたびに評価されるため、この形なら環境の変化に追従する
- 代償として同じ述語が 2 つのテンプレートに重複する。食い違うと `gpg.ssh.program` が配布されていないファイルを指すため、`tests/test_platform_parity.py` に一致検査を追加した
- `REMOTE_CONTAINERS` を立てるのは VS Code の Dev Containers 拡張であり、`@devcontainers/cli` は立てない。`devcontainer` 判定はこの制約を持ったまま残し、`docs/architecture.md` とコードコメントに記録した
- このリポジトリの Dev Container は chezmoi テンプレートと Python テストの開発だけを対象とするため、`az` / `azd` の Feature を含めない。`run_once_before_10-install-packages.sh.tmpl` のコメントをこの実態に合わせた
- `devcontainer-lock.json` は追跡しない

## 検証

Dev Container 内で ADR-020 の要件を実測した。

- templateDir の hook を持たないリポジトリで、秘密鍵を含む commit が拒否される
- 走査は 1 回だけ実行される
- lefthook 相当の hook で `.git/hooks/pre-commit` を上書きしても拒否される
- `devcontainers/base:ubuntu` の `/usr/local/bin/git` は 2.55.0 であり、張り替えの条件を満たさない。要件を満たすイメージでは張り替えが起きないという反対側の分岐を確認した
- コンテナ内の `test_git_shadow_resolution` は 14 件成功、skip 0

`isWSL` まわりは 3 環境で実測した。

| 環境 | `isWSL` | `windowsUser` | `gpg.ssh.program` | wrapper 配布 | Docker / draw.io |
| --- | --- | --- | --- | --- | --- |
| WSL (Ubuntu-22.04) | `true` | 設定済み | wrapper | される | 導入せず |
| Dev Container（CLI 経路、`devcontainer=false`） | `true` | 空 | `/opt/1Password/op-ssh-sign` | されない | 導入せず |
| Windows | `false` | 設定済み | 対象外 | されない | 対象外 |

テストスイート（Windows）: 275 件成功、15 件 skip。

## 未着手として残すもの

- 社内 npm プロキシと mise 2026.7.12 の npm backend の `trustPolicy=no-downgrade` が衝突する。プロキシ側の応答に `integrity` / `signatures` / `attestations` が欠落することが原因で、本 PR の範囲では扱わない
- `@devcontainers/cli` 経路では `run_once_after_30-install-tools.sh.tmpl` の冒頭ゲートを通過する。Docker Desktop の WSL2 バックエンドでは `isWSL` が真になるため Docker と draw.io は導入されないが、macOS や native Linux の Docker で起動したコンテナでは導入される
