### PR TITLE
docs: clarify that @devcontainers/cli is out of scope for container detection

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -152,7 +152,9 @@ GITHUB_TOKEN=$(gh auth token) mise install --yes
 - **`git-lfs` feature**：ベースイメージに `git-lfs` が含まれないため足す。ADR-020 の張り替えが `git-lfs` を対象から外すことを実機で確認するには、`/usr/local/bin/git-lfs` が存在する必要がある
 - **`powershell` feature**：dotfiles は Linux に pwsh を入れないため、これが無いと `tests/test_platform_parity.py` と `tests/test_mise_config.py` の PowerShell 依存テストが skip される。CI（ubuntu-latest）は同梱の pwsh を使うので、同じ範囲を流すために足す
 
-`@devcontainers/cli` で起動したコンテナでは `REMOTE_CONTAINERS` が立たないため、chezmoi の `.devcontainer` が false になる。CLI で検証するときは `--remote-env REMOTE_CONTAINERS=true` を渡す。
+chezmoi のコンテナ判定は、環境変数 `CODESPACES` と `REMOTE_CONTAINERS` の有無だけで決まる。`REMOTE_CONTAINERS` を立てるのは VS Code の Dev Containers 拡張であり、`@devcontainers/cli` は立てない。この判定が対象とするのは拡張と Codespaces で起動したコンテナであり、CLI で起動したコンテナは対象外である。CLI を対象へ含めるには `/.dockerenv` のような別の指標を足すことになるが、判定の軸が増えるため採らない。
+
+CLI で検証するときは `--remote-env REMOTE_CONTAINERS=true` を渡す。渡さないと `.devcontainer` が false になり、Docker Engine、draw.io、Azure CLI など、ホストへ入れる前提の導入処理がコンテナ内で走る。Docker Desktop の WSL2 バックエンドではコンテナがホストの WSL カーネルを共有して `.isWSL` が true になるため Docker Engine と draw.io は止まるが、macOS や Linux の Docker で起動したコンテナでは止まらない。
 
 Windows ホストでは、`tests/test_git_shadow_resolution.py` のうち POSIX 版のチェックスクリプトを実行するテストが skip される。`bash` が WSL の interop 版に解決され、テストが用意した偽の git を参照できないためである。全件を実行するには、このコンテナか WSL、または CI を使う。
 


### PR DESCRIPTION
## 背景

`@devcontainers/cli` で起動したコンテナで `run_once_after_30-install-tools.sh.tmpl` の冒頭ゲートを通過する、という報告があった。chezmoi の `.devcontainer` は `REMOTE_CONTAINERS` の有無だけで決まるが、この変数を立てるのは VS Code の Dev Containers 拡張であり、CLI は立てないためである。

## 判断

CLI 起動を判定できるようにするのではなく、CLI をサポート対象に含めないことを明示する方針を採った。`/.dockerenv` などの実体検出を足す案 (a)(b) は判定の軸を二本にし、`devcontainer.json` の `containerEnv` を足す案 (c) は同じ契約を検証手順と構成ファイルに二重化する。CLI での検証手順 (`--remote-env REMOTE_CONTAINERS=true`) は既に `docs/operations.md` にあり、契約としては足りている。

## 変更

`docs/operations.md` に次を明記した。

- コンテナ判定は環境変数 `CODESPACES` と `REMOTE_CONTAINERS` のみに依り、CLI 起動は対象外であること
- 別指標を足さない理由
- `--remote-env` を渡し忘れると Docker Engine、draw.io、Azure CLI などホスト向けの導入処理がコンテナ内で走ること
- Docker Desktop の WSL2 バックエンドでは `.isWSL` が true になるため Docker Engine と draw.io だけ症状が隠れ、macOS や Linux の Docker では隠れないこと

テンプレートの変更はない。

## 検証

`uv run -m unittest tests.test_platform_parity tests.test_mise_config` -> 27 tests OK (skipped=5)