### PR TITLE
fix: isolate Copilot hooks from mise tool failures

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,5 +32,6 @@ mise 設定を変更する際は、以下のツールの対応状況を確認し
 
 ## ワークアラウンド（定期チェック対象）
 
+- **core:dotnet Windows install-time verification**: `home/dot_config/mise/config.toml.tmpl` は Windows の `dotnet.install_env` で `%LOCALAPPDATA%\mise\dotnet-root` を `DOTNET_ROOT` と PATH の先頭へ設定する。mise の `core:dotnet` が install-time verification へ管理下の dotnet を自動設定するようになったら、このオプションと関連テスト、`docs/troubleshooting.md` の復旧手順を撤去する
 - **op-ssh-sign-wsl.exe CRLF (ADR-012)**: `home/dot_local/bin/executable_op-ssh-sign-wrapper.sh.tmpl` で stdout/stderr の CR を剥がして `git verify-commit` を成立させている。1Password が WSL バイナリの改行を LF に揃えた、または git 本体が find-principals 結果の `\r` を剥がすようになったら wrapper と `.gitconfig-linux` の `program` 切替を撤去する
 - **git の張り替え (ADR-020)**: `home/run_once_before_10-install-packages.sh.tmpl` の `git_unshadow` が、Codespaces と Dev Container のベースイメージが `/usr/local/bin` へソースビルドした古い git を `/usr/bin` の PPA 版へ symlink で張り替えている。ADR-020 の設定ベースフックが git 2.54 以上を要求するためである。対象イメージの `/usr/local/bin/git` がすべて 2.54 以上になったら、関数と呼び出しを撤去する（`devcontainers/base:ubuntu` は 2.55.0 で条件を満たす。Codespaces universal 5.1.5 は 2.53.0 で満たさない）

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,8 @@ reference/windows/configuration.dsc.yaml  ← WinGet DSC（参照専用）
 
 パス比較前に `\` を `/` へ正規化する。パターンファイルは `/` 前提で書く。
 
+各 command hook は mise shim 経由の `uv run` で起動する。起動時に `MISE_ENABLE_TOOLS=uv` を設定し、mise の解決対象をフックが必要とする `uv` だけに限定する。これにより `uv` の未導入版は mise が自動導入できる一方、dotnet など無関係な missing ツールの導入失敗はフックの終了状態へ影響しない。
+
 shell command の外部ネットワーク通信は、`~/.copilot/settings.json` の `sandbox.userPolicy.network` で設定する。初期状態では sandbox を有効化するだけにとどめ、外向き通信の遮断や host rule は設定しない。
 
 ## git pre-commit フック

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,26 @@ GITHUB_TOKEN=$(gh auth token) mise lock --global --platform linux-x64,linux-arm6
 mise install
 ```
 
+### Windows で `core:dotnet` の検証に失敗する
+
+症状は、インストールスクリプトが SDK を配置した後、`dotnet --list-sdks` が system 側の SDK だけを返し、次のエラーで終了することである。
+
+```text
+dotnet SDK <version> was not found in `dotnet --list-sdks` output
+```
+
+Windows 用の mise 設定は、インストール時だけ mise の共有 dotnet root を `DOTNET_ROOT` と PATH の先頭へ設定する。設定を配り直し、同じ backend とバージョンを強制的に再インストールする。
+
+```powershell
+chezmoi apply "$HOME\.config\mise\config.toml"
+mise install --force dotnet
+mise ls dotnet
+mise which dotnet
+& (mise which dotnet) --version
+```
+
+`mise ls dotnet` に `(missing)` がなく、`mise which dotnet` が `%LOCALAPPDATA%\mise\dotnet-root\dotnet.exe` を返し、最後のコマンドが設定済み SDK のバージョンを表示すれば復旧している。
+
 ## `mise.lock has changed since chezmoi last wrote it?` と聞かれる
 
 `chezmoi status` が `MM .config/mise/mise.lock` を示し、`chezmoi apply` が上のプロンプトを出す。Codespaces のような TTY の無い環境では `could not open a new TTY` で停止する。
@@ -209,5 +229,7 @@ Get-Content "$HOME\.copilot\session-state\<session-id>\events.jsonl" |
 ```
 
 `hook errored` だけから Hook 本体の障害と判断しない。標準エラー、Hook の起動コマンド、起動時に解決された runtime を確認する。
+
+本リポジトリの command hook は `MISE_ENABLE_TOOLS=uv` を設定し、mise の解決対象を `uv` に限定する。`uv` の未導入版は自動導入されるが、dotnet など他ツールの missing 状態は hook 起動時に解決しない。標準エラーに他ツールのインストールログが出る場合は、`~/.copilot/hooks/hooks.json` が最新か確認し、`chezmoi apply` で配り直す。
 
 上のフィルターで何も表示されない場合は、CLI の更新でイベント形式が変わった可能性がある。`Where-Object { $_.type -eq 'hook.end' }` まで条件を緩め、直近イベントの `data` 全体を確認する。

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -8,7 +8,6 @@ node = "lts"
 uv = "latest"
 fzf = "latest"
 github-cli = "latest"
-dotnet = "latest"
 1password = "latest"
 cue = "latest"
 ghq = "latest"
@@ -31,6 +30,14 @@ codex = "latest"
 {{ if not (and (eq .chezmoi.os "linux") (eq .chezmoi.arch "arm64")) -}}
 # プリビルドバイナリが linux/arm64 未提供のためスキップ
 cargo-make = "latest"
+{{ end -}}
+
+[tools.dotnet]
+version = "latest"
+{{ if eq .chezmoi.os "windows" -}}
+# core:dotnet の install-time verification が system dotnet を拾わないよう、
+# mise の共有 root を検証コマンドの PATH 先頭へ置く。
+install_env = { DOTNET_ROOT = '{{ env "LOCALAPPDATA" }}\mise\dotnet-root', PATH = '{{ env "LOCALAPPDATA" }}\mise\dotnet-root;$PATH' }
 {{ end -}}
 
 [settings]

--- a/home/private_dot_copilot/hooks/hooks.json
+++ b/home/private_dot_copilot/hooks/hooks.json
@@ -4,36 +4,36 @@
     "preToolUse": [
       {
         "type": "command",
-        "bash": "uv run \"$HOME/.copilot/hooks/scripts/copilot-guard.py\"",
-        "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\copilot-guard.py\"",
+        "bash": "MISE_ENABLE_TOOLS=uv uv run \"$HOME/.copilot/hooks/scripts/copilot-guard.py\"",
+        "powershell": "$env:MISE_ENABLE_TOOLS='uv'; uv run \"$HOME\\.copilot\\hooks\\scripts\\copilot-guard.py\"",
         "timeoutSec": 30
       },
       {
         "type": "command",
-        "bash": "uv run \"$HOME/.copilot/hooks/scripts/uv-enforcer.py\"",
-        "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\uv-enforcer.py\"",
+        "bash": "MISE_ENABLE_TOOLS=uv uv run \"$HOME/.copilot/hooks/scripts/uv-enforcer.py\"",
+        "powershell": "$env:MISE_ENABLE_TOOLS='uv'; uv run \"$HOME\\.copilot\\hooks\\scripts\\uv-enforcer.py\"",
         "timeoutSec": 30
       },
       {
         "type": "command",
-        "bash": "uv run \"$HOME/.copilot/hooks/scripts/node-global-enforcer.py\"",
-        "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\node-global-enforcer.py\"",
+        "bash": "MISE_ENABLE_TOOLS=uv uv run \"$HOME/.copilot/hooks/scripts/node-global-enforcer.py\"",
+        "powershell": "$env:MISE_ENABLE_TOOLS='uv'; uv run \"$HOME\\.copilot\\hooks\\scripts\\node-global-enforcer.py\"",
         "timeoutSec": 30
       }
     ],
     "postToolUse": [
       {
         "type": "command",
-        "bash": "uv run \"$HOME/.copilot/hooks/scripts/audit-log.py\"",
-        "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-log.py\"",
+        "bash": "MISE_ENABLE_TOOLS=uv uv run \"$HOME/.copilot/hooks/scripts/audit-log.py\"",
+        "powershell": "$env:MISE_ENABLE_TOOLS='uv'; uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-log.py\"",
         "timeoutSec": 15
       }
     ],
     "postToolUseFailure": [
       {
         "type": "command",
-        "bash": "uv run \"$HOME/.copilot/hooks/scripts/audit-failure.py\"",
-        "powershell": "uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-failure.py\"",
+        "bash": "MISE_ENABLE_TOOLS=uv uv run \"$HOME/.copilot/hooks/scripts/audit-failure.py\"",
+        "powershell": "$env:MISE_ENABLE_TOOLS='uv'; uv run \"$HOME\\.copilot\\hooks\\scripts\\audit-failure.py\"",
         "timeoutSec": 15
       }
     ]

--- a/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
+++ b/home/private_dot_copilot/hooks/scripts/executable_copilot-guard.py
@@ -338,14 +338,13 @@ _RUNTIME_ENV_DUMP_RE = re.compile(
     r"|\bENV\.to_h\b"         # Ruby    ENV.to_h
     r"|\bENV\.each\b"         # Ruby    ENV.each
     r"|\bDeno\.env\.toObject\b"  # Deno  Deno.env.toObject()
-    r"|\bGet-ChildItem\s+Env:"   # PowerShell Get-ChildItem Env:
-    r"|\\\$env:",              # PowerShell $env: variable access
+    r"|\bGet-ChildItem\s+Env:",  # PowerShell Get-ChildItem Env:
     re.IGNORECASE,
 )
 
-# Sensitive variable name fragments.  If a shell expansion ``$VAR`` or
-# ``${VAR}`` contains one of these (case-insensitive), it is blocked.
-_SENSITIVE_FRAGMENTS: frozenset[str] = frozenset({
+# Sensitive variable name terms. Terms must be separated by underscores or
+# span the complete name, so ordinary variables such as ``$author`` are safe.
+_SENSITIVE_TERMS: frozenset[str] = frozenset({
     "secret", "token", "key", "password", "credential",
     "api_key", "apikey", "access_key", "accesskey",
     "private_key", "privatekey",
@@ -354,6 +353,19 @@ _SENSITIVE_FRAGMENTS: frozenset[str] = frozenset({
     "db_password", "dbpassword",
     "auth",
 })
+
+# Concatenated names have no separator or case transition to identify word
+# boundaries. Match only high-signal forms so names such as author, tokens,
+# keyword, and monkey remain safe.
+_SENSITIVE_CONCATENATED_RE = re.compile(
+    r"secret"
+    r"|password"
+    r"|credential"
+    r"|token$"
+    r"|auth$"
+    r"|(?:api|access|private|ssh|signing|master|session|host|gpg|deploy|encryption)key"
+    r"|connectionstring"
+)
 
 # Safe variable names that are never blocked even if they match fragments
 # above (e.g. ``SSH_AUTH_SOCK`` contains ``auth``).
@@ -383,19 +395,30 @@ _SAFE_VARIABLES: frozenset[str] = frozenset({
     "_",  # last command
 })
 
-# Regex that captures ``$VAR`` or ``${VAR}`` references.
-_SHELL_VAR_REF_RE = re.compile(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?")
+# Regexes that capture environment-variable references by shell syntax.
+_POSIX_ENV_VAR_REF_RE = re.compile(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?")
+_POWERSHELL_ENV_VAR_REF_RE = re.compile(
+    r"\$(?:env:([A-Za-z_][A-Za-z0-9_]*)|\{env:([A-Za-z_][A-Za-z0-9_]*)\})",
+    re.IGNORECASE,
+)
 
 
 def _is_sensitive_var(name: str) -> bool:
     """Return True if *name* looks like a secret variable."""
-    lower = name.lower()
+    raw_lower = name.lower()
+    snake_name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", name)
+    snake_name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", snake_name)
+    lower = snake_name.lower()
     if lower in _SAFE_VARIABLES:
         return False
-    return any(frag in lower for frag in _SENSITIVE_FRAGMENTS)
+    separated_match = any(
+        re.search(rf"(?:^|_){re.escape(term)}(?:_|$)", lower)
+        for term in _SENSITIVE_TERMS
+    )
+    return separated_match or _SENSITIVE_CONCATENATED_RE.search(raw_lower) is not None
 
 
-def check_env_access(command: str) -> str | None:
+def check_env_access(command: str, shell: str = "bash") -> str | None:
     """Detect environment-variable access patterns in a shell command.
 
     Returns a deny reason string when the command appears to read
@@ -443,10 +466,19 @@ def check_env_access(command: str) -> str | None:
         return f"Blocked runtime env dump pattern: {m.group(0)}"
 
     # --- 4. Sensitive variable expansion ---
-    for var_match in _SHELL_VAR_REF_RE.finditer(stripped):
-        var_name = var_match.group(1)
+    var_ref_re = (
+        _POWERSHELL_ENV_VAR_REF_RE
+        if shell == "powershell"
+        else _POSIX_ENV_VAR_REF_RE
+    )
+    for var_match in var_ref_re.finditer(stripped):
+        if shell == "powershell":
+            var_name = var_match.group(1) or var_match.group(2)
+        else:
+            var_name = var_match.group(1)
         if _is_sensitive_var(var_name):
-            return f"Blocked sensitive variable reference: ${var_name}"
+            prefix = "$env:" if shell == "powershell" else "$"
+            return f"Blocked sensitive variable reference: {prefix}{var_name}"
 
     return None
 
@@ -455,7 +487,7 @@ def check_env(ctx: CheckContext) -> CheckResult | None:
     """Check for environment variable access in shell commands."""
     if ctx.tool_name not in ("bash", "powershell") or not ctx.command:
         return None
-    reason = check_env_access(ctx.command)
+    reason = check_env_access(ctx.command, ctx.tool_name)
     if reason:
         return CheckResult("deny", reason)
     return None

--- a/tests/test_copilot_guard.py
+++ b/tests/test_copilot_guard.py
@@ -191,6 +191,87 @@ class CopilotGuardEnvBlockingTests(unittest.TestCase):
         result = copilot_guard.check_env_access("echo $AUTH_TOKEN")
         self.assertIsNotNone(result)
 
+    def test_blocks_camel_case_auth_token(self) -> None:
+        result = copilot_guard.check_env_access("echo $githubToken")
+        self.assertIsNotNone(result)
+
+    def test_blocks_camel_case_api_key(self) -> None:
+        result = copilot_guard.check_env_access("echo $apiKey")
+        self.assertIsNotNone(result)
+
+    def test_blocks_concatenated_secret(self) -> None:
+        result = copilot_guard.check_env_access("echo $mysecret")
+        self.assertIsNotNone(result)
+
+    def test_blocks_concatenated_token(self) -> None:
+        result = copilot_guard.check_env_access("echo $githubtoken")
+        self.assertIsNotNone(result)
+
+    def test_blocks_concatenated_password(self) -> None:
+        result = copilot_guard.check_env_access("echo $mypassword")
+        self.assertIsNotNone(result)
+
+    def test_blocks_concatenated_api_key(self) -> None:
+        result = copilot_guard.check_env_access("echo $XAPIKEY")
+        self.assertIsNotNone(result)
+
+    def test_blocks_concatenated_signing_key(self) -> None:
+        result = copilot_guard.check_env_access("echo $signingkey")
+        self.assertIsNotNone(result)
+
+    def test_allows_author(self) -> None:
+        result = copilot_guard.check_env_access("echo $author")
+        self.assertIsNone(result)
+
+    def test_allows_keyword(self) -> None:
+        result = copilot_guard.check_env_access("echo $keyword")
+        self.assertIsNone(result)
+
+    def test_allows_tokens(self) -> None:
+        result = copilot_guard.check_env_access("echo $tokens")
+        self.assertIsNone(result)
+
+    def test_allows_monkey(self) -> None:
+        result = copilot_guard.check_env_access("echo $monkey")
+        self.assertIsNone(result)
+
+    # --- PowerShell variable syntax ---
+
+    def test_blocks_powershell_sensitive_env_var(self) -> None:
+        result = copilot_guard.check_env_access(
+            "Write-Output $env:GITHUB_TOKEN",
+            "powershell",
+        )
+        self.assertIsNotNone(result)
+
+    def test_blocks_braced_powershell_sensitive_env_var(self) -> None:
+        result = copilot_guard.check_env_access(
+            "Write-Output ${env:GITHUB_TOKEN}",
+            "powershell",
+        )
+        self.assertIsNotNone(result)
+
+    def test_allows_powershell_local_sensitive_named_var(self) -> None:
+        result = copilot_guard.check_env_access(
+            "Write-Output $GITHUB_TOKEN",
+            "powershell",
+        )
+        self.assertIsNone(result)
+
+    def test_allows_powershell_safe_env_var(self) -> None:
+        result = copilot_guard.check_env_access(
+            "Write-Output $env:PATH",
+            "powershell",
+        )
+        self.assertIsNone(result)
+
+    def test_allows_braced_powershell_safe_env_var(self) -> None:
+        result = copilot_guard.check_env_access(
+            "Write-Output ${env:PATH}",
+            "powershell",
+        )
+        self.assertIsNone(result)
+
     # --- Safe variables ---
 
     def test_allows_path(self) -> None:
@@ -261,7 +342,8 @@ class CopilotGuardEnvBlockingTests(unittest.TestCase):
 
     def test_blocks_powershell_get_childitem_env(self) -> None:
         result = copilot_guard.check_env_access(
-            "Get-ChildItem Env:"
+            "Get-ChildItem Env:",
+            "powershell",
         )
         self.assertIsNotNone(result)
 
@@ -625,6 +707,25 @@ class CopilotGuardCheckerReturnTypeTests(unittest.TestCase):
         )
         result = copilot_guard.check_env(ctx)
         self.assertIsNone(result)
+
+    def test_check_env_uses_powershell_variable_syntax(self) -> None:
+        ctx = make_ctx(
+            tool_name="powershell",
+            tool_args={"command": "Write-Output $GITHUB_TOKEN"},
+            command="Write-Output $GITHUB_TOKEN",
+        )
+        result = copilot_guard.check_env(ctx)
+        self.assertIsNone(result)
+
+    def test_check_env_blocks_powershell_sensitive_env_var(self) -> None:
+        ctx = make_ctx(
+            tool_name="powershell",
+            tool_args={"command": "Write-Output $env:GITHUB_TOKEN"},
+            command="Write-Output $env:GITHUB_TOKEN",
+        )
+        result = copilot_guard.check_env(ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.decision, "deny")
 
 class GitCommitCheckerTests(unittest.TestCase):
     """Tests for the git commit approval checker."""

--- a/tests/test_copilot_hooks_config.py
+++ b/tests/test_copilot_hooks_config.py
@@ -1,0 +1,98 @@
+"""Verify Copilot hooks isolate mise resolution to uv on every shell."""
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+HOOKS_PATH = REPO_ROOT / "home/private_dot_copilot/hooks/hooks.json"
+EXPECTED_BASH_PREFIX = "MISE_ENABLE_TOOLS=uv uv run "
+EXPECTED_POWERSHELL_PREFIX = "$env:MISE_ENABLE_TOOLS='uv'; uv run "
+
+
+def _commands() -> list[dict[str, object]]:
+    hooks = json.loads(HOOKS_PATH.read_text(encoding="utf-8"))["hooks"]
+    return [command for commands in hooks.values() for command in commands]
+
+
+class CopilotHooksConfigTests(unittest.TestCase):
+    def test_all_commands_limit_mise_to_uv(self) -> None:
+        commands = _commands()
+        self.assertEqual(len(commands), 5)
+
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertTrue(command["bash"].startswith(EXPECTED_BASH_PREFIX))
+                self.assertTrue(
+                    command["powershell"].startswith(EXPECTED_POWERSHELL_PREFIX)
+                )
+
+    @unittest.skipUnless(shutil.which("bash"), "bash is required")
+    @unittest.skipIf(os.name == "nt", "the POSIX stub requires a POSIX shell")
+    def test_bash_exports_uv_allowlist_to_hook_process(self) -> None:
+        command = _commands()[0]["bash"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            capture = root / "capture.txt"
+            stub = root / "uv"
+            stub.write_text(
+                '#!/bin/sh\nprintf "%s" "$MISE_ENABLE_TOOLS" > "$HOOK_ENV_CAPTURE"\n',
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            env = dict(os.environ)
+            env["HOOK_ENV_CAPTURE"] = str(capture)
+            env["PATH"] = f"{root}{os.pathsep}{env['PATH']}"
+
+            result = subprocess.run(
+                ["bash", "-c", command],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertEqual(capture.read_text(encoding="utf-8"), "uv")
+
+    @unittest.skipUnless(shutil.which("pwsh"), "pwsh is required")
+    def test_powershell_exports_uv_allowlist_to_hook_process(self) -> None:
+        command = _commands()[0]["powershell"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            capture = root / "capture.txt"
+            stub = root / "uv.ps1"
+            stub.write_text(
+                "Set-Content -NoNewline -LiteralPath "
+                "$env:HOOK_ENV_CAPTURE -Value $env:MISE_ENABLE_TOOLS\n",
+                encoding="utf-8",
+            )
+            env = dict(os.environ)
+            env["HOOK_ENV_CAPTURE"] = str(capture)
+            env["PATH"] = f"{root}{os.pathsep}{env['PATH']}"
+
+            result = subprocess.run(
+                ["pwsh", "-NoProfile", "-Command", command],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertEqual(capture.read_text(encoding="utf-8"), "uv")

--- a/tests/test_mise_config.py
+++ b/tests/test_mise_config.py
@@ -102,6 +102,14 @@ class MiseConfigTests(unittest.TestCase):
         self.assertEqual(len(dotnet_entries), 1)
         self.assertEqual(_tool_alias(config, "dotnet"), dotnet_entries[0]["backend"])
 
+    def test_windows_dotnet_verification_uses_mise_root(self) -> None:
+        config = CONFIG_PATH.read_text(encoding="utf-8")
+
+        self.assertIn('[tools.dotnet]\nversion = "latest"', config)
+        self.assertIn('{{ if eq .chezmoi.os "windows" -}}', config)
+        self.assertIn("install_env = { DOTNET_ROOT =", config)
+        self.assertIn(r"\mise\dotnet-root;$PATH", config)
+
     def test_backend_migration_requires_postconditions(self) -> None:
         instructions = INSTRUCTIONS_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 概要

Copilot CLI の command hook を、mise が管理する無関係なツールの導入失敗から隔離します。あわせて Windows の `core:dotnet` 導入時の検証経路と、Copilot Guard の環境変数判定を修正します。

## 変更内容

- 全 command hook で `MISE_ENABLE_TOOLS=uv` を設定
  - `uv` の自動導入は維持
  - dotnet など他ツールの missing 状態を hook 起動から分離
- Windows の `dotnet.install_env` で mise 管理下の dotnet root を検証時の PATH 先頭へ設定
- Copilot Guard の変数判定を shell ごとに分離
  - PowerShell の `$env:NAME` と `${env:NAME}` を検査
  - PowerShell のローカル変数 `$name` は環境変数として扱わない
  - `$author`、`$tokens`、`$keyword`、`$monkey` の誤検知を解消
  - camelCase と連結形式の秘密変数名は引き続き拒否
- フック設定、mise 設定、Guard の回帰テストと関連文書を更新

## 確認

- `uv run -m unittest discover -s tests -v`
- `git diff --check`
- 空の mise データ領域で `MISE_ENABLE_TOOLS=uv` による `uv` 自動導入を確認
- Windows で `mise install --force dotnet`、`mise ls dotnet`、`mise which dotnet`、mise 管理下の `dotnet --version` を確認
