### PR TITLE
fix: keep prompted chezmoi config values on non-interactive init

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ Git 2.54 以降では、これに加えて `~/.gitconfig` の `[hook "dotfiles-g
 | `.isLinux` / `.isMac` / `.isWindows` | 上から導出 |
 | `.isWSL` | Linux かつ `kernel.osrelease` に `microsoft` を含む。Docker Desktop の WSL2 バックエンドで動くコンテナはホストの WSL カーネルを共有するため、この変数だけでは実 WSL と区別できない。区別が要る箇所では `/proc/sys/fs/binfmt_misc/WSLInterop` の存在を併せて確認する（ADR-012） |
 | `.codespaces` / `.devcontainer` | それぞれ環境変数 `CODESPACES` / `REMOTE_CONTAINERS` の有無で判定。`REMOTE_CONTAINERS` を立てるのは VS Code の Dev Containers 拡張であり、`@devcontainers/cli` は立てない |
-| `.windowsUser` / `.corpUser` | 初回セットアップで入力 |
+| `.windowsUser` / `.corpUser` | 初回セットアップで入力する。入力を求めるのは stdin が TTY のときだけなので、非対話の `chezmoi init` では既存の設定値をそのまま引き継ぐ（引き継がないと空文字で上書きされ、`gitconfig-corp` の includeIf と ADR-012 の署名パスが壊れる） |
 
 ## プラットフォーム機能契約
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,13 +4,15 @@ README に載せない復旧手順だけをまとめる。一般的な `chezmoi`
 
 ## `warning: config file template has changed`
 
-`.chezmoi.toml.tmpl` の更新後に出る。設定を再生成する。
+`.chezmoi.toml.tmpl` の更新後に出る。`chezmoi update` は設定を再生成しないため、`chezmoi init` を実行するまで毎回出続ける。
 
 ```bash
 chezmoi init torumakabe
 ```
 
 リポジトリ名を省略すると、ソースディレクトリが空になり `chezmoi update` が動かなくなる。必ず `torumakabe` を指定する。
+
+`windowsUser` / `corpUser` の入力を求めるのは stdin が TTY のときだけだが、非対話で実行しても既存の設定値は引き継ぐ。値を変更したいときは対話シェルで実行する。
 
 ## `mise install` が部分失敗する
 

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -16,7 +16,20 @@
 {{-   end -}}
 {{- end -}}
 
+{{- /* 入力値は stdinIsATTY のときしか尋ねられない。非対話の再 init
+       （スクリプト、Codespaces、Dev Container、エージェント経由のシェル）で
+       既存値を空へ落とさないよう、まず現在の設定データを初期値に引き継ぐ。
+       promptStringOnce は既存値があれば尋ねずに返すが、TTY ガードの外側に
+       あるため呼び出しごと飛ぶ。この引き継ぎがその穴を塞ぐ。 */ -}}
 {{- $windowsUser := "" -}}
+{{- if hasKey . "windowsUser" -}}
+{{-   $windowsUser = .windowsUser -}}
+{{- end -}}
+{{- $corpUser := "" -}}
+{{- if hasKey . "corpUser" -}}
+{{-   $corpUser = .corpUser -}}
+{{- end -}}
+
 {{- /* windowsUser は ADR-012 の op-ssh-sign-wsl.exe パスと Windows 用 gitconfig で
        しか使わない。WSL 側では interop が無いと wsl.exe 経由の実行そのものが
        成立しないため、interop の実体を確認してから尋ねる。Docker Desktop の
@@ -28,7 +41,6 @@
 {{-   $windowsUser = promptStringOnce . "windowsUser" "Windows username (for WSL 1Password paths)" -}}
 {{- end -}}
 
-{{- $corpUser := "" -}}
 {{- if stdinIsATTY -}}
 {{-   $corpUser = promptStringOnce . "corpUser" "Corp username (for gitconfig-corp, empty to skip)" -}}
 {{- end -}}

--- a/tests/test_chezmoi_config_template.py
+++ b/tests/test_chezmoi_config_template.py
@@ -1,0 +1,88 @@
+"""Guard the chezmoi config template against losing prompted values.
+
+``home/.chezmoi.toml.tmpl`` asks for ``windowsUser`` / ``corpUser`` only when
+stdin is a TTY. ``promptStringOnce`` would return the stored answer without
+prompting, but the TTY guard skips the call entirely, so a non-interactive
+``chezmoi init`` (scripts, Codespaces, Dev Container, agent shells) used to
+write empty strings over the existing answers. Both values feed git config:
+``corpUser`` selects ``gitconfig-corp`` and ``windowsUser`` builds the
+ADR-012 op-ssh-sign paths, so losing them breaks commit signing silently.
+
+The fix seeds each variable from the current config data before the guard.
+These tests pin both the source shape and the observable behaviour.
+"""
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CONFIG_TEMPLATE_PATH = REPO_ROOT / "home/.chezmoi.toml.tmpl"
+
+PROMPTED_VARIABLES = ("windowsUser", "corpUser")
+
+
+class ConfigTemplateSourceTests(unittest.TestCase):
+    """Every prompted variable seeds itself from the existing config data."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.template = CONFIG_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    def test_prompted_variables_seed_from_existing_data(self) -> None:
+        for name in PROMPTED_VARIABLES:
+            with self.subTest(variable=name):
+                self.assertIn(f'{{{{- if hasKey . "{name}" -}}}}', self.template)
+                self.assertIn(f"{{{{-   ${name} = .{name} -}}}}", self.template)
+
+    def test_seed_precedes_the_tty_guarded_prompt(self) -> None:
+        """The seed is a fallback, so the prompt has to be able to override it."""
+        for name in PROMPTED_VARIABLES:
+            with self.subTest(variable=name):
+                seed = self.template.find(f'{{{{- if hasKey . "{name}" -}}}}')
+                prompt = self.template.find(f'promptStringOnce . "{name}"')
+                self.assertNotEqual(seed, -1)
+                self.assertNotEqual(prompt, -1)
+                self.assertLess(seed, prompt)
+
+
+@unittest.skipUnless(shutil.which("chezmoi"), "chezmoi renders the config template")
+class ConfigTemplateBehaviourTests(unittest.TestCase):
+    """Render the real template the way ``chezmoi init`` does.
+
+    ``execute-template --init`` with ``--config`` reproduces a re-init against
+    an existing config. The test process has no TTY, which is exactly the case
+    that used to wipe the answers.
+    """
+
+    def setUp(self) -> None:
+        self.root = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.template = CONFIG_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    def _render(self, existing: str | None) -> str:
+        config = self.root / "config.toml"
+        if existing is not None:
+            config.write_text(existing, encoding="utf-8")
+        return subprocess.run(
+            ["chezmoi", "--config", str(config), "execute-template", "--init"],
+            input=self.template,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+
+    def test_reinit_keeps_the_stored_corp_user(self) -> None:
+        rendered = self._render('[data]\n  corpUser = "stored-corp"\n')
+        self.assertIn('corpUser = "stored-corp"', rendered)
+
+    def test_fresh_init_leaves_the_corp_user_empty(self) -> None:
+        rendered = self._render(None)
+        self.assertIn('corpUser = ""', rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

`chezmoi update` のたびに `warning: config file template has changed` が出続けていた。原因は state に保存されたテンプレートのハッシュが古いままだったことで、これ自体は `chezmoi init` の再実行で解決する。

しかしその再実行を非対話シェルで行ったところ、既存の `corpUser` が空文字で上書きされる問題を実測した。

```
実行前: corpUser = "tomakabe_microsoft"
非対話 chezmoi init 実行後: corpUser = ""
```

`home/.chezmoi.toml.tmpl` は `windowsUser` / `corpUser` を `stdinIsATTY` ガードの内側でのみ `promptStringOnce` に渡している。`promptStringOnce` は既存値があればプロンプトを出さずに返すが、TTY ガードにより呼び出し自体が飛ぶため、初期値の空文字がそのまま出力される。

失われると `dot_gitconfig-corp.tmpl` の includeIf 条件と、ADR-012 の op-ssh-sign パス (`ne .windowsUser ""` を前提) が壊れる。コミット署名が黙って失敗する経路である。スクリプト、Codespaces、Dev Container、エージェント経由のシェルが該当する。

## 変更

TTY ガードの手前で、現在の設定データを初期値として引き継ぐ。`chezmoi init` は既存 `chezmoi.toml` の `[data]` をテンプレートのドット変数として渡すため、`hasKey` で取得できる。

```
{{- if hasKey . "corpUser" -}}
{{-   $corpUser = .corpUser -}}
{{- end -}}
```

引き継ぎはフォールバックなので、TTY があるときは従来どおりプロンプトの入力が優先される。

`tests/test_chezmoi_config_template.py` を追加した。テンプレートの構造検査に加えて、`chezmoi execute-template --init` で実際にレンダリングし、既存 config ありなら値を保持し、無ければ空になることを確認する。テストプロセスに TTY が無いことがそのまま再現条件になっている。

## 検証

- 新テンプレート: 既存 config あり → 値を保持、無し → 空
- 旧テンプレートに対して新テストを実行 → `corpUser = ""` を検出して失敗（回帰検知が効くことを確認）
- `uv run -m unittest discover -s tests` → 279 tests OK (skipped=15)

## マージ後に必要な操作

テンプレートの内容が変わるため、各マシンで再び `warning: config file template has changed` が出る。一度だけ `chezmoi init torumakabe` を実行すれば解消する。この修正以降は非対話で実行しても値は保持される。

## 補足

ADR は起こしていない。「入力は対話時のみ求める」という既存の設計判断は変えず、非対話時にデータが消えるバグを直すだけであるため。