### PR TITLE
fix: stop chezmoi ps1 scripts from loading the PowerShell profile

### DIFF
--- a/docs/adr/022-pnpm-via-mise-not-corepack.md
+++ b/docs/adr/022-pnpm-via-mise-not-corepack.md
@@ -1,0 +1,40 @@
+# ADR-022: pnpm は corepack ではなく mise で直接管理する
+
+## Status
+
+Accepted
+
+## Context
+
+`home/dot_config/mise/config.toml.tmpl` が管理していた Node 関連ツールは `node = "lts"` のみで、pnpm / yarn は node に同梱される corepack を `run_onchange_after_15-mise-sync-tools.{ps1,sh}.tmpl` が `corepack enable` することで供給していた。
+
+Node.js 25 で Corepack の同梱が廃止された（nodejs/node [PR #57617](https://github.com/nodejs/node/pull/57617) `build: stop distributing Corepack`、[PR #59835](https://github.com/nodejs/node/pull/59835) `build: remove corepack from release tarballs`。いずれも `CHANGELOG_V25.md` に記載）。`node = "lts"` が Node 26 LTS へ上がった時点で corepack は恒久的に失われ、pnpm の供給が黙って途絶える。
+
+発端は Windows での `chezmoi update` が `Unable to find type [Microsoft.PowerShell.PSConsoleReadLine]` を 2 回出力した事象で、経路は実機で次のとおり確認した。
+
+1. chezmoi は `.ps1` を既定の interpreter `pwsh -NoLogo -File` で実行する（`chezmoi dump-config` で確認）。`-NoProfile` が付かないためプロファイルが読まれる。
+2. プロファイルの `mise activate pwsh` が登録する CommandNotFound ハンドラは `[Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems()` を参照する。非対話 pwsh では PSReadLine が読み込まれず型解決に失敗する。
+3. `run_onchange_after_15-mise-sync-tools.ps1` の `Get-Command -Name 'corepack'` が失敗してハンドラが発火した。
+
+corepack が消えた直接原因は、node の再インストールが `node.exe` のロックで中断し削除だけが進んだこと（install dir から欠落していたのは zip 内アルファベット順で `node.exe` 直前までの `CHANGELOG.md` / `corepack` / `corepack.cmd` / `install_tools.bat` / `LICENSE` の 5 ファイル）である。これは環境の破損であり本 ADR の対象ではないが、corepack が消えると pnpm が黙って供給されなくなる構造が露呈した。
+
+## Decision
+
+corepack への依存をやめ、pnpm を mise で直接管理する。
+
+- `home/dot_config/mise/config.toml.tmpl` に `pnpm = "latest"` を追加する（backend は既定の `aqua:pnpm/pnpm`）。
+- `home/run_onchange_after_15-mise-sync-tools.{ps1,sh}.tmpl` から corepack 有効化ブロックを削除する。
+- `home/run_onchange_after_21-link-mise-shims.sh.tmpl` の `EXCLUDE_EXACT` の `corepack` を `pnpm` へ置き換える。npm / npx を除外しているのと同じ理由で、`~/.local/bin` 経由に予期せぬバージョンが拾われる副作用を避ける（ADR-003）。
+- `home/dot_config/mise/private_mise.lock` に pnpm 11.17.0 のエントリを 5 プラットフォーム分追加する（ADR-021）。
+
+corepack 前提を維持して今回のエラー箇所だけを塞ぐ案は、Node 26 LTS への更新時に同じ問題が再発するため採らない。yarn も mise 管理に加える案は、リポジトリに yarn の利用実績がなく lockfile と install の対象を増やす費用に見合わないため見送る。必要になった時点で `aqua:yarnpkg/berry` 等を追加する。
+
+## Consequences
+
+- pnpm のバージョンが lockfile で固定され、`mise install` の provenance 検証（github-attestations）の対象になる。
+- corepack が消えても pnpm の供給は影響を受けない。
+- yarn / pnpx / yarnpkg は提供されなくなる。
+
+## 引き継ぐ検証
+
+非対話 pwsh で mise の CommandNotFound ハンドラがエラーを出す構造そのものは残っている。今回消えたのは発火点だけで、chezmoi の ps1 スクリプトで別のコマンドが見つからなければ再発する。

--- a/docs/adr/023-chezmoi-ps1-interpreter-noprofile.md
+++ b/docs/adr/023-chezmoi-ps1-interpreter-noprofile.md
@@ -1,0 +1,41 @@
+# ADR-023: chezmoi の ps1 実行系を固定しプロファイルを読ませない
+
+## Status
+
+Accepted
+
+## Context
+
+Windows の `chezmoi update` が `Unable to find type [Microsoft.PowerShell.PSConsoleReadLine]` を 2 回出力した。経路は 3 段である。
+
+1. chezmoi は Windows で `.ps1` を既定の実行系 `pwsh -NoLogo -File` で実行する。`-NoProfile` が無いため、スクリプト実行のたびにユーザープロファイルが読まれる。
+2. プロファイルの `mise activate pwsh` が CommandNotFound ハンドラを登録し、ハンドラ本体は `[Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems()` を参照する。
+3. 非対話 pwsh には PSReadLine が読み込まれていないため、スクリプト内でコマンド解決に失敗するたびに InvalidOperation が出る。
+
+今回の発火点は `run_onchange_after_15-mise-sync-tools.ps1` の `Get-Command -Name 'corepack'`（corepack は ADR-022 で廃止済み）だが、これは症状の一例にすぎない。スクリプトが未導入コマンドの有無を調べる限り再発する。再現は `pwsh -NoLogo -Command "Get-Command -CommandType Application -Name 'nonexistent-xyz.exe' -EA SilentlyContinue"` で取れる。
+
+加えてプロファイルの読み込みは、chezmoi のスクリプト実行にユーザー環境の副作用（alias、関数、PATH 改変、mise の shim 差し込み）を持ち込む。スクリプトはプロファイルに依存しない前提で書かれており、読む必然性がない。
+
+## Decision
+
+`home/.chezmoi.toml.tmpl` の `[interpreters.ps1]` で実行系を固定し、`-NoProfile` を必ず渡す。
+
+```toml
+[interpreters.ps1]
+command = "pwsh"
+args = ["-NoLogo", "-NoProfile", "-File"]
+```
+
+プロファイル由来の副作用を排除し、スクリプトの実行環境を Machine+User の PATH に揃える。
+
+## Consequences
+
+- chezmoi のスクリプトはプロファイルに依存できなくなる。mise の shim は PATH に永続登録されているため mise 管理ツール（mise.exe / gh.exe / uv.exe / git.exe）の解決は確認済みだが、プロファイル経由でしか PATH に入らないツールは解決できない。
+- 設定変更であるため、反映には `chezmoi init` の再実行が必要になる。
+- 塞げるのは chezmoi 経由の実行だけで、他のツールが `pwsh -File` でスクリプトを起動する場合は mise のハンドラ問題が依然として発火する（ADR-022 の「引き継ぐ検証」）。
+
+## 検証
+
+- `tests/test_chezmoi_config_template.py` にソース形状と `chezmoi execute-template --init` のレンダリング結果の両方を検査するテストを追加した（`test_ps1_interpreter_is_pinned_without_the_profile` / `test_ps1_interpreter_skips_the_profile`）。
+- レンダリングした config で `chezmoi --config <cfg> dump-config` を実行し、`interpreters.ps1.args` が `["-NoLogo","-NoProfile","-File"]` になることを確認した。
+- クリーンな PATH（Machine+User のみ）で `pwsh -NoLogo -NoProfile -File` を実行し、mise.exe / gh.exe / uv.exe / git.exe が解決すること、未導入コマンドを引いても PSReadLine エラーが出ないことを確認した。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -34,6 +34,8 @@
 | [019](019-cross-platform-parity-contract.md) | クロスプラットフォーム機能等価性はプラットフォーム契約と静的検査で担保する | Accepted |
 | [020](020-git-hooks-via-config.md) | gitleaks の pre-commit は Git の設定ベースフックで配る | Accepted |
 | [021](021-mise-lockfile-platforms.md) | lockfile の対象プラットフォームは lockfile_platforms で固定する | Accepted |
+| [022](022-pnpm-via-mise-not-corepack.md) | pnpm は corepack ではなく mise で直接管理する | Accepted |
+| [023](023-chezmoi-ps1-interpreter-noprofile.md) | chezmoi の ps1 実行系を固定しプロファイルを読ませない | Accepted |
 
 ## テンプレート
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,3 +142,5 @@ chezmoi は `run_once_before_*` → 通常ファイル適用 → `run_once_after
 | 6 | `after_30-install-tools.sh` | 追加ツール導入 |
 
 変更時は、mise 設定配置前に `mise install` しないこと、Codespaces / Dev Container の分岐を壊さないことを確認する。
+
+`.ps1` スクリプトの実行系は `.chezmoi.toml.tmpl` の `[interpreters.ps1]` で `pwsh -NoLogo -NoProfile -File` に固定している（ADR-023）。プロファイルを読まないため、スクリプトは Machine+User の PATH に載るものだけに依存できる。プロファイル経由でしか PATH に入らないツールは使えない。

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -54,3 +54,13 @@
   isWSL = {{ $isWSL }}
   windowsUser = {{ $windowsUser | quote }}
   corpUser = {{ $corpUser | quote }}
+
+# chezmoi の既定は `pwsh -NoLogo -File` で、プロファイルを読む。すると
+# `mise activate pwsh` が登録する CommandNotFound ハンドラが有効になり、
+# ハンドラ本体が参照する PSReadLine の型は非対話 pwsh に存在しないため、
+# スクリプトが見つからないコマンドを引くたびに InvalidOperation が出る。
+# スクリプトはプロファイルの関数や PATH 追加に依存しない（mise shims は
+# run_once_after_05-setup-mise-shims-path が User PATH へ永続登録する）。
+[interpreters.ps1]
+  command = "pwsh"
+  args = ["-NoLogo", "-NoProfile", "-File"]

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -5,6 +5,8 @@ kubectl = "latest"
 helm = "latest"
 trivy = "latest"
 node = "lts"
+# Node 25 で corepack の同梱が廃止されたため、pnpm は mise で直接管理する
+pnpm = "latest"
 uv = "latest"
 fzf = "latest"
 github-cli = "latest"

--- a/home/dot_config/mise/private_mise.lock
+++ b/home/dot_config/mise/private_mise.lock
@@ -559,6 +559,40 @@ backend = "npm:typescript-language-server"
 [tools."npm:typescript-language-server".options]
 trust_policy_excludes = '["typescript-language-server@5.3.0"]'
 
+[[tools.pnpm]]
+version = "11.17.0"
+backend = "aqua:pnpm/pnpm"
+
+[tools.pnpm."platforms.linux-arm64"]
+checksum = "sha256:730d17de742a3efbb020ba91d7acfc0456c6ba6ad1cd8eb49f4c229fe9f504d3"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.17.0/pnpm-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/487422123"
+provenance = "github-attestations"
+
+[tools.pnpm."platforms.linux-x64"]
+checksum = "sha256:bdb1db01bf0f757495405a59a09c5c287f315889dc98d3b14bc374b9fe43a0bf"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.17.0/pnpm-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/487422122"
+provenance = "github-attestations"
+
+[tools.pnpm."platforms.macos-arm64"]
+checksum = "sha256:1e9a35d76f9d382af365d95c64f3abf7815e24350653f5bb1a37e4546265bc2b"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.17.0/pnpm-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/487422117"
+provenance = "github-attestations"
+
+[tools.pnpm."platforms.windows-arm64"]
+checksum = "sha256:46cb743b10cdf613de8e5d26edf1982ffc757a3393ec44d320b2a33f40d728d4"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.17.0/pnpm-win32-arm64.zip"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/487422120"
+provenance = "github-attestations"
+
+[tools.pnpm."platforms.windows-x64"]
+checksum = "sha256:3025c174a6dcffec14a071a5c854cb0c350a09a8c7c2857a75f75cc7b29b939c"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.17.0/pnpm-win32-x64.zip"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/487422118"
+provenance = "github-attestations"
+
 [[tools.ripgrep]]
 version = "15.2.0"
 backend = "aqua:BurntSushi/ripgrep"

--- a/home/run_after_40-check-git-hooks.ps1.tmpl
+++ b/home/run_after_40-check-git-hooks.ps1.tmpl
@@ -15,9 +15,8 @@
 #   を区別できないので使わない。
 #
 # 出力を英語にしている理由:
-#   chezmoi は Windows で powershell.exe (5.1) を既定の実行系に使う。5.1 は BOM の
-#   無いファイルを ANSI として読むため、日本語の出力は文字化けし得る。他の .ps1
-#   スクリプトと同じく、コメントは日本語、出力は英語で書く。
+#   他の .ps1 スクリプトと揃える。コメントは日本語、出力は英語で書く。
+#   実行系は `.chezmoi.toml.tmpl` の `[interpreters.ps1]` で pwsh に固定している。
 #
 # 関連:
 #   - docs/adr/020-git-hooks-via-config.md

--- a/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.ps1.tmpl
@@ -62,15 +62,5 @@ else {
   $syncExit = 0
 }
 
-# corepack (pnpm/yarn 提供) を有効化する。mise 管理 node に同梱されており、
-# 未実行だと `pnpm` コマンドが解決できない。冪等なため無条件に実行してよい。
-$corepackCmd = Get-Command -Name 'corepack' -ErrorAction SilentlyContinue
-if ($corepackCmd) {
-  & $corepackCmd.Source enable
-  if ($LASTEXITCODE -ne 0) {
-    Write-Warning 'corepack enable failed.'
-  }
-}
-
 exit $syncExit
 {{- end -}}

--- a/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
+++ b/home/run_onchange_after_15-mise-sync-tools.sh.tmpl
@@ -49,11 +49,5 @@ else
   sync_exit=0
 fi
 
-# corepack (pnpm/yarn 提供) を有効化する。mise 管理 node に同梱されており、
-# 未実行だと `pnpm` コマンドが解決できない。冪等なため無条件に実行してよい。
-if command -v corepack >/dev/null 2>&1; then
-  corepack enable || echo 'WARN: corepack enable failed.' >&2
-fi
-
 exit "$sync_exit"
 {{- end -}}

--- a/home/run_onchange_after_21-link-mise-shims.sh.tmpl
+++ b/home/run_onchange_after_21-link-mise-shims.sh.tmpl
@@ -40,7 +40,7 @@ STATE_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/chezmoi-dotfiles/mise-shim-lin
 # 起動する恐れがあるため、Copilot 経由での利用価値より副作用リスクを優先して除外。
 # rust は mise 管理外 (docs/adr/016-rust-external-rustup.md) のため shim 自体が存在せず対象外。
 EXCLUDE_EXACT=(
-  node npm npx corepack
+  node npm npx pnpm
   dotnet dnx
 )
 

--- a/tests/test_chezmoi_config_template.py
+++ b/tests/test_chezmoi_config_template.py
@@ -10,12 +10,19 @@ ADR-012 op-ssh-sign paths, so losing them breaks commit signing silently.
 
 The fix seeds each variable from the current config data before the guard.
 These tests pin both the source shape and the observable behaviour.
+
+The template also pins the ``.ps1`` interpreter (ADR-023). chezmoi defaults to
+``pwsh -NoLogo -File``, which loads the profile, which activates mise, whose
+CommandNotFound handler dereferences a PSReadLine type that a non-interactive
+pwsh does not have. Every failed command lookup inside a script then prints an
+InvalidOperation error, so ``-NoProfile`` has to stay in the argument list.
 """
 
 import pathlib
 import shutil
 import subprocess
 import tempfile
+import tomllib
 import unittest
 
 
@@ -23,6 +30,8 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 CONFIG_TEMPLATE_PATH = REPO_ROOT / "home/.chezmoi.toml.tmpl"
 
 PROMPTED_VARIABLES = ("windowsUser", "corpUser")
+
+EXPECTED_PS1_INTERPRETER = {"command": "pwsh", "args": ["-NoLogo", "-NoProfile", "-File"]}
 
 
 class ConfigTemplateSourceTests(unittest.TestCase):
@@ -47,6 +56,13 @@ class ConfigTemplateSourceTests(unittest.TestCase):
                 self.assertNotEqual(seed, -1)
                 self.assertNotEqual(prompt, -1)
                 self.assertLess(seed, prompt)
+
+    def test_ps1_interpreter_is_pinned_without_the_profile(self) -> None:
+        """The interpreter is literal TOML, so the source has to carry it verbatim."""
+        args = ", ".join(f'"{arg}"' for arg in EXPECTED_PS1_INTERPRETER["args"])
+        self.assertIn("[interpreters.ps1]", self.template)
+        self.assertIn(f'command = "{EXPECTED_PS1_INTERPRETER["command"]}"', self.template)
+        self.assertIn(f"args = [{args}]", self.template)
 
 
 @unittest.skipUnless(shutil.which("chezmoi"), "chezmoi renders the config template")
@@ -82,6 +98,12 @@ class ConfigTemplateBehaviourTests(unittest.TestCase):
     def test_fresh_init_leaves_the_corp_user_empty(self) -> None:
         rendered = self._render(None)
         self.assertIn('corpUser = ""', rendered)
+
+    def test_ps1_interpreter_skips_the_profile(self) -> None:
+        """A rendered config must run .ps1 scripts without the PowerShell profile."""
+        rendered = self._render(None)
+        config = tomllib.loads(rendered)
+        self.assertEqual(config["interpreters"]["ps1"], EXPECTED_PS1_INTERPRETER)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

Windows で `chezmoi update` を実行すると、次のエラーが 2 回出ていた。

```
InvalidOperation: Unable to find type [Microsoft.PowerShell.PSConsoleReadLine].
```

原因は 3 段の連鎖である。

1. chezmoi は `.ps1` を既定の実行系 `pwsh -NoLogo -File` で実行する。`-NoProfile` が無いため、スクリプト実行のたびにユーザープロファイルが読まれる
2. プロファイルの `mise activate pwsh` が CommandNotFound ハンドラを登録し、その本体が `[Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems()` を参照する
3. 非対話 pwsh には PSReadLine が読み込まれていないため、スクリプト内でコマンド解決に失敗するたびに InvalidOperation が出る

今回の発火点は `run_onchange_after_15-mise-sync-tools.ps1` の `Get-Command -Name 'corepack'` だった。corepack が消えていたのは、node の再インストールが `node.exe` のロックで中断し、削除だけ進んだ環境破損による。

## 対応

2 層で塞いだ。

**発火点の除去（ADR-022）**: corepack への依存をやめ、pnpm を mise で直接管理する。Node 25 で Corepack の同梱が廃止された（nodejs/node#57617, #59835）ため、いずれ必要だった変更でもある。

- `config.toml.tmpl` に `pnpm = "latest"` を追加し、lockfile へ 5 プラットフォーム分のエントリを追加
- `run_onchange_after_15-mise-sync-tools.{ps1,sh}.tmpl` の corepack 有効化ブロックを削除
- `run_onchange_after_21-link-mise-shims.sh.tmpl` の `EXCLUDE_EXACT` を `corepack` から `pnpm` へ

**構造の是正（ADR-023）**: `.chezmoi.toml.tmpl` の `[interpreters.ps1]` で `pwsh -NoLogo -NoProfile -File` に固定する。corepack だけを消しても、スクリプトが未導入コマンドの有無を調べる限り同じ現象は再発するため、プロファイル読み込み自体をやめる。副次的に、chezmoi のスクリプト実行がユーザー環境の副作用（alias、関数、PATH 改変）を持ち込まなくなる。

## 注意点

- **適用時に `chezmoi init` の再実行が必要**。config template の変更なので `chezmoi update` だけでは反映されない
- プロファイル経由でしか PATH に入らないツールは、chezmoi のスクリプトから解決できなくなる。mise の shim は Machine+User の PATH に永続登録されているため、mise.exe / gh.exe / uv.exe / git.exe が解決することはクリーンな PATH で確認済み
- 塞げるのは chezmoi 経由の実行だけである。他のツールが `pwsh -File` でスクリプトを起動する場合、mise のハンドラ問題は依然として発火する（ADR-022 の「引き継ぐ検証」に記録）
- `run_after_40-check-git-hooks.ps1.tmpl` にあった「chezmoi は Windows で powershell.exe (5.1) を使う」というコメントは事実誤認だったので、あわせて修正した

## 検証

- `uv run -m unittest discover -s tests` → 304 tests OK (skipped=16)
- `tests/test_chezmoi_config_template.py` にソース形状と `chezmoi execute-template --init` のレンダリング結果を検査するテストを追加
- レンダリングした config で `chezmoi --config <cfg> dump-config` を実行し、`interpreters.ps1.args` が `["-NoLogo","-NoProfile","-File"]` になることを確認
- クリーンな PATH（Machine+User のみ）で `pwsh -NoLogo -NoProfile -File` を実行し、未導入コマンドを引いても PSReadLine エラーが出ないことを確認